### PR TITLE
basic podcast album override option in preferences

### DIFF
--- a/airtime_mvc/application/controllers/PreferenceController.php
+++ b/airtime_mvc/application/controllers/PreferenceController.php
@@ -45,6 +45,7 @@ class PreferenceController extends Zend_Controller_Action
                 Application_Model_Preference::SetDefaultCrossfadeDuration($values["stationDefaultCrossfadeDuration"]);
                 Application_Model_Preference::SetDefaultFadeIn($values["stationDefaultFadeIn"]);
                 Application_Model_Preference::SetDefaultFadeOut($values["stationDefaultFadeOut"]);
+                Application_Model_Preference::SetPodcastAlbumOverride($values["podcastAlbumOverride"]);
                 Application_Model_Preference::SetAllow3rdPartyApi($values["thirdPartyApi"]);
                 Application_Model_Preference::SetAllowedCorsUrls($values["allowedCorsUrls"]);
                 Application_Model_Preference::SetDefaultLocale($values["locale"]);

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -100,6 +100,25 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
             'value' => $defaultFadeOut,
         ));
 
+
+        $podcast_album_override = new Zend_Form_Element_Radio('podcastAlbumOverride');
+        $podcast_album_override->setLabel(_('Podcast Album Override'));
+        $podcast_album_override->setDescription(_('Always replace downloaded podcast track album with podcast name.'));
+        $podcast_album_override->setMultiOptions(array(
+            _("Disabled"),
+            _("Enabled"),
+        ));
+        $podcast_album_override->setValue(Application_Model_Preference::GetPodcastAlbumOverride());
+        $podcast_album_override->setDescription(_('Enabling this means that podcast tracks will always contain the podcast name in their album field.'));
+        $podcast_album_override->setSeparator(' '); //No <br> between radio buttons
+        //$third_party_api->addDecorator(new Zend_Form_Decorator_Label(array('tag' => 'dd', 'class' => 'radio-inline-list')));
+        $podcast_album_override->addDecorator('HtmlTag', array('tag' => 'dd',
+            'id'=>"podcastAlbumOverride-element",
+            'class' => 'radio-inline-list',
+        ));
+        $this->addElement($podcast_album_override);
+
+
         $third_party_api = new Zend_Form_Element_Radio('thirdPartyApi');
         $third_party_api->setLabel(_('Public Airtime API'));
         $third_party_api->setDescription(_('Required for embeddable schedule widget.'));
@@ -124,6 +143,10 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
         $allowedCorsUrls->setDescription(_('Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line.'));
         $allowedCorsUrls->setValue($allowedCorsUrlsValue);
         $this->addElement($allowedCorsUrls);
+
+
+
+
 
         $locale = new Zend_Form_Element_Select("locale");
         $locale->setLabel(_("Default Language"));

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -144,10 +144,6 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
         $allowedCorsUrls->setValue($allowedCorsUrlsValue);
         $this->addElement($allowedCorsUrls);
 
-
-
-
-
         $locale = new Zend_Form_Element_Select("locale");
         $locale->setLabel(_("Default Language"));
         $locale->setMultiOptions(Application_Model_Locale::getLocales());

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -103,7 +103,6 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
 
         $podcast_album_override = new Zend_Form_Element_Radio('podcastAlbumOverride');
         $podcast_album_override->setLabel(_('Podcast Album Override'));
