### PR TITLE
per podcast album override

### DIFF
--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.1/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.1/downgrade.sql
@@ -1,1 +1,3 @@
 ALTER TABLE imported_podcast DROP COLUMN IF EXISTS album_override;
+ALTER TABLE third_party_track_references ALTER COLUMN file_id DROP DEFAULT;
+ALTER TABLE third_party_track_references ALTER COLUMN file_id SET NOT NULL;

--- a/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.1/downgrade.sql
+++ b/airtime_mvc/application/controllers/downgrade_sql/airtime_3.0.0-alpha.1/downgrade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE imported_podcast DROP COLUMN IF EXISTS album_override;

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.1/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.1/upgrade.sql
@@ -1,0 +1,1 @@
+ALTER TABLE imported_podcast ADD COLUMN album_override boolean default 'f' NOT NULL;

--- a/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.1/upgrade.sql
+++ b/airtime_mvc/application/controllers/upgrade_sql/airtime_3.0.0-alpha.1/upgrade.sql
@@ -1,1 +1,3 @@
 ALTER TABLE imported_podcast ADD COLUMN album_override boolean default 'f' NOT NULL;
+ALTER TABLE third_party_track_references ALTER COLUMN file_id SET DEFAULT 0;
+ALTER TABLE third_party_track_references ALTER COLUMN file_id DROP NOT NULL;

--- a/airtime_mvc/application/models/airtime/map/ImportedPodcastTableMap.php
+++ b/airtime_mvc/application/models/airtime/map/ImportedPodcastTableMap.php
@@ -42,6 +42,7 @@ class ImportedPodcastTableMap extends TableMap
         $this->addPrimaryKey('id', 'DbId', 'INTEGER', true, null, null);
         $this->addColumn('auto_ingest', 'DbAutoIngest', 'BOOLEAN', true, null, false);
         $this->addColumn('auto_ingest_timestamp', 'DbAutoIngestTimestamp', 'TIMESTAMP', false, null, null);
+        $this->addColumn('album_override', 'DbAlbumOverride', 'BOOLEAN', true, null, false);
         $this->addForeignKey('podcast_id', 'DbPodcastId', 'INTEGER', 'podcast', 'id', true, null, null);
         // validators
     } // initialize()

--- a/airtime_mvc/application/models/airtime/map/ThirdPartyTrackReferencesTableMap.php
+++ b/airtime_mvc/application/models/airtime/map/ThirdPartyTrackReferencesTableMap.php
@@ -42,7 +42,7 @@ class ThirdPartyTrackReferencesTableMap extends TableMap
         $this->addPrimaryKey('id', 'DbId', 'INTEGER', true, null, null);
         $this->addColumn('service', 'DbService', 'VARCHAR', true, 256, null);
         $this->addColumn('foreign_id', 'DbForeignId', 'VARCHAR', false, 256, null);
-        $this->addForeignKey('file_id', 'DbFileId', 'INTEGER', 'cc_files', 'id', true, null, null);
+        $this->addForeignKey('file_id', 'DbFileId', 'INTEGER', 'cc_files', 'id', true, null, 0);
         $this->addColumn('upload_time', 'DbUploadTime', 'TIMESTAMP', false, null, null);
         $this->addColumn('status', 'DbStatus', 'VARCHAR', false, 256, null);
         // validators

--- a/airtime_mvc/application/models/airtime/om/BaseImportedPodcastPeer.php
+++ b/airtime_mvc/application/models/airtime/om/BaseImportedPodcastPeer.php
@@ -24,13 +24,13 @@ abstract class BaseImportedPodcastPeer
     const TM_CLASS = 'ImportedPodcastTableMap';
 
     /** The total number of columns. */
-    const NUM_COLUMNS = 4;
+    const NUM_COLUMNS = 5;
 
     /** The number of lazy-loaded columns. */
     const NUM_LAZY_LOAD_COLUMNS = 0;
 
     /** The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS) */
-    const NUM_HYDRATE_COLUMNS = 4;
+    const NUM_HYDRATE_COLUMNS = 5;
 
     /** the column name for the id field */
     const ID = 'imported_podcast.id';
@@ -40,6 +40,9 @@ abstract class BaseImportedPodcastPeer
 
     /** the column name for the auto_ingest_timestamp field */
     const AUTO_INGEST_TIMESTAMP = 'imported_podcast.auto_ingest_timestamp';
