### PR TITLE
Rewrite config from /etc/airtime-saas to plain /etc/airtime

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -110,7 +110,7 @@ define("WHMCS_API_URL", "https://account.sourcefabric.com/includes/api.php");
 define("SUBDOMAIN_WHMCS_CUSTOM_FIELD_NAME", "Choose your domain");
 
 //Sentry error logging
-define('SENTRY_CONFIG_PATH', '/etc/airtime-saas/sentry.airtime_web.ini');
+define('SENTRY_CONFIG_PATH', LIBRETIME_CONF_DIR . '/sentry.airtime_web.ini');
 
 //Provisioning status
 define('PROVISIONING_STATUS_SUSPENDED' , 'Suspended');

--- a/airtime_mvc/application/models/RabbitMq.php
+++ b/airtime_mvc/application/models/RabbitMq.php
@@ -81,16 +81,18 @@ class Application_Model_RabbitMq
     public static function getRmqConfigPath() {
         //Hack for Airtime Pro. The RabbitMQ settings for communicating with airtime_analyzer are global
         //and shared between all instances on Airtime Pro.
+        //
+        // todo: rewrite me to only use the config class and not access /etc/airtime directly
         $CC_CONFIG = Config::getConfig();
         $devEnv = "production"; //Default
         if (array_key_exists("dev_env", $CC_CONFIG)) {
             $devEnv = $CC_CONFIG["dev_env"];
         }
-        $rmq_config_path = "/etc/airtime-saas/".$devEnv."/rabbitmq-analyzer.ini";
+        $rmq_config_path = LIBRETIME_CONF_DIR . '/' . $devEnv."/rabbitmq-analyzer.ini";
         if (!file_exists($rmq_config_path)) {
             // If the dev env specific rabbitmq-analyzer.ini doesn't exist default
             // to the production rabbitmq-analyzer.ini
-            $rmq_config_path = "/etc/airtime-saas/production/rabbitmq-analyzer.ini";
+            $rmq_config_path = LIBRETIME_CONF_PATH . "/production/rabbitmq-analyzer.ini";
         }
         return $rmq_config_path;
     }

--- a/airtime_mvc/public/setup/media-setup.php
+++ b/airtime_mvc/public/setup/media-setup.php
@@ -25,8 +25,7 @@ require_once(dirname(dirname( __DIR__)) . "/application/models/airtime/CcMusicDi
 class MediaSetup extends Setup {
 
     const MEDIA_FOLDER = "mediaFolder";
-    const AIRTIME_CONF_PATH = "/etc/airtime/airtime.conf";
-    const RMQ_INI_BASE_PATH = "/etc/airtime-saas/";
+    const LIBRETIME_CONF_FILE_NAME = "airtime.conf";
     const RMQ_INI_FILE_NAME = "rabbitmq-analyzer.ini";
 
     static $path;
@@ -77,8 +76,11 @@ class MediaSetup extends Setup {
              * airtime.conf to airtime.conf.tmp during the setup process. Now that we're done,
              * we can rename it to airtime.conf.bak to avoid confusion.
              */
-            if (file_exists(self::AIRTIME_CONF_PATH . ".tmp")) {
-                rename(self::AIRTIME_CONF_PATH . ".tmp", self::AIRTIME_CONF_PATH . ".bak");
+            $fileName = LIBRETIME_CONF_DIR . '/' . self::LIBRETIME_CONF_FILE_NAME;
+            $tmpFile = $fileName . '.tmp';
+            $bakFile = $fileName . '.bak';
+            if (file_exists($tmpFile)) {
+                rename($tmpFile, $bakFile);
             }
         } else {
             self::$message = "Failed to move airtime.conf; /etc/airtime doesn't exist!";
@@ -96,7 +98,7 @@ class MediaSetup extends Setup {
      * @return boolean false if either of the copy or removal operations fail
      */
     function moveAirtimeConfig() {
-        return copy(AIRTIME_CONF_TEMP_PATH, self::AIRTIME_CONF_PATH)
+        return copy(AIRTIME_CONF_TEMP_PATH, LIBRETIME_CONF_DIR . '/' . self::LIBRETIME_CONF_FILE_NAME)
             && unlink(AIRTIME_CONF_TEMP_PATH);
     }
 
@@ -105,8 +107,8 @@ class MediaSetup extends Setup {
      * @return boolean false if either of the copy or removal operations fail
      */
     function moveRmqConfig() {
-        return copy(RMQ_INI_TEMP_PATH, self::RMQ_INI_BASE_PATH . self::RMQ_INI_FILE_NAME)
-            && copy(RMQ_INI_TEMP_PATH, self::RMQ_INI_BASE_PATH . "production/" . self::RMQ_INI_FILE_NAME)
+        return copy(RMQ_INI_TEMP_PATH, LIBRETIME_CONF_DIR . '/' . self::RMQ_INI_FILE_NAME)
+            && copy(RMQ_INI_TEMP_PATH, LIBRETIME_CONF_DIR . '/production/' . self::RMQ_INI_FILE_NAME)
             && unlink(RMQ_INI_TEMP_PATH);
     }
 

--- a/python_apps/airtime-celery/README.rst
+++ b/python_apps/airtime-celery/README.rst
@@ -28,7 +28,7 @@ Developers
 To debug, you can run celery directly from the command line:
 
     $ cd /my/airtime/root/python_apps/airtime-celery
-    $ RMQ_CONFIG_FILE=/etc/airtime/airtime.conf celery -A airtime-celery.tasks worker --loglevel=info
+    $ RMQ_CONFIG_FILE=${LIBRETIME_CONF_DIR}/airtime.conf celery -A airtime-celery.tasks worker --loglevel=info
 
 This worker can be run alongside the service without issue.
 
@@ -57,8 +57,8 @@ If you run into issues getting Celery to accept tasks from Airtime:
 
     2) Check the log file (/var/log/airtime/airtime-celery[-DEV_ENV].log) to make sure Celery started correctly.
 
-    3) Check your /etc/airtime/airtime.conf rabbitmq settings. Make sure the settings here align with
-       /etc/airtime-saas/production/rabbitmq.ini.
+    3) Check your $LIBRETIME_CONF_DIR/airtime.conf rabbitmq settings. Make sure the settings here align with
+       $LIBRETIME_CONF_DIR/$ENVIRONMENT/rabbitmq.ini.
 
     4) Check RabbitMQ to make sure the celeryresults and task queues were created in the correct vhost.
 

--- a/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader.py
@@ -10,7 +10,7 @@ from boto.s3.key import Key
 # https://github.com/docker/docker-registry/issues/400
 u'fix getaddrinfo deadlock'.encode('idna')
 
-CLOUD_CONFIG_PATH = '/etc/airtime-saas/cloud_storage.conf'
+CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'cloud_storage.conf')
 STORAGE_BACKEND_FILE = "file"
 SOCKET_TIMEOUT = 240
 

--- a/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader_libcloud.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/cloud_storage_uploader_libcloud.py
@@ -6,7 +6,7 @@ from libcloud.storage.providers import get_driver
 from libcloud.storage.types import Provider, ContainerDoesNotExistError, ObjectDoesNotExistError
 
 
-CLOUD_CONFIG_PATH = '/etc/airtime-saas/cloud_storage.conf'
+CLOUD_CONFIG_PATH = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), 'cloud_storage.conf')
 STORAGE_BACKEND_FILE = "file"
 
 class CloudStorageUploader:

