### PR TITLE
Add Vagrant support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,13 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "forwarded_port", guest: 8888, host:8888
+
+  config.vm.provision "shell", path: "docs/scripts/install.sh"
+  config.vm.provision "shell", path: "docs/scripts/serve.sh"
+
+end

--- a/docs/_css/term.css
+++ b/docs/_css/term.css
@@ -1,0 +1,17 @@
+pre code.console {
+  background-color: black;
+  color: #808080;
+  padding: 1em;
+  border-radius: 5px;
+  font-size: 110%;
+  overflow: auto;
+}
+
+span.hljs-built_in,
+span.hljs-comment,
+span.hljs-keyword,
+span.hljs-variable {
+  color: #808080;
+  font-weight: normal;
+  font-style: normal;
+}

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,32 @@
+Documentation
+=============
+
+The LibreTime documentation site is generated with [mkdocs](http://www.mkdocs.org/). To get started contributing to this project, fork it on Github. Then install mkdocs and clone this repo locally:
+
+```console
+$ sudo brew install python              # For OSX users
+$ sudo aptitude install python-pip      # For Debian/Ubuntu users
+$ sudo pip install mkdocs
+$ git clone https://github.com/libretime/libretime
+$ cd libretime
+$ git remote add sandbox https://github.com/<username>/libretime   # URL for your fork
+$ mkdocs build --clean
+$ mkdocs serve
+```
+
+Your local LibreTime docs site should now be available for browsing: [http://localhost:8888/](http://localhost:8888/).
+
+When you find a typo, an error, unclear or missing explanations or instructions, open a new terminal and start editing. Your changes should be reflected automatically on the local server. Find the page you’d like to edit; everything is in the docs/ directory. Make your changes, commit and push them, and start a pull request:
+
+```console
+$ git checkout -b fix_typo
+$ vi docs/index.md                      # Add/edit/remove whatever you see fit. Be bold!
+$ mkdocs build --clean; mkdocs serve    # Go check your changes. We’ll wait...
+$ git diff                              # Make sure there aren’t any unintended changes.
+diff --git a/docs/index.md b/docs/index.md
+...
+$ git commit -am”Fixed typo.”           # Useful commit message are a good habit.
+$ git push sandbox fix_typo
+```
+
+Visit your fork on Github and start a PR.

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,9 @@
+Features
+========
+
+TBD
+
+Screenshots
+-----------
+
+TBD

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+Welcome to LibreTime
+====================
+
+LibreTime makes it easy to run your own online radio station. Check out some [features](features.md) and [screenshots](features.md#screenshots), then [install it](install.md) and start broadcasting!
+
+LibreTime is Free/Libre and Open Source Software (FLOSS). Among other things, this means that you have the freedom to:
+
+* Run it royalty-free for as long as you like.
+* Read and alter the code that makes it work (or hire someone to do this for you!)
+* Contribute documentation, bug-fixes, etc. so that everyone in the community benefits.
+
+LibreTime is a fork of AirTime due to stalled development of the FLOSS version. For background on this, see this [open letter to the Airtime community](https://gist.github.com/hairmare/8c03b69c9accc90cfe31fd7e77c3b07d).
+
+
+Getting Started
+---------------
+
+The easiest way to check out LibreTime for yourself is to run a local instance in a virtual machine:
+
+1. Install Git, Vagrant and Virtualbox:
+```console
+$ sudo apt-get install git vagrant virtualbox
+```
+2. Clone this repository locally:
+```console
+$ git clone https://github.com/libretime/libretime.git
+```
+3. Launch the VM:
+```console
+$ cd libretime
+$ vagrant up
+```
+

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,8 @@
+Installing LibreTime
+====================
+
+LibreTime should generally be installed on a dedicated host. By default, its installer will install and configure all its dependencies.
+
+```console
+$ ./installer
+```

--- a/docs/scripts/install.sh
+++ b/docs/scripts/install.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+echo "Updating Apt."
+apt-get update > /dev/null
+echo "Ensuring Pip is installed."
+DEBIAN_FRONTEND=noninteractive apt-get install -y -qq python-pip > /dev/null
+echo "Updating Pip."
+pip install pip -q -q --upgrade > /dev/null
+echo "Ensuring Mkdocs is installed."
+pip install -q mkdocs > /dev/null

--- a/docs/scripts/serve.sh
+++ b/docs/scripts/serve.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+cd /vagrant
+echo "Stopping any running Mkdocs servers."
+pkill mkdocs
+echo "Building Mkdocs documentation."
+mkdocs build --clean -q > /dev/null
+echo "Launching Mkdocs server."
+mkdocs serve > /dev/null 2>&1 &
+echo "Visit http://localhost:8888 to see the LibreTime documentation."

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: LibreTime
+theme: readthedocs
+
+dev_addr: '0.0.0.0:8888'
+site_dir: '/tmp/aegir_docs/_site'
+
+extra_css:
+  - '_css/term.css'
+
+pages:
+  - 'Home': index.md
+  - 'Features': features.md
+  - 'Install': install.md
+  - 'Documentation': documentation.md


### PR DESCRIPTION
Since the installation script appears not to be functioning at the moment, I figured adding a Vagrantfile would make for simpler local dev/test environment setup and teardown.

I've currently got our docs being built and served via Mkdocs within the Vagrant VM, to simplify documentation. I figure to add provisioning via our install script, so that we end up with a full-functioning LibreTime install.