### PR TITLE
Make git optional during build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,27 @@
 #!/bin/bash -e
 composer install
 
-git rev-parse HEAD > VERSION
+git_build=""
+if [ -d .git ]; then
+    echo " * Building from Git"
+    git_build="y"
+fi
+
+if [ "${git_build}" = "y" ]; then
+    git_version=`git tag --points-at HEAD`
+    echo " * Version from tag: ${git_version}"
+    if [ "${git_version}" = "" ]; then
+        git_version=`git rev-parse --short HEAD`
+        echo " * Overriding empty version with sha1 commit-ish: ${git_version}"
+    fi
+    echo ${git_version} > VERSION
+else
+    # if no file was in tarball we create one letting the user know
+    # travis should release tarballs with a pre-written VERSION file
+    # at some stage
+    if [ ! -f VERSION ]; then
+        folder_name=$(basename `pwd`)
+        echo "tarball install from folder ${folder_name}" > VERSION
+    fi
+fi
 


### PR DESCRIPTION
Currently the installer fails when using a github tarball that comes without a .git folder (https://github.com/LibreTime/libretime/issues/47#issuecomment-285365745).

With this change build.sh only executes git if a .git folder is detected. It uses the name of the downloaded folder as part of the version string if a tarball is used.

I plan on releasing travis-ci built tarballs that contain the tagged version (once we have one) and also have a pre-downloaded composer vendor folder. Those will already contain a VERSION file as well and this change already contains the setup needed for that.

Example output with `.git/` folder without tag

```
 * Building from Git
 * Version from tag: 
 * Overriding empty version with sha1 commit-ish: 285ed854f
```

With tag:

```
 * Building from Git
 * Version from tag: v0.0.0
```

In the non-git case it stays silent.