### PR TITLE
Restart services always with systemd

### DIFF
--- a/installer/systemd/airtime-celery.service
+++ b/installer/systemd/airtime-celery.service
@@ -8,6 +8,7 @@ Group=celery
 Environment=RMQ_CONFIG_FILE=/etc/airtime/airtime.conf
 WorkingDirectory=/srv/airtime
 ExecStart=/bin/celery worker -A airtime-celery.tasks:celery --time-limit=300 --concurrency=1 --config=celeryconfig -l INFO
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/installer/systemd/airtime-liquidsoap.service
+++ b/installer/systemd/airtime-liquidsoap.service
@@ -5,6 +5,7 @@ Description=Airtime Liquidsoap Service
 ExecStart=/usr/bin/airtime-liquidsoap
 User=libretime-playout
 Group=libretime-playout
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/installer/systemd/airtime-playout.service
+++ b/installer/systemd/airtime-playout.service
@@ -5,6 +5,7 @@ Description=Airtime Playout Service
 ExecStart=/usr/bin/airtime-playout
 User=libretime-pypo
 Group=libretime-pypo
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/installer/systemd/airtime_analyzer.service
+++ b/installer/systemd/airtime_analyzer.service
@@ -5,6 +5,7 @@ Description=LibreTime Media Analyzer Service
 ExecStart=/usr/bin/airtime_analyzer
 User=airtime-analyzer
 Group=airtime-analyzer
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This essentially results in the same behaviour legacy upstream was exploiting in upstart. Normally I would argue that depending on such a feature as part of an applications runtime feature-set is bad. This applies, but until we can get that sorted at another level this makes everything work as intended when running through systemd.