### PR TITLE
Problem: Failed logins always try log in against legacy upstream

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -106,7 +106,8 @@ define('UI_PLAYLISTCONTROLLER_OBJ_SESSNAME', 'PLAYLISTCONTROLLER_OBJ');
 define('UI_BLOCK_SESSNAME', 'BLOCK');*/
 
 //WHMCS integration
-define("WHMCS_API_URL", "https://account.sourcefabric.com/includes/api.php");
+define("LIBRETIME_ENABLE_WHMCS", false);
+define("WHMCS_API_URL", "https://account.example.org/includes/api.php");
 define("SUBDOMAIN_WHMCS_CUSTOM_FIELD_NAME", "Choose your domain");
 
 //Sentry error logging


### PR DESCRIPTION
Solution: Make the login fallback optional and deactivate it in the default config.

I'm leaving the code in here mostly because I want to revisit it and make it modular so I can later on plug my own FreeIPA things :)