### PR TITLE
Add missing argument to playlistNotFound call

### DIFF
--- a/airtime_mvc/application/controllers/PlaylistController.php
+++ b/airtime_mvc/application/controllers/PlaylistController.php
@@ -226,7 +226,7 @@ class PlaylistController extends Zend_Controller_Action
             $obj = new $objInfo['className']($id);
             $this->createFullResponse($obj);
         } catch (PlaylistNotFoundException $e) {
-            $this->playlistNotFound();
+            $this->playlistNotFound($type);
         } catch (Exception $e) {
             $this->playlistUnknownError($e);
         }


### PR DESCRIPTION
Was on 2.5.x as 7dbf4cf5d2d37057e1f5ab72cb12ffcc5ddc1ccb