### PR TITLE
Create release tarball using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
 - ./travis/php.sh
 - ./travis/python.sh
 deploy:
-  provider: pages
+- provider: pages
   skip_cleanup: true
   local_dir: build/docs
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
@@ -82,4 +82,18 @@ deploy:
   name: R. LibreTime DocBot
   on:
     branch: master
+    condition: $PYTHON = true
+- provider: script
+  skip_cleanup: true
+  script: travis/release.sh
+  on:
+    tags: true
+    condition: $PYTHON = true
+- provider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  file_glob: true
+  file: build/libretime-*.tar.gz
+  on:
+    tags: true
     condition: $PYTHON = true

--- a/dev_tools/release/release.sh
+++ b/dev_tools/release/release.sh
@@ -26,12 +26,10 @@ fi
 dir=$(dirname $(readlink -f $0))
 gitrepo=$(readlink -f ./../../)
 
-echo ${gitrepo}
-
 echo "Creating tarball for LibreTime ${suffix}."
 
 target=/tmp/libretime-${suffix}
-target_file=/tmp/libretime-${suffix}.tar.gz
+target_file=${gitrepo}/build/libretime-${suffix}.tar.gz
 
 rm -rf $target
 rm -f $target_file
@@ -51,7 +49,7 @@ git checkout --quiet tags/${suffix}
 echo " Done"
 
 echo -n "Running composer install..."
-composer install --quiet --no-dev
+composer install --quiet --no-dev --ignore-platform-reqs
 echo " Done"
 
 popd

--- a/travis/release.sh
+++ b/travis/release.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -xe
+
+pushd dev_tools/release
+bash -e release.sh ${TRAVIS_TAG}
+popd


### PR DESCRIPTION
This should take care of automatically uploading a release tarball containing a prepoulatated `vendor/` dir as well as a pre-made `VERSION` file to [github releases](https://github.com/LibreTime/libretime/releases).

It tested it as best as I can and I hope that it works as intended on the next tag. If it doesn't I'll prepare a prompt fix. I hope we can get this working without too many tags but think we should just do releases often enough until this works fine.

Based on the same tarball (manually uploaded) from the script I have rpmbuilding pretty much ready on the code side of things, with this I can make it really automated.