### PR TITLE
Add empty default Facebook config

### DIFF
--- a/airtime_mvc/build/airtime.example.conf
+++ b/airtime_mvc/build/airtime.example.conf
@@ -301,3 +301,10 @@ soundcloud_client_secret = 0
 soundcloud_redirect_uri = http://libretime.example.org/soundcloud_callback.php
 #
 # ----------------------------------------------------------------------
+#                          F A C E B O O K
+# ----------------------------------------------------------------------
+#
+[facebook]
+facebook_app_id = 0
+facebook_app_url = http://example.org
+facebook_app_api_key = 0


### PR DESCRIPTION
This will get rid of the sad tape error on the facebook widgets page `/embeddablewidgets/facebook`. We will probably end up having to document how to set up facebook properly, but I'd like to take care of that while I'm testing against real facebook.