+
+    /** the column name for the album_override field */
+    const ALBUM_OVERRIDE = 'imported_podcast.album_override';
 
     /** the column name for the podcast_id field */
     const PODCAST_ID = 'imported_podcast.podcast_id';
@@ -63,12 +66,12 @@ abstract class BaseImportedPodcastPeer
      * e.g. ImportedPodcastPeer::$fieldNames[ImportedPodcastPeer::TYPE_PHPNAME][0] = 'Id'
      */
     protected static $fieldNames = array (
-        BasePeer::TYPE_PHPNAME => array ('DbId', 'DbAutoIngest', 'DbAutoIngestTimestamp', 'DbPodcastId', ),
-        BasePeer::TYPE_STUDLYPHPNAME => array ('dbId', 'dbAutoIngest', 'dbAutoIngestTimestamp', 'dbPodcastId', ),
-        BasePeer::TYPE_COLNAME => array (ImportedPodcastPeer::ID, ImportedPodcastPeer::AUTO_INGEST, ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP, ImportedPodcastPeer::PODCAST_ID, ),
-        BasePeer::TYPE_RAW_COLNAME => array ('ID', 'AUTO_INGEST', 'AUTO_INGEST_TIMESTAMP', 'PODCAST_ID', ),
-        BasePeer::TYPE_FIELDNAME => array ('id', 'auto_ingest', 'auto_ingest_timestamp', 'podcast_id', ),
-        BasePeer::TYPE_NUM => array (0, 1, 2, 3, )
+        BasePeer::TYPE_PHPNAME => array ('DbId', 'DbAutoIngest', 'DbAutoIngestTimestamp', 'DbAlbumOverride', 'DbPodcastId', ),
+        BasePeer::TYPE_STUDLYPHPNAME => array ('dbId', 'dbAutoIngest', 'dbAutoIngestTimestamp', 'dbAlbumOverride', 'dbPodcastId', ),
+        BasePeer::TYPE_COLNAME => array (ImportedPodcastPeer::ID, ImportedPodcastPeer::AUTO_INGEST, ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP, ImportedPodcastPeer::ALBUM_OVERRIDE, ImportedPodcastPeer::PODCAST_ID, ),
+        BasePeer::TYPE_RAW_COLNAME => array ('ID', 'AUTO_INGEST', 'AUTO_INGEST_TIMESTAMP', 'ALBUM_OVERRIDE', 'PODCAST_ID', ),
+        BasePeer::TYPE_FIELDNAME => array ('id', 'auto_ingest', 'auto_ingest_timestamp', 'album_override', 'podcast_id', ),
+        BasePeer::TYPE_NUM => array (0, 1, 2, 3, 4, )
     );
 
     /**
@@ -78,12 +81,12 @@ abstract class BaseImportedPodcastPeer
      * e.g. ImportedPodcastPeer::$fieldNames[BasePeer::TYPE_PHPNAME]['Id'] = 0
      */
     protected static $fieldKeys = array (
-        BasePeer::TYPE_PHPNAME => array ('DbId' => 0, 'DbAutoIngest' => 1, 'DbAutoIngestTimestamp' => 2, 'DbPodcastId' => 3, ),
-        BasePeer::TYPE_STUDLYPHPNAME => array ('dbId' => 0, 'dbAutoIngest' => 1, 'dbAutoIngestTimestamp' => 2, 'dbPodcastId' => 3, ),
-        BasePeer::TYPE_COLNAME => array (ImportedPodcastPeer::ID => 0, ImportedPodcastPeer::AUTO_INGEST => 1, ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP => 2, ImportedPodcastPeer::PODCAST_ID => 3, ),
-        BasePeer::TYPE_RAW_COLNAME => array ('ID' => 0, 'AUTO_INGEST' => 1, 'AUTO_INGEST_TIMESTAMP' => 2, 'PODCAST_ID' => 3, ),
-        BasePeer::TYPE_FIELDNAME => array ('id' => 0, 'auto_ingest' => 1, 'auto_ingest_timestamp' => 2, 'podcast_id' => 3, ),
-        BasePeer::TYPE_NUM => array (0, 1, 2, 3, )
+        BasePeer::TYPE_PHPNAME => array ('DbId' => 0, 'DbAutoIngest' => 1, 'DbAutoIngestTimestamp' => 2, 'DbAlbumOverride' => 3, 'DbPodcastId' => 4, ),
+        BasePeer::TYPE_STUDLYPHPNAME => array ('dbId' => 0, 'dbAutoIngest' => 1, 'dbAutoIngestTimestamp' => 2, 'dbAlbumOverride' => 3, 'dbPodcastId' => 4, ),
+        BasePeer::TYPE_COLNAME => array (ImportedPodcastPeer::ID => 0, ImportedPodcastPeer::AUTO_INGEST => 1, ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP => 2, ImportedPodcastPeer::ALBUM_OVERRIDE => 3, ImportedPodcastPeer::PODCAST_ID => 4, ),
+        BasePeer::TYPE_RAW_COLNAME => array ('ID' => 0, 'AUTO_INGEST' => 1, 'AUTO_INGEST_TIMESTAMP' => 2, 'ALBUM_OVERRIDE' => 3, 'PODCAST_ID' => 4, ),
+        BasePeer::TYPE_FIELDNAME => array ('id' => 0, 'auto_ingest' => 1, 'auto_ingest_timestamp' => 2, 'album_override' => 3, 'podcast_id' => 4, ),
+        BasePeer::TYPE_NUM => array (0, 1, 2, 3, 4, )
     );
 
     /**
@@ -160,11 +163,13 @@ abstract class BaseImportedPodcastPeer
             $criteria->addSelectColumn(ImportedPodcastPeer::ID);
             $criteria->addSelectColumn(ImportedPodcastPeer::AUTO_INGEST);
             $criteria->addSelectColumn(ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP);
+            $criteria->addSelectColumn(ImportedPodcastPeer::ALBUM_OVERRIDE);
             $criteria->addSelectColumn(ImportedPodcastPeer::PODCAST_ID);
         } else {
             $criteria->addSelectColumn($alias . '.id');
             $criteria->addSelectColumn($alias . '.auto_ingest');
             $criteria->addSelectColumn($alias . '.auto_ingest_timestamp');
+            $criteria->addSelectColumn($alias . '.album_override');
             $criteria->addSelectColumn($alias . '.podcast_id');
         }
     }

--- a/airtime_mvc/application/models/airtime/om/BaseImportedPodcastQuery.php
+++ b/airtime_mvc/application/models/airtime/om/BaseImportedPodcastQuery.php
@@ -9,11 +9,13 @@
  * @method ImportedPodcastQuery orderByDbId($order = Criteria::ASC) Order by the id column
  * @method ImportedPodcastQuery orderByDbAutoIngest($order = Criteria::ASC) Order by the auto_ingest column
  * @method ImportedPodcastQuery orderByDbAutoIngestTimestamp($order = Criteria::ASC) Order by the auto_ingest_timestamp column
+ * @method ImportedPodcastQuery orderByDbAlbumOverride($order = Criteria::ASC) Order by the album_override column
  * @method ImportedPodcastQuery orderByDbPodcastId($order = Criteria::ASC) Order by the podcast_id column
  *
  * @method ImportedPodcastQuery groupByDbId() Group by the id column
  * @method ImportedPodcastQuery groupByDbAutoIngest() Group by the auto_ingest column
  * @method ImportedPodcastQuery groupByDbAutoIngestTimestamp() Group by the auto_ingest_timestamp column
+ * @method ImportedPodcastQuery groupByDbAlbumOverride() Group by the album_override column
  * @method ImportedPodcastQuery groupByDbPodcastId() Group by the podcast_id column
  *
  * @method ImportedPodcastQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
@@ -29,11 +31,13 @@
  *
  * @method ImportedPodcast findOneByDbAutoIngest(boolean $auto_ingest) Return the first ImportedPodcast filtered by the auto_ingest column
  * @method ImportedPodcast findOneByDbAutoIngestTimestamp(string $auto_ingest_timestamp) Return the first ImportedPodcast filtered by the auto_ingest_timestamp column
+ * @method ImportedPodcast findOneByDbAlbumOverride(boolean $album_override) Return the first ImportedPodcast filtered by the album_override column
  * @method ImportedPodcast findOneByDbPodcastId(int $podcast_id) Return the first ImportedPodcast filtered by the podcast_id column
  *
  * @method array findByDbId(int $id) Return ImportedPodcast objects filtered by the id column
  * @method array findByDbAutoIngest(boolean $auto_ingest) Return ImportedPodcast objects filtered by the auto_ingest column
  * @method array findByDbAutoIngestTimestamp(string $auto_ingest_timestamp) Return ImportedPodcast objects filtered by the auto_ingest_timestamp column
+ * @method array findByDbAlbumOverride(boolean $album_override) Return ImportedPodcast objects filtered by the album_override column
  * @method array findByDbPodcastId(int $podcast_id) Return ImportedPodcast objects filtered by the podcast_id column
  *
  * @package    propel.generator.airtime.om
@@ -142,7 +146,7 @@ abstract class BaseImportedPodcastQuery extends ModelCriteria
      */
     protected function findPkSimple($key, $con)
     {
-        $sql = 'SELECT "id", "auto_ingest", "auto_ingest_timestamp", "podcast_id" FROM "imported_podcast" WHERE "id" = :p0';
+        $sql = 'SELECT "id", "auto_ingest", "auto_ingest_timestamp", "album_override", "podcast_id" FROM "imported_podcast" WHERE "id" = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -341,6 +345,33 @@ abstract class BaseImportedPodcastQuery extends ModelCriteria
         }
 
         return $this->addUsingAlias(ImportedPodcastPeer::AUTO_INGEST_TIMESTAMP, $dbAutoIngestTimestamp, $comparison);
