### PR TITLE
Change default email sender

### DIFF
--- a/airtime_mvc/application/configs/constants.php
+++ b/airtime_mvc/application/configs/constants.php
@@ -25,6 +25,7 @@ define('AIRTIME_TRANSIFEX_URL'      , 'http://libretime.org/translating/');
 define('SUPPORT_TICKET_URL'         , 'https://github.com/LibreTime/libretime/issues');
 define('UI_REVAMP_EMBED_URL'        , 'https://www.youtube.com/embed/nqpNnCKGluY');
 define('LIBRETIME_WHATS_NEW_URL'    , 'https://github.com/LibreTime/libretime/releases');
+define('LIBRETIME_EMAIL_FROM'       , 'noreply@libretime.org');
 
 define('LICENSE_VERSION'    , 'GNU AGPL v.3');
 define('LICENSE_URL'        , 'http://www.gnu.org/licenses/agpl-3.0-standalone.html');

--- a/airtime_mvc/application/models/Email.php
+++ b/airtime_mvc/application/models/Email.php
@@ -13,7 +13,7 @@ class Application_Model_Email
      */
     public static function send($subject, $message, $to) {
 
-        $headers = sprintf('From: %s <noreply@account.sourcefabric.com>', SAAS_PRODUCT_BRANDING_NAME);
+        $headers = sprintf('From: %s <%s>', SAAS_PRODUCT_BRANDING_NAME, LIBRETIME_EMAIL_FROM);
         return mail($to, $subject, $message, $headers);
 
     }


### PR DESCRIPTION
The new noreply@ address is now `noreply@libretime.org` and the address gets moved to contants.php rather than being hardcoded in the email model.

Fixes #18 