### PR TITLE
Add missing playout dependency

### DIFF
--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -91,7 +91,8 @@ yum install -y \
   python-pip \
   selinux-policy \
   policycoreutils-python \
-  python-celery 
+  python-celery \
+  lsof
 
 # for pip ssl install
 yum install -y \


### PR DESCRIPTION
Pypo uses lsof to check if files are not being used before removing them. This one was a bit non obvious since it errs to the log and doesn't affect playout.