### PR TITLE
Fix release.sh script

### DIFF
--- a/dev_tools/release/release.sh
+++ b/dev_tools/release/release.sh
@@ -46,7 +46,8 @@ echo " Done"
 pushd $target
 
 echo -n "Checking out tag ${suffix}..."
-git checkout --quiet ${suffix}
+git fetch --quiet --tags
+git checkout --quiet tags/${suffix}
 echo " Done"
 
 echo -n "Running composer install..."


### PR DESCRIPTION
Make it add vendor to the tarball and just be a generally nicer script with less verbose output and no ability to wipe my working copies .git folder when executed in the wrong dir.

I plan on using this to create tarballs that can be used for the rpmbuild process without the build box needing to run composer and connect to the internet. The openSUSE Build Service boxen do not have a connection to the internet during builds.

I'll do some additional testing with travis and my fork before I implement the changes needed for travis to autodeploy the tarball built by the script. For 3.0.0-alpha I'll probably just upload the results of the script.