### PR TITLE
Make password reset work for eveyone

### DIFF
--- a/airtime_mvc/application/controllers/LoginController.php
+++ b/airtime_mvc/application/controllers/LoginController.php
@@ -156,7 +156,7 @@ class LoginController extends Zend_Controller_Action
         if ($request->isPost()) {
             if ($form->isValid($request->getPost())) {
                 $query = CcSubjsQuery::create();
-                $username = $form->userName->getValue();
+                $username = $form->username->getValue();
                 $email = $form->email->getValue();
 
                 if (empty($username)) {
@@ -179,7 +179,18 @@ class LoginController extends Zend_Controller_Action
                         $form->email->addError($this->view->translate(_("Email could not be sent. Check your mail server settings and ensure it has been configured properly.")));
                     }
                 } else {
-                    $form->email->addError($this->view->translate(sprintf(_pro("That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."), WHMCS_PASSWORD_RESET_URL)));
+                    if (!LIBRETIME_ENABLE_WHMCS) {
+                    	$form->email->addError($this->view->translate(_("That username or email address could not be found.")));
+                    } else {
+                        $form->email->addError(
+                            $this->view->translate(
+                                sprintf(
+                                    _pro("That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."),
+                                    WHMCS_PASSWORD_RESET_URL
+                                )
+                            )
+                        );
+                    }
                 }
             } else { //Form is not valid
                 $form->email->addError($this->view->translate(_("There was a problem with the username or email address you entered.")));

--- a/airtime_mvc/application/forms/PasswordRestore.php
+++ b/airtime_mvc/application/forms/PasswordRestore.php
@@ -41,7 +41,6 @@ class Application_Form_PasswordRestore extends Zend_Form
             )
         ));
 
-        /*
         $cancel = new Zend_Form_Element_Button("cancel");
         $cancel->class = 'ui-button ui-widget ui-state-default ui-button-text-only center';
         $cancel->setLabel(_("Back"))
@@ -49,6 +48,5 @@ class Application_Form_PasswordRestore extends Zend_Form
                ->setAttrib('onclick', 'window.location = ' . Zend_Controller_Front::getInstance()->getBaseUrl('login'))
                ->setDecorators(array('ViewHelper'));
         $this->addElement($cancel);
-        */
     }
 }

--- a/airtime_mvc/application/models/Auth.php
+++ b/airtime_mvc/application/models/Auth.php
@@ -32,8 +32,8 @@ class Application_Model_Auth
 
         $message = sprintf(_("Hi %s, \n\nPlease click this link to reset your password: "), $user->getDbLogin());
         $message .= "{$e_link_protocol}://{$e_link_base}:{$e_link_port}{$e_link_path}";
-        $message .= sprintf(_pro("\n\nIf you have any problems, please contact our support team: %s"), SUPPORT_ADDRESS);
-        $message .= sprintf(_pro("\n\nThank you,\nThe %s Team"), SAAS_PRODUCT_BRANDING_NAME);
+        $message .= sprintf(_("\n\nIf you have any problems, please contact our support team: %s"), SUPPORT_ADDRESS);
+        $message .= sprintf(_("\n\nThank you,\nThe %s Team"), SAAS_PRODUCT_BRANDING_NAME);
 
         $str = sprintf(_('%s Password Reset'), SAAS_PRODUCT_BRANDING_NAME);
         return Application_Model_Email::send($str, $message, $user->getDbEmail());

--- a/airtime_mvc/application/views/scripts/form/password-restore.phtml
+++ b/airtime_mvc/application/views/scripts/form/password-restore.phtml
@@ -1,3 +1,4 @@
+<?php if (LIBRETIME_ENABLE_WHMCS): ?>
 <fieldset>
     <legend>Station Owners</legend>
     <p>
@@ -5,8 +6,11 @@
     </p>
 
 </fieldset>
+<?php endif; ?>
 <fieldset>
+    <?php if (LIBRETIME_ENABLE_WHMCS): ?>
     <legend>DJs, Program Managers, and Others</legend>
+    <?php endif; ?>
     <form enctype="application/x-www-form-urlencoded" method="post" action="">
         <dl class="zend_form">
 


### PR DESCRIPTION
This stops distinguishing between superadmin users from whmcs vs regular local users on the password reset page.

Sending mail gets handled through `mail()` so it is up to the sysadmin to set this up properly. The vagrant install is not able to send mail out of the box and I think that is ok.

Fixes #12 