-        $podcast_album_override->setDescription(_('Always replace downloaded podcast track album with podcast name.'));
         $podcast_album_override->setMultiOptions(array(
             _("Disabled"),
             _("Enabled"),

--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -358,8 +358,7 @@ class Application_Model_Preference
     {
         self::setValue("third_party_api", $bool);
     }
-    
-    
+
     public static function GetAllow3rdPartyApi()
     {
         $val = self::getValue("third_party_api");
@@ -374,10 +373,8 @@ class Application_Model_Preference
     public static function GetPodcastAlbumOverride()
     {
         $val = self::getValue("podcast_album_override");
-        return (strlen($val) == 0 ) ? "1" : $val;
+        return $val === '1' ? true : false;
     }
-
-
 
     public static function SetPhone($phone)
     {

--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -358,12 +358,26 @@ class Application_Model_Preference
     {
         self::setValue("third_party_api", $bool);
     }
-
+    
+    
     public static function GetAllow3rdPartyApi()
     {
         $val = self::getValue("third_party_api");
         return (strlen($val) == 0 ) ? "1" : $val;
     }
+
+    public static function SetPodcastAlbumOverride($bool)
+    {
+        self::setValue("podcast_album_override", $bool);
+    }
+    
+    public static function GetPodcastAlbumOverride()
+    {
+        $val = self::getValue("podcast_album_override");
+        return (strlen($val) == 0 ) ? "1" : $val;
+    }
+
+
 
     public static function SetPhone($phone)
     {

--- a/airtime_mvc/application/services/PodcastEpisodeService.php
+++ b/airtime_mvc/application/services/PodcastEpisodeService.php
@@ -150,6 +150,7 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
             'callback_url'  => $stationUrl . 'rest/media',
             'api_key'       => $CC_CONFIG["apiKey"][0],
             'podcast_name'  => $title,
+            'album_override' => Application_Model_Preference::GetPodcastAlbumOverride(),
         );
         $task = $this->_executeTask(static::$_CELERY_TASKS[self::DOWNLOAD], $data);
         // Get the created ThirdPartyTaskReference and set the episode ID so

--- a/airtime_mvc/application/views/scripts/form/preferences_general.phtml
+++ b/airtime_mvc/application/views/scripts/form/preferences_general.phtml
@@ -31,6 +31,8 @@
 
         <?php echo $this->element->getElement('stationDefaultCrossfadeDuration')->render() ?>
 
+        <?php echo $this->element->getElement('podcastAlbumOverride')->render() ?>
+
         <?php echo $this->element->getElement('thirdPartyApi')->render() ?>
         <?php echo $this->element->getElement('allowedCorsUrls')->render() ?>
 

--- a/python_apps/airtime-celery/airtime-celery/tasks.py
+++ b/python_apps/airtime-celery/airtime-celery/tasks.py
@@ -157,15 +157,10 @@ def podcast_download(id, url, callback_url, api_key, podcast_name, album_overrid
                 # currently hardcoded for mp3s may want to add support for oggs etc
                 m = MP3(audiofile.name, ID3=EasyID3)
                 logger.debug('podcast_download loaded mp3 {0}'.format(audiofile.name))
-                # replace the album id3 tag with the podcast name if the album tag is empty
-                try:
-                    m['album']
-                except KeyError:
-                    logger.debug('setting new album name to {0} in podcast'.format(podcast_name.encode('ascii', 'ignore')))
-                    m['album'] = podcast_name
-                # if the album override option is enabled replace the album id3 tag with the podcast name even if the album tag contains data
-                if album_override is True:
-                    m['album'] = podcast_name
+
+                # replace album title as needed
+                m = podcast_override_album(m, podcast_name, album_override)
+
                 m.save()
                 filetypeinfo = m.pprint()
                 logger.info('filetypeinfo is {0}'.format(filetypeinfo.encode('ascii', 'ignore')))
@@ -181,6 +176,22 @@ def podcast_download(id, url, callback_url, api_key, podcast_name, album_overrid
         obj['status'] = 0
     return json.dumps(obj)
 
+def podcast_override_album(m, podcast_name, override):
+    """
+    Override m['album'] if empty or forced with override arg
+    """
+    # if the album override option is enabled replace the album id3 tag with the podcast name even if the album tag contains data
+    if override is True:
+        logger.debug('overriding album name to {0} in podcast'.format(podcast_name.encode('ascii', 'ignore')))
+        m['album'] = podcast_name
+    else:
+        # replace the album id3 tag with the podcast name if the album tag is empty
+        try:
+            m['album']
+        except KeyError:
+           logger.debug('setting new album name to {0} in podcast'.format(podcast_name.encode('ascii', 'ignore')))
+           m['album'] = podcast_name
+    return m
 
 def get_filename(r):
     """


### PR DESCRIPTION
This adds an option to preferences that makes it so that downloaded podcasts will always have their album ID3 tag  overridden, even if it isn't empty. 

There needs to be some troubleshooting because it is always overriding even if this option is disabled. 

This is either due to the wrong boolean being passed via rabbitMQ to the celery task or the python code in the celery tasks.py not being able to interpret the bool correctly. I'll work to fix it but if someone else notices a possible issue feel free to point it out. 

This fixes #89 