+    }
+
+    /**
+     * Filter the query on the album_override column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByDbAlbumOverride(true); // WHERE album_override = true
+     * $query->filterByDbAlbumOverride('yes'); // WHERE album_override = true
+     * </code>
+     *
+     * @param     boolean|string $dbAlbumOverride The value to use as filter.
+     *              Non-boolean arguments are converted using the following rules:
+     *                * 1, '1', 'true',  'on',  and 'yes' are converted to boolean true
+     *                * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
+     *              Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
+     * @param     string $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return ImportedPodcastQuery The current query, for fluid interface
+     */
+    public function filterByDbAlbumOverride($dbAlbumOverride = null, $comparison = null)
+    {
+        if (is_string($dbAlbumOverride)) {
+            $dbAlbumOverride = in_array(strtolower($dbAlbumOverride), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
+        }
+
+        return $this->addUsingAlias(ImportedPodcastPeer::ALBUM_OVERRIDE, $dbAlbumOverride, $comparison);
     }
 
     /**

--- a/airtime_mvc/application/models/airtime/om/BaseThirdPartyTrackReferences.php
+++ b/airtime_mvc/application/models/airtime/om/BaseThirdPartyTrackReferences.php
@@ -49,6 +49,7 @@ abstract class BaseThirdPartyTrackReferences extends BaseObject implements Persi
 
     /**
      * The value for the file_id field.
+     * Note: this column has a database default value of: 0
      * @var        int
      */
     protected $file_id;
@@ -101,6 +102,27 @@ abstract class BaseThirdPartyTrackReferences extends BaseObject implements Persi
      * @var		PropelObjectCollection
      */
     protected $celeryTaskssScheduledForDeletion = null;
+
+    /**
+     * Applies default values to this object.
+     * This method should be called from the object's constructor (or
+     * equivalent initialization method).
+     * @see        __construct()
+     */
+    public function applyDefaultValues()
+    {
+        $this->file_id = 0;
+    }
+
+    /**
+     * Initializes internal state of BaseThirdPartyTrackReferences object.
+     * @see        applyDefaults()
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->applyDefaultValues();
+    }
 
     /**
      * Get the [id] column value.
@@ -334,6 +356,10 @@ abstract class BaseThirdPartyTrackReferences extends BaseObject implements Persi
      */
     public function hasOnlyDefaultValues()
     {
+            if ($this->file_id !== 0) {
+                return false;
+            }
+
         // otherwise, everything was equal, so return true
         return true;
     } // hasOnlyDefaultValues()
@@ -1129,7 +1155,7 @@ abstract class BaseThirdPartyTrackReferences extends BaseObject implements Persi
     public function setCcFiles(CcFiles $v = null)
     {
         if ($v === null) {
-            $this->setDbFileId(NULL);
+            $this->setDbFileId(0);
         } else {
             $this->setDbFileId($v->getDbId());
         }
@@ -1427,6 +1453,7 @@ abstract class BaseThirdPartyTrackReferences extends BaseObject implements Persi
         $this->alreadyInValidation = false;
         $this->alreadyInClearAllReferencesDeep = false;
         $this->clearAllReferences();
+        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);

--- a/airtime_mvc/application/services/PodcastEpisodeService.php
+++ b/airtime_mvc/application/services/PodcastEpisodeService.php
@@ -87,7 +87,7 @@ class Application_Service_PodcastEpisodeService extends Application_Service_Thir
     public function addPlaceholder($podcastId, $episode) {
         $existingEpisode = PodcastEpisodesQuery::create()->findOneByDbEpisodeGuid($episode["guid"]);
         if (!empty($existingEpisode)) {
-            throw new DuplicatePodcastEpisodeException("Episode already exists: \n" . var_export($episode, true));
+            throw new DuplicatePodcastEpisodeException(sprintf("Episode already exists for podcast: %s, guid: %s\n", $episode['podcast_id'], $episode['guid']));
         }
         // We need to check whether the array is parsed directly from the SimplePie
         // feed object, or whether it's passed in as json

--- a/airtime_mvc/application/upgrade/Upgrades.php
+++ b/airtime_mvc/application/upgrade/Upgrades.php
@@ -506,3 +506,16 @@ class AirtimeUpgrader300alpha extends AirtimeUpgrader
         return '3.0.0-alpha';
     }
 }
