### PR TITLE
Re-enable hw output

### DIFF
--- a/airtime_mvc/application/forms/StreamSetting.php
+++ b/airtime_mvc/application/forms/StreamSetting.php
@@ -22,6 +22,26 @@ class Application_Form_StreamSetting extends Zend_Form
 
         $setting = $this->setting;
 
+        $output_sound_device = new Zend_Form_Element_Checkbox('output_sound_device');
+        $output_sound_device->setLabel(_('Hardware Audio Output:'))
+                            ->setRequired(false)
+                            ->setValue(($setting['output_sound_device'] == "true")?1:0)
+                            ->setDecorators(array('ViewHelper'));
+        $this->addElement($output_sound_device);
+
+        $output_sound_device_type = new Zend_Form_Element_Select('output_sound_device_type');
+        $output_sound_device_type->setLabel(_('Output Type'))
+            ->setMultiOptions(array(
+                "ALSA"=>_("ALSA"),
+                "AO"=>_("AO"),
+                "OSS"=>_("OSS"),
+                "Portaudio"=>_("Portaudio"),
+                "Pulseaudio"=>_("Pulseaudio"),
+                "Jack"=>_("Jack")))
+            ->setValue(isset($setting['output_sound_device_type'])?$setting['output_sound_device_type']:0)
+            ->setDecorators(array('ViewHelper'));
+        $this->addElement($output_sound_device_type);
+
         $icecast_vorbis_metadata = new Zend_Form_Element_Checkbox('icecast_vorbis_metadata');
         $icecast_vorbis_metadata->setLabel(_('Icecast Vorbis Metadata'))
                                 ->setRequired(false)

--- a/install
+++ b/install
@@ -456,7 +456,7 @@ loud "          * Installing Airtime Services *            "
 loud "-----------------------------------------------------"
 
 verbose "\n * Installing necessary python services..."
-loudCmd "pip install setuptools"
+loudCmd "pip install setuptools --upgrade"
 verbose "...Done"
 
 verbose "\n * Creating /run/airtime..."


### PR DESCRIPTION
This re-adds hardware output setting in the ui as per the [taiga#29](https://tree.taiga.io/project/robbt-libreairwaves-airtime-fork/issue/29).

It's basically a cherry-pick of only the first commit from #40. Most of the install issues from #40 have already been sorted out and other issues have open PRs. We will do a 3.0.0-alpha release as soon has we have feature-parity with the tarball (assumingly where most of @comiconomenclaturist's changes came from).

Fixes #40

Thanks, @comiconomenclaturist for the contribution.