### PR TITLE
adding the default rabbitmq-analyzer.ini file to fix install script

### DIFF
--- a/airtime_mvc/build/rabbitmq-analyzer.ini
+++ b/airtime_mvc/build/rabbitmq-analyzer.ini
@@ -1,0 +1,7 @@
+[rabbitmq]
+host = 127.0.0.1
+port = 5672
+user = airtime
+password = airtime
+vhost = /airtime
+


### PR DESCRIPTION
This fixes #24 by adding a rabbitmq-analyzer.ini file.