+
+class AirtimeUpgrader300alpha1 extends AirtimeUpgrader
+{
+    protected function getSupportedSchemaVersions() {
+        return array(
+            '3.0.0-alpha'
+        );
+    }
+
+    public function getNewVersion() {
+        return '3.0.0-alpha.1';
+    }
+}

--- a/airtime_mvc/application/views/scripts/podcast/podcast.phtml
+++ b/airtime_mvc/application/views/scripts/podcast/podcast.phtml
@@ -17,9 +17,14 @@
                     <span class="podcast-metadata-field">{{podcast.url}}</span>
                 </a>
             </div>
-
-            <label for="podcast_auto_ingest"><?php echo _("Automatically download latest episodes?") ?></label>
-            <input name="podcast_auto_ingest" ng-model="podcast.auto_ingest" type="checkbox"/>
+            <div>
+                <label for="podcast_auto_ingest"><input name="podcast_auto_ingest" ng-model="podcast.auto_ingest" type="checkbox" class="no-float"/></label>
+                <span class="podcast-metadata-field"><?php echo _("Automatically download latest episodes?") ?></span>
+            </div>
+            <div>
+                <label for="podcast_album_override"><input name="podcast_album_override" ng-model="podcast.album_override" type="checkbox" class="no-float"/></label>
+                <span class="podcast-metadata-field"><?php echo _("Override album name with podcast name during ingest."); ?></span>
+            </div>
         </form>
     </div>
 

