### PR TITLE
config to disable live chat

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -109,6 +109,9 @@ define('UI_BLOCK_SESSNAME', 'BLOCK');*/
 define("WHMCS_API_URL", "https://account.sourcefabric.com/includes/api.php");
 define("SUBDOMAIN_WHMCS_CUSTOM_FIELD_NAME", "Choose your domain");
 
+//LiveChat integration
+define('LIBRETIME_ENABLE_LIVECHAT', false);
+
 //Sentry error logging
 define('SENTRY_CONFIG_PATH', '/etc/airtime-saas/sentry.airtime_web.ini');
 

--- a/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
+++ b/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
@@ -224,7 +224,8 @@ class PageLayoutInitPlugin extends Zend_Controller_Plugin_Abstract
         }
 
         $view->headScript()->appendScript("var userType = '$userType';");
-        if (array_key_exists('REQUEST_URI', $_SERVER) //Doesn't exist for unit tests
+        if (LIBRETIME_ENABLE_LIVECHAT === true
+            && array_key_exists('REQUEST_URI', $_SERVER) //Doesn't exist for unit tests
             && strpos($_SERVER['REQUEST_URI'], 'Dashboard/stream-player') === false
             && strpos($_SERVER['REQUEST_URI'], 'audiopreview') === false
             && $_SERVER['REQUEST_URI'] != "/") {


### PR DESCRIPTION
Problem: Live Chat points back to legacy upstream and I do not believe we can let them do support for us ;)

Solution: Deactivate live chat through constants.php so it never gets checked.

This is like https://github.com/Robbt/Airtime/commit/34db703381f8ccf7fdee3706c3df58f347da7e00 but removes one more sql call and makes it easy to reactivate should anyone want to use the feature in future.