--- a/python_apps/airtime_analyzer/bin/airtime_analyzer
+++ b/python_apps/airtime_analyzer/bin/airtime_analyzer
@@ -8,8 +8,9 @@ import os
 import airtime_analyzer.airtime_analyzer as aa
 
 VERSION = "1.0"
-DEFAULT_RMQ_CONFIG_PATH = '/etc/airtime/airtime.conf'
-DEFAULT_CLOUD_STORAGE_CONFIG_PATH = '/etc/airtime-saas/production/cloud_storage.conf'
+LIBRETIME_CONF_DIR = os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime')
+DEFAULT_RMQ_CONFIG_PATH = os.path.join(LIBRETIME_CONF_DIR, 'airtime.conf')
+DEFAULT_CLOUD_STORAGE_CONFIG_PATH = os.path.join(LIBRETIME_CONF_DIR, os.getenv('ENVIRONMENT', 'production'), 'airtime.conf')
 DEFAULT_HTTP_RETRY_PATH = '/tmp/airtime_analyzer_http_retries'
 
 def run():

--- a/python_apps/airtime_analyzer/tests/analyzer_pipeline_tests.py
+++ b/python_apps/airtime_analyzer/tests/analyzer_pipeline_tests.py
@@ -22,7 +22,7 @@ def teardown():
 def test_basic():
     filename = os.path.basename(DEFAULT_AUDIO_FILE)
     q = Queue.Queue()
-    #cloud_storage_config_path = '/etc/airtime-saas/production/cloud_storage.conf'
+    #cloud_storage_config_path = os.path.join(os.getenv('LIBRETIME_CONF_DIR', '/etc/airtime'), '/production/cloud_storage.conf')
     #cloud_storage_config = config_file.read_config_file(cloud_storage_config_path)
     cloud_storage_config = SafeConfigParser()
     cloud_storage_config.add_section("current_backend")


### PR DESCRIPTION
This is the results of 

```bash
sed -i -e 's|/etc/airtime-saas/|/etc/airtime/|' `grep -irl 'airtime-saas' airtime_mvc/ python_apps/` 
```

It might need more testing, the airtime-saas part never really made sense, zf1 has environments for that, ie you would create a saas env based on production for instance.

I beleive legacy upstream was using this to share configuration between customers (ie. analyser runs only once and writes to a shared S3 bucket). I assume they mount the airtime-saas folder onto individual customers instances with a global config. Like I said, I don't feel that this makes sense since all it does is make hacking at the configs in airtime-saas a bit easier. A serious SaaS operation should be using something like puppet or ansible to achieve this.