--- a/airtime_mvc/application/views/scripts/podcast/podcast.phtml
+++ b/airtime_mvc/application/views/scripts/podcast/podcast.phtml
@@ -17,11 +17,11 @@
                     <span class="podcast-metadata-field">{{podcast.url}}</span>
                 </a>
             </div>
-            <div>
+            <div style="padding-top: 0.1em;">
                 <label for="podcast_auto_ingest"><input name="podcast_auto_ingest" ng-model="podcast.auto_ingest" type="checkbox" class="no-float"/></label>
                 <span class="podcast-metadata-field"><?php echo _("Automatically download latest episodes?") ?></span>
             </div>
-            <div>
+            <div style="padding-top: 0.1em;">
                 <label for="podcast_album_override"><input name="podcast_album_override" ng-model="podcast.album_override" type="checkbox" class="no-float"/></label>
                 <span class="podcast-metadata-field"><?php echo _("Override album name with podcast name during ingest."); ?></span>
             </div>

--- a/airtime_mvc/application/views/scripts/podcast/podcast.phtml
+++ b/airtime_mvc/application/views/scripts/podcast/podcast.phtml
@@ -18,7 +18,7 @@
                 </a>
             </div>
             <div style="padding-top: 0.1em;">
-                <label for="podcast_auto_ingest"><input name="podcast_auto_ingest" ng-model="podcast.auto_ingest" type="checkbox" class="no-float"/></label>
+                <label for="podcast_auto_ingest"><input name="podcast_auto_ingest" ng-model="podcast.auto_ingest" type="checkbox" class="float-right"/></label>
                 <span class="podcast-metadata-field"><?php echo _("Automatically download latest episodes?") ?></span>
             </div>
             <div style="padding-top: 0.1em;">

