### PR TITLE
Problem: Install cleanup needed for CentOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.define "centos" do |os|
     os.vm.box = 'centos/7'
-    provision_libretime(os, "centos.sh", installer_args + "--ignore-dependencies --distribution=centos --web-user=apache")
+    provision_libretime(os, "centos.sh", installer_args + "--ignore-dependencies --distribution=centos --web-user=apache --selinux")
   end
 
   def provision_libretime(config, prepare_script, installer_args)

--- a/install
+++ b/install
@@ -49,7 +49,10 @@ showhelp () {
     -a, --apache
                 Install apache and deploy a basic configuration for Airtime
     -i, --icecast
-                Install Icecast 2 and deploy a basic configuration for Airtime"
+                Install Icecast 2 and deploy a basic configuration for Airtime
+    --selinux
+                Run restorecon on directories and files that need tagging to
+                allow the WEB_USER access."
     exit 0
 }
 
@@ -67,6 +70,7 @@ postgres="f"
 apache="f"
 icecast="f"
 ignore_dependencies="f"
+selinux="f"
 # Interactive
 _i=1
 # Verbose
@@ -222,6 +226,9 @@ while :; do
             ;;
         --web-port=?*)
             web_port=${1#*=}
+            ;;
+        --selinux)
+            selinux="t"
             ;;
         --)
             shift
@@ -745,6 +752,18 @@ if [ "$ignore_dependencies" = "f" ]; then
     if [ "$dist" = "debian" ]; then
         loudCmd "/usr/sbin/locale-gen"
     fi
+fi
+
+# If the user requested it we run restorecon on files that need
+# tagging for selinux.
+if [ "$selinux" = "t" ]; then
+    loud "\n-----------------------------------------------------"
+    loud "              * Restoring SELinux Tags *             "
+    loud "-----------------------------------------------------"
+
+    verbose "\n * Running restorecon..."
+    loudCmd "restorecon -Rv /etc/airtime /srv/airtime > /dev/null 2>&1"
+    verbose "...Done"
 fi
 
 verbose "\n * Reloading apache..."

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -84,6 +84,7 @@ yum install -y \
   php-bcmath \
   php-mbstring \
   httpd \
+  fdk-aac \
   liquidsoap \
   silan \
   icecast \
@@ -94,6 +95,7 @@ yum install -y \
 
 # for pip ssl install
 yum install -y \
+  gcc \
   python-devel \
   python-lxml \
   openssl-devel

--- a/python_apps/pypo/liquidsoap/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/ls_script.liq
@@ -45,26 +45,30 @@ def check_version(~version=liquidsoap.version, major, minor) =
     list.nth(v,0) > major or list.nth(v,0) == major and list.nth(v,1) >= minor
 end
 
+# cue cut fix for liquidsoap <1.2.2
+#
+# This was most likely broken on 1.1.1 (debian) as well.
+# 
+# adapted from https://github.com/savonet/liquidsoap/issues/390#issuecomment-277562081
+#
+def fix_cue_in(~cue_in_metadata='liq_cue_in', m) =
+    # 0.04 might need to be adjusted according to your frame size
+    if float_of_string(m[cue_in_metadata]) < 0.04 then
+        [(cue_in_metadata, "0")]
+    else
+        []
+    end
+end
+
 def create_source()
     l = request.equeue(id="s#{!source_id}", length=0.5)
 
     l = audio_to_stereo(id="queue_src", l)
 
-    # cue cut fix for liquidsoap <1.2.2
-    #
-    # This was most likely broken on 1.1.1 (debian) as well.
-    # 
-    # adapted from https://github.com/savonet/liquidsoap/issues/390#issuecomment-277562081
-    #
-    if not check_version(1, 3) then
-        l = map_metadata(fun (~cue_in_metadata='liq_cue_in', m) ->
-            # 0.04 might need to be adjusted according to your frame size
-            if float_of_string(m[cue_in_metadata]) < 0.04 then
-                [(cue_in_metadata, "0")]
-            else
-                []
-            end
-        end)
+    l = if not check_version(1, 3) then
+        map_metadata(fix_cue_in, l)
+    else
+        l
     end
     l = cue_cut(l)
     l = amplify(1., override="replay_gain", l)


### PR DESCRIPTION
These are the remaining blocker issues we found when retesting CentOS with #64.

* [x] install `gcc` and `fdk-aac`
* [x] run `restorecon` on newly SELinux tagged files after installing them
* [x] fix `fix_cue_in` from #65  to work with both liquidsoap 1.1 and 1.2