### PR TITLE
Problem: std_err_override is a hack for python < 2.7

### DIFF
--- a/python_apps/pypo/bin/pyponotify
+++ b/python_apps/pypo/bin/pyponotify
@@ -28,7 +28,6 @@ from configobj import ConfigObj
 # custom imports
 #from util import *
 from api_clients import *
-from std_err_override import LogWriter
 
 LOG_LEVEL = logging.INFO
 LOG_PATH = '/var/log/airtime/pypo/notify.log'
@@ -54,6 +53,7 @@ parser.add_option("-n", "--liquidsoap-started", help="notify liquidsoap started"
 (options, args) = parser.parse_args()
 
 # Set up logging
+logging.captureWarnings(True)
 logFormatter = logging.Formatter("%(asctime)s [%(module)s] [%(levelname)-5.5s]  %(message)s")
 rootLogger = logging.getLogger()
 rootLogger.setLevel(LOG_LEVEL)

--- a/python_apps/pypo/pypo/__main__.py
+++ b/python_apps/pypo/pypo/__main__.py
@@ -31,11 +31,11 @@ from configobj import ConfigObj
 
 # custom imports
 from api_clients import api_client
-#from std_err_override import LogWriter
 import pure
 
 LOG_PATH = '/var/log/airtime/pypo/pypo.log'
 LOG_LEVEL = logging.INFO
+logging.captureWarnings(True)
 
 # Set up command-line options
 parser = OptionParser()

--- a/python_apps/pypo/pypo/pypofetch.py
+++ b/python_apps/pypo/pypo/pypofetch.py
@@ -18,7 +18,6 @@ from threading import Thread, Timer
 from subprocess import Popen, PIPE
 
 from api_clients import api_client
-from std_err_override import LogWriter
 from timeout import ls_timeout
 
 
@@ -28,8 +27,7 @@ def keyboardInterruptHandler(signum, frame):
     sys.exit(0)
 signal.signal(signal.SIGINT, keyboardInterruptHandler)
 
-#need to wait for Python 2.7 for this..
-#logging.captureWarnings(True)
+logging.captureWarnings(True)
 
 POLL_INTERVAL = 480
 

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -16,12 +16,9 @@ import json
 import hashlib
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
-from std_err_override import LogWriter
-
 CONFIG_PATH = '/etc/airtime/airtime.conf'
 
-#need to wait for Python 2.7 for this..
-#logging.captureWarnings(True)
+logging.captureWarnings(True)
 
 
 class PypoFile(Thread):

--- a/python_apps/pypo/pypo/pypomessagehandler.py
+++ b/python_apps/pypo/pypo/pypomessagehandler.py
@@ -13,10 +13,7 @@ from kombu.simple import SimpleQueue
 from amqp.exceptions import AMQPError
 import json
 
-from std_err_override import LogWriter
-
-#need to wait for Python 2.7 for this..
-#logging.captureWarnings(True)
+logging.captureWarnings(True)
 
 
 class PypoMessageHandler(Thread):

--- a/python_apps/pypo/pypo/pypopush.py
+++ b/python_apps/pypo/pypo/pypopush.py
@@ -21,12 +21,9 @@ from Queue import Empty, Queue
 from threading import Thread
 
 from api_clients import api_client
-from std_err_override import LogWriter
 from timeout import ls_timeout
 
-
-#need to wait for Python 2.7 for this..
-#logging.captureWarnings(True)
+logging.captureWarnings(True)
 
 PUSH_INTERVAL = 2
 


### PR DESCRIPTION
Solution: Replace std_err_override with logging.captureWarnings(True) in pypo

The quite ugly hack with std_err_override seems to have been made for python < 2.7. Since all major distros have at least python 2.7 installed we can stop using the std_err_override hack.

This removes it from pypo, media-monitor still uses the module and we can completely delete it when we have removed media-monitor after having maybe backported the watched folders feature to analyzer.

I'm doing this since it makes packaging pypo much easier, we have one module less to care about. I'm also considering putting the modules we end up keeping into the [Python Package Index](https://pypi.python.org/pypi) index so we do not need a local clone or tarball to install python parts. 