### PR TITLE
Disable all google tracking per default

### DIFF
--- a/airtime_mvc/application/common/GoogleAnalytics.php
+++ b/airtime_mvc/application/common/GoogleAnalytics.php
@@ -9,6 +9,9 @@ class Application_Common_GoogleAnalytics
     public static function generateGoogleTagManagerDataLayerJavaScript()
     {
         $code = "";
+        if (LIBRETIME_ENABLE_GOOGLE_ANALYTICS !== true) {
+            return $code;
+        }
 
         try {
             $clientId = Application_Model_Preference::GetClientId();
@@ -55,6 +58,11 @@ class Application_Common_GoogleAnalytics
     /** Generate the JavaScript snippet that logs a trial to paid conversion  */
     public static function generateConversionTrackingJavaScript()
     {
+        $code = "";
+        if (LIBRETIME_ENABLE_GOOGLE_ANALYTICS !== true) {
+            return $code;
+        }
+
         $newPlan = Application_Model_Preference::GetPlanLevel();
         $oldPlan = Application_Model_Preference::GetOldPlanLevel();
 

--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -104,6 +104,9 @@ define('UI_PLAYLISTCONTROLLER_OBJ_SESSNAME', 'PLAYLISTCONTROLLER_OBJ');
 /*define('UI_PLAYLIST_SESSNAME', 'PLAYLIST');
 define('UI_BLOCK_SESSNAME', 'BLOCK');*/
 
+// Google Analytics integration
+define('LIBRETIME_ENABLE_GOOGLE_ANALYTICS', false);
+
 //WHMCS integration
 define('LIBRETIME_ENABLE_WHMCS',            false);
 define('WHMCS_PASSWORD_RESET_URL',          'https://account.example.com/pwreset.php');

--- a/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
+++ b/airtime_mvc/application/controllers/plugins/PageLayoutInitPlugin.php
@@ -240,11 +240,6 @@ class PageLayoutInitPlugin extends Zend_Controller_Plugin_Abstract
                 $view->headScript()->appendFile($baseUrl . 'js/airtime/common/livechat.js?' . $CC_CONFIG['airtime_version'], 'text/javascript');
             }
         }
-
-        /*
-        if (isset($CC_CONFIG['demo']) && $CC_CONFIG['demo'] == 1) {
-            $view->headScript()->appendFile($baseUrl.'js/libs/google-analytics.js?'.$CC_CONFIG['airtime_version'],'text/javascript');
-        }*/
     }
 
     protected function _initViewHelpers()

--- a/airtime_mvc/application/layouts/scripts/layout.phtml
+++ b/airtime_mvc/application/layouts/scripts/layout.phtml
@@ -9,6 +9,7 @@
 	<?php $baseUrl = Application_Common_OsPath::getBaseDir(); ?>
 </head>
 <body>
+<?php if (LIBRETIME_ENABLE_GOOGLE_ANALYTICS === true): ?>
 <!-- Google Tag Manager -->
 <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-55N6NH"
 height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
@@ -18,7 +19,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-55N6NH');</script>
 <!-- End Google Tag Manager -->
-
+<?php endif; ?>
 <?php echo $this->partial('partialviews/trialBox.phtml', array("is_trial"=>$this->isTrial(), "trial_remain"=> $this->trialRemaining())) ?>
 
     <div id="Panel" class="sticky">

--- a/airtime_mvc/public/js/libs/google-analytics.js
+++ b/airtime_mvc/public/js/libs/google-analytics.js
@@ -1,9 +1,0 @@
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', 'UA-28765064-1']);
-_gaq.push(['_trackPageview']);
-
-(function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();


### PR DESCRIPTION
My browser was already blocking this. I feel we should not tag a release that uses google services with any ids relating to legacy upstream.