### PR TITLE
remove broken late static binding compat code

### DIFF
--- a/airtime_mvc/application/common/PodcastManager.php
+++ b/airtime_mvc/application/common/PodcastManager.php
@@ -56,7 +56,7 @@ class PodcastManager {
     protected static function _findUningestedEpisodes($podcast, $service) {
         $episodeList = $service->getPodcastEpisodes($podcast->getDbPodcastId());
         $episodes = array();
-        usort($episodeList, array(static::class, "_sortByEpisodePubDate"));
+        usort($episodeList, array(__CLASS__, "_sortByEpisodePubDate"));
         for ($i = 0; $i < sizeof($episodeList); $i++) {
             $episodeData = $episodeList[$i];
             $ts = $podcast->getDbAutoIngestTimestamp();

--- a/airtime_mvc/application/common/TaskManager.php
+++ b/airtime_mvc/application/common/TaskManager.php
@@ -351,8 +351,7 @@ class TaskFactory {
      */
     private static function _isTask($c) {
         $reflect = new ReflectionClass($c);
-        $clazz = version_compare(phpversion(), '5.5.0', '<') ? "AirtimeTask" : AirtimeTask::class;
-        return $reflect->implementsInterface($clazz);
+        return $reflect->implementsInterface('AirtimeTask');
     }
 
     /**

--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -135,8 +135,7 @@ class ApiController extends Zend_Controller_Action
      */
     public function pollCeleryAction() {
         $taskManager = TaskManager::getInstance();
-        $clazz = version_compare(phpversion(), '5.5.0', '<') ? get_class(new CeleryTask) : CeleryTask::class;
-        $taskManager->runTask($clazz);
+        $taskManager->runTask('CeleryTask');
     }
 
     /**

--- a/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
+++ b/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
@@ -64,8 +64,7 @@ class PageLayoutInitPlugin extends Zend_Controller_Plugin_Abstract
             // We can't afford to wait 7 minutes to run an upgrade: users could
             // have several minutes of database errors while waiting for a
             // schema change upgrade to happen after a deployment
-            $clazz = version_compare(phpversion(), '5.5.0', '<') ? get_class(new UpgradeTask) : UpgradeTask::class;
-            $taskManager->runTask($clazz);
+            $taskManager->runTask('UpgradeTask');
 
             // Piggyback the TaskManager onto API calls. This provides guaranteed consistency
             // (there is at least one API call made from pypo to Airtime every 7 minutes) and


### PR DESCRIPTION
Problem: CentOS still installs php 5.4 if you take the easy route to install it. So far I haven't found any complete features that depend on 5.5 to work. Some of the code has been written in an incompatible fashion without any real need for it.

Solution: Don't use any php 5.4 features for the time being.

If more changes had been needed I would have switched to 5.5 (or even 7) in a hearbeat, turns out the changes we need to support all version are rather minimal and make things simpler over the board.

* [x] don't use `static::class` in a class that does not have a parent class, use `__CLASS__` instead.
* [x] don't use `<ClassName>::class`, since we already know what class we want `"<ClassName>"` ist just fine.