### PR TITLE
Add docs linked from help page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/LibreTime/libretime.svg?branch=master)](https://travis-ci.org/LibreTime/libretime)
 
-LibreTime is a community managed fork of the AirTime project.
+LibreTime makes it easy to run your own online or terrestrial radio station. It is a community managed fork of the AirTime project.
 
 It is managed by a friendly inclusive community of stations 
 from around the globe that use, document and improve LibreTime. 
@@ -10,6 +10,8 @@ Join us in fixing bugs and in defining how we manage the
 codebase going forward.
 
 We are currently ramping up development on this repository.
+
+Check out the [documentation](http://libretime.org) for more information and start broadcasting!
 
 Please note that LibreTime is released with a [Contributor Code 
 of Conduct](https://github.com/LibreTime/code-of-conduct/blob/CODE-OF-CONDUCT.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,23 @@
+**What is LibreTime?**
+
+LibreTime is a community managed fork of the AirTime project.
+
+It is managed by a friendly inclusive community of stations 
+from around the globe that use, document and improve LibreTime. 
+
+**Can I upgrade to LibreTime?**
+
+In theory you can update any pre 3.0 version of AirTime to
+LibreTime 3.0.0 and above. 
+
+LibreTime is complex software, as such it is close to impossible
+to guarantee that every upgrade path works as intended. This
+means you should trial the update on a parallel test 
+infrastructure to minimize possible downtime.
+
+Please let the community know if you encounter issues with the
+update process. 
+
+**Why did you fork AirTime?**
+
+See this [open letter to the Airtime community](https://gist.github.com/hairmare/8c03b69c9accc90cfe31fd7e77c3b07d).

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -1,0 +1,4 @@
+While LibreTime is translatable software, it does not yet have a translation interface.
+
+Please [let us know](https://github.com/LibreTime/libretime/issues/new) if you want 
+to contribute to the translation effort so we can prioritize setting such an interface.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ pages:
   - 'Home': index.md
   - 'What is LibreTime': manual/index.md
   - 'Features': features.md
+  - 'F.A.Q.': faq.md
   - 'Rights and Royalties': manual/rights-and-royalties/index.md
   - 'Using LibreTime':
     - 'On air in 60 seconds!': 'manual/on-air-in-60-seconds/index.md'
@@ -71,6 +72,7 @@ pages:
   - 'Development':
     - 'Testing': testing.md
     - 'Vagrant': vagrant.md
+    - 'Translating': translating.md
     - 'Documentation': documentation.md
   - 'Appendix':
     - 'Expert install': manual/expert-install/index.md


### PR DESCRIPTION
I linked these docs from the help page pointing to a 404 and this takes care of adding some rather bare content so we have something up and running for 3.0.0-alpha.

I believe this is about all we need for the first release. It can also be merged post-release since it will show up on the docs instantly.

I'll tag 3.0.0-alpha release later today and do some more outreach after it is tagged. I'd also like to start draining the taiga board to ensure that nothing went missing from there.