### PR TITLE
Replace Airtime Pro wording

### DIFF
--- a/airtime_mvc/application/forms/StreamSetting.php
+++ b/airtime_mvc/application/forms/StreamSetting.php
@@ -83,7 +83,7 @@ class Application_Form_StreamSetting extends Zend_Form
         $custom = Application_Model_Preference::getUsingCustomStreamSettings();
         $customSettings = new Zend_Form_Element_Radio('customStreamSettings');
         $customSettings->setLabel(_('Streaming Server:'));
-        $customSettings->setMultiOptions(array(_("Airtime Pro Streaming"), _("Custom / 3rd Party Streaming")));
+        $customSettings->setMultiOptions(array(_("Default Streaming"), _("Custom / 3rd Party Streaming")));
         $customSettings->setValue(!empty($custom) ? $custom : 0);
         $this->addElement($customSettings);
     }


### PR DESCRIPTION
Let's just call this "default" streaming for now. Fixes #31