### PR TITLE
General fixes for TLS

### DIFF
--- a/airtime_mvc/application/models/StoredFile.php
+++ b/airtime_mvc/application/models/StoredFile.php
@@ -510,6 +510,10 @@ SQL;
     	$serverPort = $_SERVER['SERVER_PORT'];
     	$subDir = $CC_CONFIG['baseDir'];
 
+        if ($protocol === 'https' && $serverPort == 80) {
+            $serverPort = 443;
+        }
+
     	if ($subDir[0] === "/") {
     		$subDir = substr($subDir, 1, strlen($subDir) - 1);
     	}

--- a/python_apps/api_clients/api_clients/api_client.py
+++ b/python_apps/api_clients/api_clients/api_client.py
@@ -186,8 +186,9 @@ class RequestProvider(object):
         self.requests = {}
         if self.config["general"]["base_dir"].startswith("/"):
             self.config["general"]["base_dir"] = self.config["general"]["base_dir"][1:]
-        self.url = ApcUrl("http://%s:%s/%s%s/%s" \
-            % (self.config["general"]["base_url"], str(self.config["general"]["base_port"]),
+        self.url = ApcUrl("%s://%s:%s/%s%s/%s" \
+            % (str(("https", "http")[self.config["general"]["base_port"] == 443]),
+               self.config["general"]["base_url"], str(self.config["general"]["base_port"]),
                self.config["general"]["base_dir"], self.config["api_base"],
                '%%action%%'))
         # Now we must discover the possible actions
@@ -323,8 +324,9 @@ class AirtimeApiClient(object):
         # TODO : Make other methods in this class use this this method.
         if self.config["general"]["base_dir"].startswith("/"):
             self.config["general"]["base_dir"] = self.config["general"]["base_dir"][1:]
-        url = "http://%s:%s/%s%s/%s" %  \
-            (self.config["general"]["base_url"], str(self.config["general"]["base_port"]),
+        url = "%s://%s:%s/%s%s/%s" %  \
+            (str(("https", "http")[self.config["general"]["base_port"] == 443]),
+             self.config["general"]["base_url"], str(self.config["general"]["base_port"]),
              self.config["general"]["base_dir"], self.config["api_base"],
              self.config[config_action_key])
         url = url.replace("%%api_key%%", self.config["general"]["api_key"])


### PR DESCRIPTION
This is an old one from my legacy upstream fork and takes care of allowing the api client to access files from the library through tls if the tls listener is on port 443.

It also has a fix for the API where it would build a `https://<hostname>:80` url instead of `https://<hostname>:443`. A more serious fix would probably make the URL configurable on not depend on `$_SERVER` as much, but this works.

For it to also work we would need to make the protocol fully configurable. At least with this things won't completely fail if you switch the install to 443 and close off 80.