### PR TITLE
Use Zend_File_Transfer instead of $_FILES

### DIFF
--- a/airtime_mvc/application/models/airtime/CcFiles.php
+++ b/airtime_mvc/application/models/airtime/CcFiles.php
@@ -92,8 +92,8 @@ class CcFiles extends BaseCcFiles {
 
         //Extract the original filename, which we set as the temporary title for the track
         //until it's finished being processed by the analyzer.
-        $originalFilename = $_FILES["file"]["name"];
-        $tempFilePath = $_FILES['file']['tmp_name'];
+        $originalFilename = $fileArray['file']['name'];
+        $tempFilePath = $fileArray['file']['tmp_name'];
 
         try {
             return self::createAndImport($fileArray, $tempFilePath, $originalFilename);


### PR DESCRIPTION
This should give us more information in the case of an error and is the framework idiomatic way to handle a RESTful file upload.

I'm hoping this helps debug https://github.com/LibreTime/libretime/issues/3