--- a/airtime_mvc/build/schema.xml
+++ b/airtime_mvc/build/schema.xml
@@ -543,7 +543,7 @@
     <column name="service" phpName="DbService" type="VARCHAR" size="256" required="true" />
     <!-- Make foreign ID a VARCHAR field in case a service uses hashes or other non-integer identifiers -->
     <column name="foreign_id" phpName="DbForeignId" type="VARCHAR" size="256" />
-    <column name="file_id" phpName="DbFileId" type="INTEGER" required="true" />
+    <column name="file_id" phpName="DbFileId" type="INTEGER" required="true" default="0" />
     <column name="upload_time" phpName="DbUploadTime" type="TIMESTAMP" />
     <column name="status" phpName="DbStatus" type="VARCHAR" size="256" />
     <unique name="foreign_id_unique">

--- a/airtime_mvc/build/schema.xml
+++ b/airtime_mvc/build/schema.xml
@@ -605,6 +605,7 @@
     <column name="id" phpName="DbId" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
     <column name="auto_ingest" phpName="DbAutoIngest" type="BOOLEAN"  required="true" defaultValue="false"/>
     <column name="auto_ingest_timestamp" phpName="DbAutoIngestTimestamp" type="TIMESTAMP" required="false" />
+    <column name="album_override" phpName="DbAlbumOverride" type="BOOLEAN" required="true" defaultValue="false"/>
     <column name="podcast_id" phpName="DbPodcastId" required="true" type="INTEGER"/>
     <foreign-key foreignTable="podcast" name="podcast_id_fkey" onDelete="CASCADE">
       <reference local="podcast_id" foreign="id" />

--- a/airtime_mvc/build/sql/schema.sql
+++ b/airtime_mvc/build/sql/schema.sql
@@ -685,7 +685,7 @@ CREATE TABLE "third_party_track_references"
     "id" serial NOT NULL,
     "service" VARCHAR(256) NOT NULL,
     "foreign_id" VARCHAR(256),
-    "file_id" INTEGER NOT NULL,
+    "file_id" INTEGER DEFAULT 0 NOT NULL,
     "upload_time" TIMESTAMP,
     "status" VARCHAR(256),
     PRIMARY KEY ("id"),

--- a/airtime_mvc/build/sql/schema.sql
+++ b/airtime_mvc/build/sql/schema.sql
@@ -760,6 +760,7 @@ CREATE TABLE "imported_podcast"
     "id" serial NOT NULL,
     "auto_ingest" BOOLEAN DEFAULT 'f' NOT NULL,
     "auto_ingest_timestamp" TIMESTAMP,
+    "album_override" BOOLEAN DEFAULT 'f' NOT NULL,
     "podcast_id" INTEGER NOT NULL,
     PRIMARY KEY ("id")
 );

--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -4145,6 +4145,12 @@ li .ui-state-hover {
     margin: 8px 0 0;
 }
 
+.podcast-metadata input[type="checkbox"].float-right {
+    float:right;
+    margin: 8px 0 0;
+
+}
+
 .podcast-metadata label,
 .media-metadata label {
     display: block;

--- a/airtime_mvc/public/css/styles.css
+++ b/airtime_mvc/public/css/styles.css
@@ -4140,6 +4140,11 @@ li .ui-state-hover {
     margin: 8px 0 0;
 }
 
+.podcast-metadata input[type="checkbox"].no-float {
+    float: none;
+    margin: 8px 0 0;
+}
+
 .podcast-metadata label,
 .media-metadata label {
     display: block;


### PR DESCRIPTION
This allows you to override the album name in a downloaded podcast at the per podcast level. The global option takes precedence to it so it can only activate overriding if that is disabled. I should probably change that to it only being used as the default for new podcasts. Let me know what you think.

It also has the fix for getting a green checkmark after downloads have processed.

<img width="599" alt="screen shot 2017-03-18 at 11 41 19" src="https://cloud.githubusercontent.com/assets/116588/24071351/dca78f8c-0bcf-11e7-8324-0eb255ed82cf.png">

Setting it results in

<img width="722" alt="screen shot 2017-03-18 at 11 51 14" src="https://cloud.githubusercontent.com/assets/116588/24071409/3cff1020-0bd1-11e7-8b4c-d6d263d4fb67.png">

vs.

<img width="727" alt="screen shot 2017-03-18 at 11 51 07" src="https://cloud.githubusercontent.com/assets/116588/24071411/4a363c8c-0bd1-11e7-95f6-f55f906bd402.png">

Fixed #92 