### PR TITLE
Problem: Pro widgets contain ads for legacy upstream

### DIFF
--- a/airtime_mvc/application/views/scripts/embed/player.phtml
+++ b/airtime_mvc/application/views/scripts/embed/player.phtml
@@ -395,7 +395,7 @@
                 <li></li>
             </ul>
         </div>
-        <a class="airtime_pro" target="_blank" href="https://www.airtime.pro/">Powered by <span class="airtime-pro-orange">Airtime Pro</span></a>
+        <a class="airtime_pro" target="_blank" href="<?php echo PRODUCT_SITE_URL; ?>">Powered by <?php echo PRODUCT_NAME; ?></a>
 
     </div>
 </div>

--- a/airtime_mvc/application/views/scripts/embed/weekly-program.phtml
+++ b/airtime_mvc/application/views/scripts/embed/weekly-program.phtml
@@ -93,7 +93,7 @@
     </div>
 
     <div class="weekly-schedule-widget-footer" <?php if ($this->widgetStyle == "premium") echo "style='display:none'"; ?>>
-        <a href="https://airtime.pro" target="_blank">Powered by <span>Airtime Pro</span></a>
+        <a href="<?php echo PRODUCT_SITE_URL; ?>" target="_blank">Powered by <?php echo PRODUCT_NAME; ?></a>
     </div>
 </div>
 


### PR DESCRIPTION
Solution: Use PRODUCT_NAME and PRODUCT_SITE_URL in pro widgets.