### PR TITLE
Update i18n strings

### DIFF
--- a/airtime_mvc/application/forms/AddShowWhat.php
+++ b/airtime_mvc/application/forms/AddShowWhat.php
@@ -27,7 +27,7 @@ class Application_Form_AddShowWhat extends Zend_Form_SubForm
             'class'      => 'input_text',
             'required'   => true,
             'filters'    => array('StringTrim'),
-            'value'      => _('New Show'),
+            'value'      => _('Untitled Show'),
             'validators' => array($notEmptyValidator, array('StringLength', false, array(0, $maxLens['name'])))
         ));
 

--- a/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ast/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2014-01-27 10:20+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: Asturian (http://www.transifex.com/sourcefabric/airtime/language/ast/)\n"
+"Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ast\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/az/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Azerbaijani (http://www.transifex.com/sourcefabric/airtime/language/az/)\n"
+"Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: az\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/az/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/az/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/cs_CZ/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Iva Heilova <iva.heilova@sourcefabric.org>, 2015
 # Sourcefabric <contact@sourcefabric.org>, 2013
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Czech (Czech Republic) (http://www.transifex.com/sourcefabric/airtime/language/cs_CZ/)\n"
+"Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: cs_CZ\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Soubor s nahrávkou neexistuje"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Rok %s musí být v rozmezí 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Zobrazit nahraný soubor metadat"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s - %s - %s není platné datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s : %s : %s není platný čas"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Upravit"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Upravit vysílání"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Smazat"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Přístup odepřen"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Nelze přetáhnout opakujícící se vysílání"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Nelze přesunout vysílání z minulosti"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Nelze přesunout vysílání do minulosti"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Nelze nastavit překrývající se vysílání."
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Nelze přesunout nahrané vysílání méně než 1 hodinu před tím, než bude znovu vysíláno."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Vysílání bylo vymazáno, protože nahrané vysílání neexistuje!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Musíte počkat 1 hodinu před dalším vysíláním."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Název"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Tvůrce"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Délka"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Žánr"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Nálada"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Označení "
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Skladatel"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Autorská práva"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Rok "
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Stopa"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Jazyk"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Čas začátku"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Čas konce"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Přehráno"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalendář"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Uživatelé"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streamy"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Stav"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Historie odvysílaného"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Historie nastavení"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Statistiky poslechovost"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Nápověda"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Začínáme"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Návod k obsluze"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Nemáte udělen přístup k tomuto zdroji."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Nemáte udělen přístup k tomuto zdroji. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr "Soubor neexistuje v %s"
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Špatný požadavek. Žádný 'mode' parametr neprošel."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Špatný požadavek. 'Mode' parametr je neplatný."
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Nemáte oprávnění k odpojení zdroje."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Neexistuje zdroj připojený k tomuto vstupu."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Nemáte oprávnění ke změně zdroje."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nenalezen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Něco je špatně."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Náhled"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Přidat do Playlistu"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Přidat do chytrého bloku"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Upravit metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Smazat"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Stáhnout"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplikátní Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Žádná akce není k dispozici"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Nemáte oprávnění odstranit vybrané položky."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopie %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Webstream bez názvu"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream uložen."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Neplatná forma hodnot."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Zkontrolujte prosím zda je správné administrátorské jméno/heslo v Systému->Streamovací stránka."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Uživatel byl úspěšně přidán!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio přehrávač"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Uživatel byl úspěšně aktualizován!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Nastavení úspěšně aktualizováno!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Nahrávání:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Mastr stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nic není naplánované"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Stávající vysílání:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Stávající"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Používáte nejnovější verzi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nová verze k dispozici: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Tato verze bude brzy zastaralá."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Tato verze již není podporována."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Prosím aktualizujte na "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Přidat do aktuálního playlistu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Přidat do aktuálního chytrého bloku"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Přidat 1 položku"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Přidat %s položek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Můžete přidat skladby pouze do chytrých bloků."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Můžete přidat pouze skladby, chytré bloky a webstreamy do playlistů."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Prosím vyberte si pozici kurzoru na časové ose."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Upravit metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Přidat k vybranému vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Vyberte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Vyberte tuto stránku"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Zrušte označení této stránky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Zrušte zaškrtnutí všech"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Jste si jisti, že chcete smazat vybranou položku(y)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Naplánováno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Název"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Tvůrce"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Rychlost přenosu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Skladatel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Autorská práva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Zakódováno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Žánr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Označení "
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Jazyk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Naposledy změněno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Naposledy vysíláno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Délka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Nálada"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Vlastník"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Opakovat Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Vzorkovací rychlost"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Číslo stopy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Nahráno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Internetové stránky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Rok "
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Nahrávání ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Vše"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Soubory"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlisty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Chytré bloky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Webové streamy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Neznámý typ: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Jste si jisti, že chcete smazat vybranou položku?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Probíhá nahrávání..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Získávání dat ze serveru..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Soundcloud id tohoto souboru je: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Došlo k chybě při nahrávání do SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Chybný kód: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Chyba msg: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Vstup musí být kladné číslo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Vstup musí být číslo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Vstup musí být ve formátu: rrrr-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Vstup musí být ve formátu: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Právě nahráváte soubory. %sPřechodem na jinou obrazovku zrušíte nahrávací proces. %sOpravdu chcete opustit tuto stránku?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Otevřít Media Builder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "prosím nastavte čas '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Váš prohlížeč nepodporuje přehrávání souborů tohoto typu: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dynamický blok není možno ukázat předem"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Omezeno na: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist uložen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlist zamíchán"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime si není jistý statusem souboru. To se může stát, když je soubor na vzdálené jednotce, která je nepřístupná nebo když je soubor v adresáři, který již není 'sledovaný'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Počítat posluchače %s : %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Připomenout za 1 týden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Nikdy nepřipomínat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Ano, pomoc Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Obrázek musí být buď jpg, jpeg, png nebo gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Statický chytrý blok uloží kritéria a vygeneruje obsah bloku okamžitě. To vám umožní upravit a zobrazit je v knihovně před přidáním do vysílání."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Dynamický chytrý blok bude ukládat pouze kritéria. Obsah bloku bude generován během přidání do vysílání. Nebudete moci prohlížet a upravovat obsah v knihovně."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Požadované délky bloku nebude dosaženo pokud Airtime nenalezne dostatek unikátních skladeb, které odpovídají vašim kritériím. Povolte tuto možnost, pokud chcete, aby byly skladby přidány do chytrého bloku vícekrát."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Chytré bloky promíchány"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Chytrý blok generován a kritéria uložena"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Chytrý blok uložen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Zpracovává se..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Vyberte modifikátor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "obsahuje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "neobsahuje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "je"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "není"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "začíná s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "končí s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "je větší než"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "je menší než"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "se pohybuje v rozmezí"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Vyberte složku k uložení"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Vyberte složku ke sledování"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Jste si jisti, že chcete změnit složku úložiště ?\n"
+"Tímto odstraníte soubry z vaší Airtime knihovny!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Správa složek médií"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Jste si jisti, že chcete odstranit sledovanou složku?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Tato cesta není v současné době dostupná."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Některé typy streamů vyžadují zvláštní konfiguraci. Detaily o přístupu %sAAC+ Support%s nebo %sOpus Support%s jsou poskytovány."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Připojeno k streamovacímu serveru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Stream je vypnut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Získávání informací ze serveru..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Nelze se připojit k streamovacímu serveru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Pokud je Airtime za routerem nebo firewall, budete možná muset nastavit přesměrování portu a tato informace pole budou nesprávná. V tomto případě budete muset ručně aktualizovat pole tak, aby ukazovalo správně host/port/mount, do kterých se Váš DJ potřebuje připojit. Povolené rozpětí je mezi 1024 a 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Pro více informací si prosím přečtěte %s Airtime manuál %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Zaškrtněte tuto volbu pro zapnutí metadat OGG streamů (metadata streamu jsou název sklady, umělec a název vysílání, které se zobrazí v audio přehrávači). VLC a mpřehrávač mají vážné chyby při přehrávání OGG/VORBIS streamu, který má povolené metadata informace: budou odpojena od streamu po každé písni. Pokud používáte stream OGG a vaši posluchači nevyžadují podporu těchto audio přehrávačů, pak neváhejte a tuto možnost povolte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Zaškrtněte toto políčko pro automatické vypnutí zdroje Master/Vysílání na odpojení zdroje."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Zaškrtněte toto políčko pro automatické zapnutí Master/Vysílání zdroj na připojení zdroje."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Pokud váš Icecast server očekává uživatelské jméno 'zdroj', může toto pole zůstat prázdné."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Pokud váš live streaming klient nepožádá o uživatelské jméno, toto pople bz mělo být 'zdroj'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Toto je administrátorské jméno a heslo pro Icecast / SHOUTcast k získání statistik poslechovosti."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Upozornění: Nelze změnit toto pole v průběhu vysílání programu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Žádný výsledek nenalezen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Toto následuje stejný bezpečnostní vzor pro výsílání: pouze uživatelé přiřazení k vysílání se mohou připojit."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Zadejte vlastní ověření, které bude fungovat pouze pro toto vysílání."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Ukázka vysílání již neexistuje!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Varování: Vysílání nemohou být znovu linkována."
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Propojením vašich opakujících se show, jakákoliv média zařazena v jakékoliv opakující se show bude také zařazena do dalších opakujících se show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Časové pásmo je nastaveno v časovém pásmu stanice defoltně. Show v kalendáři bude zobrazena v lokálním čase nastaveném časovým pásmem vašeho uživatelského rozhraní ve vašem uživatelském nastavení. "
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Vysílání je prázdné"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Získávání dat ze serveru ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Toto vysílání nemá naplánovaný obsah."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Toto vysílání není zcela vyplněno."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Leden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Únor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Březen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Duben"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Květen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Červen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Červenec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Srpen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Září"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Říjen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Listopad"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Prosinec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Leden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Únor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Březen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Duben"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Červen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Červenec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Srpen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Září"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Říjen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Listopad"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Prosinec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Neděle"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Pondělí"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Úterý"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Středa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Čtvrtek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Pátek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Sobota"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Ne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Út"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "St"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Čt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Pá"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "So"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Vysílání delší než naplánovaný čas bude ukončeno začátkem dalšího vysílání."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Zrušit aktuální vysílání?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Zastavit nahrávání aktuálního vysílání?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "OK"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Obsah vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Odstranit veškerý obsah?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Odstranit vybranou položku(y)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Začátek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Konec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Trvání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Pozvolné zesilování "
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Pozvolné zeslabování"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Vysílání prázdné"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Nahrávání z Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Náhled stopy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Nelze naplánovat mimo vysílání."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Posunutí 1 položky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Posunutí %s položek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Uložit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Prvky Waveform jsou k dispozici v prohlížeči podporující Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Vybrat vše"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Nic nevybrat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Odebrat vybrané naplánované položky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Přejít na aktuálně přehrávanou skladbu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Zrušit aktuální vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Otevřít knihovnu pro přidání nebo odebrání obsahu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Přidat / Odebrat obsah"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "používá se"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Podívat se"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Otevřít"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrátor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Program manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Host"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Hosté mohou dělat následující:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Zobrazit plán"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Zobrazit obsah vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJ může dělat následující:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Spravovat přidělený obsah vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Import media souborů"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Vytvořit playlisty, smart bloky a webstreamy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Spravovat obsah vlastní knihovny"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Progam Manažeři může dělat následující:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Zobrazit a spravovat obsah vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Plán ukazuje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Spravovat celý obsah knihovny"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Správci mohou provést následující:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Správa předvoleb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Správa uživatelů"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Správa sledovaných složek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Odeslat zpětnou vazbu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Zobrazit stav systému"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Přístup playout historii"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Zobrazit posluchače statistiky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Zobrazit / skrýt sloupce"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Z {z} do {do}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "rrrr-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Ne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Út"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "St"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Čt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Pá"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "So"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Zavřít"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hodina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Hotovo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Vyberte soubory"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Přidejte soubory do fronty pro nahrávání a klikněte na tlačítko start."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Přidat soubory."
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Zastavit Nahrávání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Začít nahrávat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Přidat soubory"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Nahráno %d / %d souborů"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "Nedostupné"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Soubory přetáhněte zde."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Chybná přípona souboru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Chybná velikost souboru."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Chybný součet souborů."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Chyba Init."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Chyba HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Chyba zabezpečení."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Obecná chyba. "
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "CHyba IO."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Soubor: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d souborů ve frontě"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Soubor: %f , velikost: %s , max. velikost souboru:% m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Přidané URL může být špatné nebo neexistuje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Chyba: Soubor je příliš velký: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Chyba: Neplatná přípona souboru: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Nastavit jako default"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Vytvořit vstup"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Editovat historii nahrávky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Žádné vysílání"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Kopírovat %s řádků %s do schránky"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%s náhled tisku %s k vytištění této tabulky použijte funkci tisku ve vašem prohlížeči. Po dokončení stiskněte escape."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-mail se nepodařilo odeslat. Zkontrolujte nastavení poštovního serveru a ujistěte se, že byl správně nakonfigurován."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Zadali jste chybně uživatelské jméno nebo heslo. Prosím, zkuste zadat znovu."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "Nemáte oprávnění odstranit vybrané %s (s)."
 msgid "You can only add tracks to smart block."
 msgstr "Můžete pouze přidat skladby do chytrého bloku."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Můžete přidat pouze skladby, chytré bloky a webstreamy do playlistů."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Playlist bez názvu"
@@ -384,2627 +2414,88 @@ msgstr "Playlist bez názvu"
 msgid "Untitled Smart Block"
 msgstr "Chytrý block bez názvu"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Neznámý Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Nemáte udělen přístup k tomuto zdroji."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preference aktualizovány."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Podpora nastavení aktualizována."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Technická podpora"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Nastavení streamu aktualizováno."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "cesta by měla být specifikována"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problém s Liquidsoap ..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Nemáte oprávnění k odpojení zdroje."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Neexistuje zdroj připojený k tomuto vstupu."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Nemáte oprávnění ke změně zdroje."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Zadali jste chybně uživatelské jméno nebo heslo. Prosím, zkuste zadat znovu."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-mail se nepodařilo odeslat. Zkontrolujte nastavení poštovního serveru a ujistěte se, že byl správně nakonfigurován."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Nemáte udělen přístup k tomuto zdroji. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr "Soubor neexistuje v %s"
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Špatný požadavek. Žádný 'mode' parametr neprošel."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Špatný požadavek. 'Mode' parametr je neplatný."
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio přehrávač"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Nahrávání:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Mastr stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nic není naplánované"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Stávající vysílání:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Stávající"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Používáte nejnovější verzi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nová verze k dispozici: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Tato verze bude brzy zastaralá."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Tato verze již není podporována."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Prosím aktualizujte na "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Přidat do aktuálního playlistu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Přidat do aktuálního chytrého bloku"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Přidat 1 položku"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Přidat %s položek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Můžete přidat skladby pouze do chytrých bloků."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Prosím vyberte si pozici kurzoru na časové ose."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Přidat k vybranému vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Vyberte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Vyberte tuto stránku"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Zrušte označení této stránky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Zrušte zaškrtnutí všech"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Jste si jisti, že chcete smazat vybranou položku(y)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Naplánováno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Rychlost přenosu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Zakódováno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Naposledy změněno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Naposledy vysíláno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Vlastník"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Opakovat Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Vzorkovací rychlost"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Číslo stopy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Nahráno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Internetové stránky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Nahrávání ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Vše"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Soubory"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlisty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Chytré bloky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Webové streamy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Neznámý typ: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Jste si jisti, že chcete smazat vybranou položku?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Probíhá nahrávání..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Získávání dat ze serveru..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Soundcloud id tohoto souboru je: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Došlo k chybě při nahrávání do SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Chybný kód: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Chyba msg: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Vstup musí být kladné číslo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Vstup musí být číslo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Vstup musí být ve formátu: rrrr-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Vstup musí být ve formátu: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Právě nahráváte soubory. %sPřechodem na jinou obrazovku zrušíte nahrávací proces. %sOpravdu chcete opustit tuto stránku?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Otevřít Media Builder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "prosím nastavte čas '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "prosím nastavte čas v sekundách '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Váš prohlížeč nepodporuje přehrávání souborů tohoto typu: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dynamický blok není možno ukázat předem"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Omezeno na: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist uložen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlist zamíchán"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime si není jistý statusem souboru. To se může stát, když je soubor na vzdálené jednotce, která je nepřístupná nebo když je soubor v adresáři, který již není 'sledovaný'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Počítat posluchače %s : %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Připomenout za 1 týden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Nikdy nepřipomínat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Ano, pomoc Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Obrázek musí být buď jpg, jpeg, png nebo gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Statický chytrý blok uloží kritéria a vygeneruje obsah bloku okamžitě. To vám umožní upravit a zobrazit je v knihovně před přidáním do vysílání."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Dynamický chytrý blok bude ukládat pouze kritéria. Obsah bloku bude generován během přidání do vysílání. Nebudete moci prohlížet a upravovat obsah v knihovně."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Požadované délky bloku nebude dosaženo pokud Airtime nenalezne dostatek unikátních skladeb, které odpovídají vašim kritériím. Povolte tuto možnost, pokud chcete, aby byly skladby přidány do chytrého bloku vícekrát."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Chytré bloky promíchány"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Chytrý blok generován a kritéria uložena"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Chytrý blok uložen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Zpracovává se..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Vyberte modifikátor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "obsahuje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "neobsahuje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "je"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "není"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "začíná s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "končí s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "je větší než"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "je menší než"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "se pohybuje v rozmezí"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Vyberte složku k uložení"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Vyberte složku ke sledování"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Jste si jisti, že chcete změnit složku úložiště ?\nTímto odstraníte soubry z vaší Airtime knihovny!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Správa složek médií"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Jste si jisti, že chcete odstranit sledovanou složku?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Tato cesta není v současné době dostupná."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Některé typy streamů vyžadují zvláštní konfiguraci. Detaily o přístupu %sAAC+ Support%s nebo %sOpus Support%s jsou poskytovány."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Připojeno k streamovacímu serveru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Stream je vypnut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Získávání informací ze serveru..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Nelze se připojit k streamovacímu serveru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Pokud je Airtime za routerem nebo firewall, budete možná muset nastavit přesměrování portu a tato informace pole budou nesprávná. V tomto případě budete muset ručně aktualizovat pole tak, aby ukazovalo správně host/port/mount, do kterých se Váš DJ potřebuje připojit. Povolené rozpětí je mezi 1024 a 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Pro více informací si prosím přečtěte %s Airtime manuál %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Zaškrtněte tuto volbu pro zapnutí metadat OGG streamů (metadata streamu jsou název sklady, umělec a název vysílání, které se zobrazí v audio přehrávači). VLC a mpřehrávač mají vážné chyby při přehrávání OGG/VORBIS streamu, který má povolené metadata informace: budou odpojena od streamu po každé písni. Pokud používáte stream OGG a vaši posluchači nevyžadují podporu těchto audio přehrávačů, pak neváhejte a tuto možnost povolte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Zaškrtněte toto políčko pro automatické vypnutí zdroje Master/Vysílání na odpojení zdroje."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Zaškrtněte toto políčko pro automatické zapnutí Master/Vysílání zdroj na připojení zdroje."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Pokud váš Icecast server očekává uživatelské jméno 'zdroj', může toto pole zůstat prázdné."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Pokud váš live streaming klient nepožádá o uživatelské jméno, toto pople bz mělo být 'zdroj'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Toto je administrátorské jméno a heslo pro Icecast / SHOUTcast k získání statistik poslechovosti."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Upozornění: Nelze změnit toto pole v průběhu vysílání programu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Žádný výsledek nenalezen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Toto následuje stejný bezpečnostní vzor pro výsílání: pouze uživatelé přiřazení k vysílání se mohou připojit."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Zadejte vlastní ověření, které bude fungovat pouze pro toto vysílání."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Ukázka vysílání již neexistuje!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Varování: Vysílání nemohou být znovu linkována."
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Propojením vašich opakujících se show, jakákoliv média zařazena v jakékoliv opakující se show bude také zařazena do dalších opakujících se show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Časové pásmo je nastaveno v časovém pásmu stanice defoltně. Show v kalendáři bude zobrazena v lokálním čase nastaveném časovým pásmem vašeho uživatelského rozhraní ve vašem uživatelském nastavení. "
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Vysílání je prázdné"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Získávání dat ze serveru ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Toto vysílání nemá naplánovaný obsah."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Toto vysílání není zcela vyplněno."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Leden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Únor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Březen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Duben"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Květen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Červen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Červenec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Srpen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Září"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Říjen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Listopad"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Prosinec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Leden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Únor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Březen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Duben"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Červen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Červenec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Srpen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Září"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Říjen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Listopad"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Prosinec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Neděle"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Pondělí"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Úterý"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Středa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Čtvrtek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Pátek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Sobota"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Ne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Út"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "St"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Čt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Pá"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "So"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Vysílání delší než naplánovaný čas bude ukončeno začátkem dalšího vysílání."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Zrušit aktuální vysílání?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Zastavit nahrávání aktuálního vysílání?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "OK"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Obsah vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Odstranit veškerý obsah?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Odstranit vybranou položku(y)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Začátek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Konec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Trvání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Pozvolné zesilování "
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Pozvolné zeslabování"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Vysílání prázdné"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Nahrávání z Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Náhled stopy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Nelze naplánovat mimo vysílání."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Posunutí 1 položky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Posunutí %s položek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Uložit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Zrušit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Prvky Waveform jsou k dispozici v prohlížeči podporující Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Vybrat vše"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Nic nevybrat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Odebrat vybrané naplánované položky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Přejít na aktuálně přehrávanou skladbu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Zrušit aktuální vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Otevřít knihovnu pro přidání nebo odebrání obsahu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Přidat / Odebrat obsah"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "používá se"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Podívat se"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Otevřít"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrátor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Program manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Host"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Hosté mohou dělat následující:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Zobrazit plán"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Zobrazit obsah vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJ může dělat následující:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Spravovat přidělený obsah vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Import media souborů"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Vytvořit playlisty, smart bloky a webstreamy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Spravovat obsah vlastní knihovny"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Progam Manažeři může dělat následující:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Zobrazit a spravovat obsah vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Plán ukazuje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Spravovat celý obsah knihovny"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Správci mohou provést následující:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Správa předvoleb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Správa uživatelů"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Správa sledovaných složek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Odeslat zpětnou vazbu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Zobrazit stav systému"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Přístup playout historii"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Zobrazit posluchače statistiky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Zobrazit / skrýt sloupce"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Z {z} do {do}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "rrrr-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Ne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Út"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "St"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Čt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Pá"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "So"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Zavřít"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hodina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Hotovo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Vyberte soubory"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Přidejte soubory do fronty pro nahrávání a klikněte na tlačítko start."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Stav"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Přidat soubory."
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Zastavit Nahrávání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Začít nahrávat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Přidat soubory"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Nahráno %d / %d souborů"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "Nedostupné"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Soubory přetáhněte zde."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Chybná přípona souboru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Chybná velikost souboru."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Chybný součet souborů."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Chyba Init."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Chyba HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Chyba zabezpečení."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Obecná chyba. "
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "CHyba IO."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Soubor: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d souborů ve frontě"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Soubor: %f , velikost: %s , max. velikost souboru:% m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Přidané URL může být špatné nebo neexistuje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Chyba: Soubor je příliš velký: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Chyba: Neplatná přípona souboru: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Nastavit jako default"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Vytvořit vstup"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Editovat historii nahrávky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Žádné vysílání"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Kopírovat %s řádků %s do schránky"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%s náhled tisku %s k vytištění této tabulky použijte funkci tisku ve vašem prohlížeči. Po dokončení stiskněte escape."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Vybrat kurzor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Odstranit kurzor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "vysílání neexistuje"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Znovu spustit vysílaní %s od %s na %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Vybrat kurzor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Odstranit kurzor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "vysílání neexistuje"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Uživatel byl úspěšně přidán!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Uživatel byl úspěšně aktualizován!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Nastavení úspěšně aktualizováno!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Webstream bez názvu"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream uložen."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Neplatná forma hodnot."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Rok %s musí být v rozmezí 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s - %s - %s není platné datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s : %s : %s není platný čas"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Přehrát"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Zastavit"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Nastavit Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Nstavit Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Kurzor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Sdílet"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Vyberte stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "vypnout zvuk"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "zapnout zvuk"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "O aplikaci"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr "%1$s %2$s, open radio software pro plánování a řízení vzdálené stanice. "
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr "%1$s %2$s je distribuován pod %3$s"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr "Vítejte v %s!"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr "Zde můžete vidět jak začít s používáním %s pro automatizované vysílání:"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Pro podrobnější nápovědu si přečtěte %suživatelský manuál%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Historie odvysílaného"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Přehled logu"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Shrnutí souboru"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Shrnutí show"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Rozšířit statický blok"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Rozšířit dynamický blok"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Název:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Popis:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Doba trvání:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Promíchat Playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Promíchat"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Prázdný playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Vymazat"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Zesílit: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Zeslabit: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Uložit playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Neotevřený playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "UKázat Waveform"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue in: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Původní délka:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Nastavení Streamu"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Přihlásit"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr "Vítejte v %s demo! Můžete se přihlásit přes uživatelské jméno 'admin' a heslo 'admin'."
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nové heslo"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Prosím zadejte a potvrďte své nové heslo v políčkách níže."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Správa uživatelů"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nový uživatel"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Uživatelské jméno"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Jméno"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Příjmení"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Typ uživatele"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Najít vysílání"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Vybrat instanci show"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Najdi"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Opakovat dny:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Odstranit"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Přidat"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Zobrazit zdroj"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Registrovat Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr "Klikněte na box níže pro podporu vaší stanice na %s."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Požadováno)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(pouze pro ověřovací účely, nebude zveřejněno)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Poznámka: Cokoli většího než 600x600 bude zmenšeno."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Zobrazit co posílám "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Pravidla a podmínky"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Vyberte dny:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "nebo"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "a"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " do "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "soubory splňují kritéria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtrovat historii"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Za účelem podpory vaší stanice musí být povolena funkce 'Zaslat Váš názor')."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Dodatečné možnosti"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Následující informace se zobrazí u posluchačů na jejich přehrávačích:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Webová stránka vaší rádiové stanice)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL streamu: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Vyberte soubor"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Nastavit"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktuálně importovaný soubor:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr "Znovu projít sledovaný adresář (Tato funkce je užitečná, pokud je síť přeplněna a nedojde k synchronizaci s %s)"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Odebrat sledovaný adresář"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Nesledujete žádné mediální soubory."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Hlavní zdroj"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Nastavení SoundCloud "
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Přidat toto vysílání"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Aktualizace vysílání"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Co"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Kdy"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Vložení Live Streamu"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Kdo"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Styl"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Velikost disku"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Probíhá importování souboru ..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Rozšířené možnosti hledání"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Název:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Tvůrce:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Skladba:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Délka:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Vzorová frekvence:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit frekvence:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Nálada:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Žánr:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Rok:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Označení:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Skladatel:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dirigent:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Autorská práva:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC číslo"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Internetová stránka:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Jazyk:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Cesta souboru:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamický Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statický Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audio stopa"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Obsah Playlistu: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Obsah statistického Smart Blocku: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Kritéria dynamickeho Smart Blocku: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Omezit na "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Váše zkušební období vyprší "
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dny"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Předchozí:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Další:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Zdrojové Streamy"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Poslech"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Odhlásit "
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Vzory přehledu logů"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Nový vzor přehledu logů"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Vzory přehledu logů nejsou"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Vzory přehledu souboru"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Nový vzor přehledu souboru"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Nový vzor přehledu souboru"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Vytvořit soubor přehledu nastavení"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Vytvořit vzor přehledu logů"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Jméno"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Přidat elementy"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Přidat nové pole"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Nastavit defolní šablnu"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Popis"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL streamu:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Defaultní délka:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Žádný webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Nápověda"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Stránka nebyla nalezena!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Stránka, kterou hledáte, neexistuje!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "předchozí"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "přehrát"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pauza"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "další"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max. hlasitost"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Nutná aktualizace"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Chcete-li přehrávat média, budete si muset buď nastavit svůj prohlížeč na nejnovější verzi nebo aktualizovat svůj%sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Datum zahájení:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Datum zahájení:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Zadán neplatný znak "
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Datum ukončení:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Všechna má vysílání:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Hledat uživatele:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Název stanice"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Webová stránka stanice:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Stát:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Město:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Popis stanice:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo stanice:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Podpořit mou stanici na %s"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "Zaškrtnutí tohoto okénka souhlasím s  %s's %spravidly ochrany osobních údajů%s."
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Musíte souhlasit se zásadami ochrany osobních údajů."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Nahráno z Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Vysílat znovu?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Hodnota je požadována a nemůže zůstat prázdná"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%hodnota%' není platná e-mailová adresa v základním formátu local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%hodnota%' neodpovídá formátu datumu '%formátu%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%hodnota%' je kratší než požadovaných %min% znaků"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%hodnota%' je více než %max% znaků dlouhá"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%hodnota%' není mezi '%min%' a '%max%', včetně"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Hesla se neshodují"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "Čas musí být zadán"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Musíte počkat alespoň 1 hodinu před dalším vysíláním"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Obnovit heslo"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Pořad bez názvu"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC číslo:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Defoltní nastavení doby plynulého přechodu"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Přednastavení Fade In:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Přednastavení Fade Out:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Vypnuto"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Povoleno"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Časové pásmo stanice"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Týden začíná"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Uživatelské jméno:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Heslo:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Ověřit heslo:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Jméno:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Příjmení:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobilní telefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Typ uživatele:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Přihlašovací jméno není jedinečné."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Importovaná složka:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Sledované složky:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Neplatný adresář"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Výchozí licence:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Všechna práva jsou vyhrazena"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Práce je ve veřejné doméně"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons označení"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons nekomerční"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Nezasahujte do díla"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Zachovejte licenci"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons nekomerční Nezasahujte do díla"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons nekomerční Zachovejte licenci"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Časové pásmo uživatelského rozhraní"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Právě se přehrává"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Vyberte kritéria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Kvalita (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Vzorkovací frekvence (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "hodiny"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minuty"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "položka"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statický"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamický"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generovat obsah playlistu a uložit kritéria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generovat"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Promíchat obsah playlistu"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limit nemůže být prázdný nebo menší než 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limit nemůže být větší než 24 hodin"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Hodnota by měla být celé číslo"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 je max hodnota položky, kterou lze nastavit"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Musíte vybrat kritéria a modifikátor"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Délka' by měla být ve formátu '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Hodnota by měla být v časový formát (např. 0000-00-00 nebo 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Hodnota musí být číslo"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Hodnota by měla být menší než 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Hodnota by měla mít méně znaků než %s"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Hodnota nemůže být prázdná"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Metadata Icecast Vorbis"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Označení streamu:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Umělec - Název"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Vysílání - Umělec - Název"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Název stanice - Název vysílání"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Povolit Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifikátor"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Heslo"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Potvrďte nové heslo"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Potvrzené heslo neodpovídá vašemu heslu."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Povoleno:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Typ streamu:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Typ služby:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanály:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Jsou povolena pouze čísla."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Přípojný bod"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Administrátorské jméno"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Administrátorské heslo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server nemůže být prázdný."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port nemůže být prázdný."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount nemůže být prázdný s Icecast serverem."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%hodnota%' nesedí formát času 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Časová zó"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Opakovat?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Nelze vytvořit vysílání v minulosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Nelze měnit datum/čas vysílání, které bylo již spuštěno"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Datum/čas ukončení nemůže být v minulosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Nelze mít dobu trvání < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Nelze nastavit dobu trvání 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Nelze mít dobu trvání delší než 24 hodin"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "Použij  %s ověření pravosti:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Použít ověření uživatele:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Uživatelské jméno"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Uživatelské heslo"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Uživatelské jméno musí být zadáno."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Heslo musí být zadáno."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Barva pozadí:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Barva textu:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Opište znaky, které vidíte na obrázku níže."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dny"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr "den v měsíci"
 msgid "day of the week"
 msgstr "den v týdnu"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Datum ukončení:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Nekončí?"
@@ -3877,115 +2633,1174 @@ msgstr "Datum ukončení musí být po počátečním datumu"
 msgid "Please select a repeat day"
 msgstr "Prosím vyberte den opakování"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Nahráno z Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Vysílat znovu?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Barva pozadí:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Barva textu:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalendář"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Odstranit"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Uživatelé"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Název:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streamy"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Pořad bez názvu"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Žánr:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Popis:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Statistiky poslechovost"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%hodnota%' nesedí formát času 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Historie nastavení"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Doba trvání:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Časová zó"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Opakovat?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Nelze vytvořit vysílání v minulosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Nelze měnit datum/čas vysílání, které bylo již spuštěno"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Datum/čas ukončení nemůže být v minulosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Nelze mít dobu trvání < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Nelze nastavit dobu trvání 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Nelze mít dobu trvání delší než 24 hodin"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Nelze nastavit překrývající se vysílání."
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Hledat uživatele:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Uživatelské jméno:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Heslo:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Ověřit heslo:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Jméno:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Příjmení:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobilní telefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Typ uživatele:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Přihlašovací jméno není jedinečné."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Začínáme"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Návod k obsluze"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Hodnota je požadována a nemůže zůstat prázdná"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Datum zahájení:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Název:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Tvůrce:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Rok:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Označení:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Skladatel:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dirigent:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Nálada:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Autorská práva:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC číslo:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Internetová stránka:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Jazyk:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Čas začátku"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Čas konce"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Časové pásmo uživatelského rozhraní"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Název stanice"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo stanice:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Poznámka: Cokoli většího než 600x600 bude zmenšeno."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Defoltní nastavení doby plynulého přechodu"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Přednastavení Fade In:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Přednastavení Fade Out:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Vypnuto"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Povoleno"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Časové pásmo stanice"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Týden začíná"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%hodnota%' není platná e-mailová adresa v základním formátu local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%hodnota%' neodpovídá formátu datumu '%formátu%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%hodnota%' je kratší než požadovaných %min% znaků"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%hodnota%' je více než %max% znaků dlouhá"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%hodnota%' není mezi '%min%' a '%max%', včetně"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Hesla se neshodují"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Jsou povolena pouze čísla."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Přihlásit"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Opište znaky, které vidíte na obrázku níže."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Heslo"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Potvrďte nové heslo"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Potvrzené heslo neodpovídá vašemu heslu."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Uživatelské jméno"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Obnovit heslo"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Právě se přehrává"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Webová stránka stanice:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Stát:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Město:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Popis stanice:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Podpořit mou stanici na %s"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "Zaškrtnutí tohoto okénka souhlasím s  %s's %spravidly ochrany osobních údajů%s."
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Musíte souhlasit se zásadami ochrany osobních údajů."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Všechna má vysílání:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Vyberte kritéria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Kvalita (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Popis"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Vzorkovací frekvence (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "hodiny"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minuty"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "položka"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statický"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamický"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generovat obsah playlistu a uložit kritéria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generovat"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Promíchat obsah playlistu"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Promíchat"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limit nemůže být prázdný nebo menší než 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limit nemůže být větší než 24 hodin"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Hodnota by měla být celé číslo"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 je max hodnota položky, kterou lze nastavit"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Musíte vybrat kritéria a modifikátor"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Délka' by měla být ve formátu '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Hodnota by měla být v časový formát (např. 0000-00-00 nebo 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Hodnota musí být číslo"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Hodnota by měla být menší než 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Hodnota by měla mít méně znaků než %s"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Hodnota nemůže být prázdná"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Výchozí licence:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Všechna práva jsou vyhrazena"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Práce je ve veřejné doméně"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons označení"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons nekomerční"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Nezasahujte do díla"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Zachovejte licenci"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons nekomerční Nezasahujte do díla"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons nekomerční Zachovejte licenci"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Metadata Icecast Vorbis"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Označení streamu:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Umělec - Název"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Vysílání - Umělec - Název"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Název stanice - Název vysílání"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Povolit Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifikátor"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Povoleno:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Typ streamu:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit frekvence:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Typ služby:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanály:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Jméno"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Přípojný bod"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Administrátorské jméno"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Administrátorské heslo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server nemůže být prázdný."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port nemůže být prázdný."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount nemůže být prázdný s Icecast serverem."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Importovaná složka:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Sledované složky:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Neplatný adresář"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Přehrát"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Zastavit"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Nastavit Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Nstavit Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Kurzor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr "%s Heslo onboveno"
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in a cue out jsou prázné."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Nelze nastavit delší cue out než je délka souboru."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Nelze nastavit větší cue in než cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Nelze nastavit menší cue out než je cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Znovu odvysílat %s od %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Vyberte zemi"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s není platný adresář."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s je již nastaveno jako aktuální uložiště adresáře nebo ve sledovaném seznamu souborů."
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s je již nastaven jako aktuální adresář úložiště nebo v seznamu sledovaných složek."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s je již nastaven jako aktuální adresář úložiště nebo v seznam
 msgid "%s doesn't exist in the watched list."
 msgstr "%s neexistuje v seznamu sledovaných."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr "%s Heslo onboveno"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Vyberte zemi"
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Vysílání může mít max. délku 24 hodin."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Nelze naplánovat překrývající se vysílání.\nPoznámka:. Změna velikosti opakujícího se vysílání ovlivňuje všechny opakování tohoto vysílání."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Program který si prohlížíte je zastaralý!"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Program který si prohlížíte je zastaralý! "
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Nemáte povoleno plánovat vysílání %s ."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Nemůžete přidávat soubory do nahrávaného vysílání."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Vysílání %s skončilo a nemůže být nasazeno."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Vysílání %s bylo již dříve aktualizováno!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Obsah v propojených show musí být zařazen před nebo po kterémkoliv, který je vysílaný "
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr "Nelze naplánovat playlist, který obsahuje chybějící soubory."
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Vybraný soubor neexistuje!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Vysílání může mít max. délku 24 hodin."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Nelze naplánovat překrývající se vysílání.\n"
+"Poznámka:. Změna velikosti opakujícího se vysílání ovlivňuje všechny opakování tohoto vysílání."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Znovu odvysílat %s od %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1049 @@ msgstr "Neplatný webstream - tento vypadá jako stažení souboru."
 msgid "Unrecognized stream type: %s"
 msgstr "Neznámý typ streamu: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Soubor s nahrávkou neexistuje"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Zobrazit nahraný soubor metadat"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Upravit"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Upravit vysílání"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Přístup odepřen"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Nelze přetáhnout opakujícící se vysílání"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Nelze přesunout vysílání z minulosti"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Nelze přesunout vysílání do minulosti"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Nelze přesunout nahrané vysílání méně než 1 hodinu před tím, než bude znovu vysíláno."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Vysílání bylo vymazáno, protože nahrané vysílání neexistuje!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Musíte počkat 1 hodinu před dalším vysíláním."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Stopa"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Přehráno"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "předchozí"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "přehrát"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pauza"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "další"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "vypnout zvuk"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "zapnout zvuk"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max. hlasitost"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Nutná aktualizace"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Chcete-li přehrávat média, budete si muset buď nastavit svůj prohlížeč na nejnovější verzi nebo aktualizovat svůj%sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "O aplikaci"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr "%1$s %2$s, open radio software pro plánování a řízení vzdálené stanice. "
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr "%1$s %2$s je distribuován pod %3$s"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr "Vítejte v %s!"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr "Zde můžete vidět jak začít s používáním %s pro automatizované vysílání:"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Pro podrobnější nápovědu si přečtěte %suživatelský manuál%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Sdílet"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Vyberte stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Stránka nebyla nalezena!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Stránka, kterou hledáte, neexistuje!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Zobrazit zdroj"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Vyberte dny:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Přidat"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Opakovat dny:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtrovat historii"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Vybrat instanci show"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Najdi"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Nastavení SoundCloud "
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Hlavní zdroj"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Vyberte soubor"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Nastavit"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktuálně importovaný soubor:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr "Znovu projít sledovaný adresář (Tato funkce je užitečná, pokud je síť přeplněna a nedojde k synchronizaci s %s)"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Odebrat sledovaný adresář"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Nesledujete žádné mediální soubory."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Registrovat Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr "Klikněte na box níže pro podporu vaší stanice na %s."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Požadováno)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(pouze pro ověřovací účely, nebude zveřejněno)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Zobrazit co posílám "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Pravidla a podmínky"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Najít vysílání"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "nebo"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "a"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " do "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "soubory splňují kritéria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Dodatečné možnosti"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Následující informace se zobrazí u posluchačů na jejich přehrávačích:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Webová stránka vaší rádiové stanice)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL streamu: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Za účelem podpory vaší stanice musí být povolena funkce 'Zaslat Váš názor')."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Skladba:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Délka:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Vzorová frekvence:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC číslo"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Cesta souboru:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamický Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statický Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audio stopa"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Obsah Playlistu: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Obsah statistického Smart Blocku: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Kritéria dynamickeho Smart Blocku: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Omezit na "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Probíhá importování souboru ..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Rozšířené možnosti hledání"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr "Vítejte v %s demo! Můžete se přihlásit přes uživatelské jméno 'admin' a heslo 'admin'."
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nové heslo"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Prosím zadejte a potvrďte své nové heslo v políčkách níže."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Předchozí:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Další:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Zdrojové Streamy"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Poslech"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Odhlásit "
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Váše zkušební období vyprší "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Promíchat Playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Prázdný playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Vymazat"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Zeslabit: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Uložit playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Neotevřený playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "UKázat Waveform"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue in: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Původní délka:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Zesílit: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Rozšířit statický blok"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Rozšířit dynamický blok"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Přehled logu"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Shrnutí souboru"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Shrnutí show"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Vzory přehledu logů"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Nový vzor přehledu logů"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Vzory přehledu logů nejsou"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Vzory přehledu souboru"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Nový vzor přehledu souboru"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Nový vzor přehledu souboru"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Vytvořit soubor přehledu nastavení"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Vytvořit vzor přehledu logů"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Přidat elementy"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Přidat nové pole"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Nastavit defolní šablnu"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Nastavení Streamu"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Přidat toto vysílání"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Aktualizace vysílání"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Co"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Kdy"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Vložení Live Streamu"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Kdo"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Styl"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Velikost disku"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Správa uživatelů"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nový uživatel"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Jméno"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Příjmení"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Typ uživatele"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL streamu:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Defaultní délka:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Žádný webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "prosím nastavte čas v sekundách '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Obsah v propojených show musí být zařazen před nebo po kterémkoliv, který je vysílaný "

--- a/airtime_mvc/locale/cs_CZ/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/cs_CZ/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/da_DK/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Danish (Denmark) (http://www.transifex.com/sourcefabric/airtime/language/da_DK/)\n"
+"Language: da_DK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: da_DK\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_AT/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # hoerich <hoerich@gmx.at>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2013
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: German (Austria) (http://www.transifex.com/sourcefabric/airtime/language/de_AT/)\n"
+"Language: de_AT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de_AT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Aufeichnung existiert nicht"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Das Jahr %s muß innerhalb des Bereichs von 1753 - 9999 liegen."
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Metadaten der aufgezeichneten Datei ansehen"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s ist kein gültiges Datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s-%s-%s ist kein gültiger Zeitpunkt."
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Sendung bearbeiten"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Löschen"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Zugriff verweigert"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Wiederkehrende Sendungen können nicht per Drag'n'Drop verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Eine in der Vergangenheit liegende Sendung kann nicht verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Eine Sendung kann nicht in die Vergangenheit verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Sendungen können nicht überlappend geplant werden."
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Eine aufgezeichnete Sendung kann nicht verschoben werden, wenn der Zeitpunkt der Wiederholung weniger als eine Stunde bevor liegt."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Die Sendung wurde gelöscht, weil die aufgezeichnete Sendung nicht existiert."
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Titel"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Interpret"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Dauer"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Stimmung"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Komponist"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Jahr"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Titel"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Sprache"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Beginn"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Ende"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Abgespielt"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalender"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Benutzer"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout Verlauf"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Verlaufsvorlagen"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Hörerstatistiken"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Hilfe"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Kurzanleitung"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Benutzerhandbuch"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Sie haben nicht die erforderliche Berechtigung sich mit dieser Quelle zu verbinden."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Sie haben nicht die erforderliche Berechtigung sich mit dieser Quelle zu verbinden."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Fehlerhafte Anfrage. Kein passender 'Mode'-Parameter."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Fehlerhafte Anfrage. 'Mode'-Parameter ist ungültig."
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Sie haben nicht die erforderliche Berechtigung die Quelle zu trennen."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Mit diesem Eingang ist keine Quelle verbunden."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Sie haben nicht die erforderliche Berechtigung die Quelle zu wechseln."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nicht gefunden"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Etwas ist falsch gelaufen."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Vorschau"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Zu Playlist hinzufügen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Hinzufügen zu Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Metadaten bearbeiten"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Löschen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Herunterladen"
 
@@ -277,81 +891,1515 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Playlist duplizieren"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Keine Aktion verfügbar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Sie haben nicht die erforderliche Berechtigung die gewählten Objekte zu löschen."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopie von %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Unbenannter Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream gespeichert"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Ungültiger Eingabewert"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Bitte versichern Sie sich, dass Benutzer/Passwort unter System->Streams korrekt eingetragen ist."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Benutzer erfolgreich hinzugefügt!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Benutzer erfolgreich aktualisiert!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Einstellungen erfolgreich aktualisiert!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Aufzeichnung:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nichts geplant"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Aktuelle Sendung:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Aktuell"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Sie verwenden die aktuellste Version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Neue Version verfügbar:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Diese Version wird in Kürze veraltet sein."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Diese Version wird technisch nicht mehr unterstützt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Bitte aktualisieren sie auf "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Zu aktueller Playlist hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Zu aktuellem Smart Block hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Füge 1 Objekt hinzu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Füge %s Objekte hinzu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Sie können einem Smart Block nur Titel hinzufügen (keine Playlist oa.)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Sie können einer Playlist nur Titel, Smart Blocks und Webstreams hinzufügen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Bitte wählen Sie eine Cursor-Position auf der Zeitleiste."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Metadaten bearbeiten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Zu gewählter Sendung hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Auswahl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Ganze Seite markieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Ganze Seite nicht markieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Keines Markieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Wollen sie die gewählten Objekte wirklich löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Geplant"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Titel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Interpret"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bitrate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Komponist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded By"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Sprache"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Zuletzt geändert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Zuletzt gespielt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Dauer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Stimmung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Besitzer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Samplerate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Titelnummer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Hochgeladen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Webseite"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Jahr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "wird geladen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Alle"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Dateien"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlisten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blöcke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Unbekannter Typ:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Wollen sie das gewählte Objekt wirklich löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Hochladen wird durchgeführt..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Daten werden vom Server abgerufen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Die SoundCloud ID für diese Datei ist:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Während dem Hochladen auf SoundCloud ist ein Fehler aufgetreten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Fehler Code:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Fehlermeldung:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Der eingegeben Wert muß eine positive Zahl sein"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Der eingegebene Wert muß eine Zahl sein"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Der Wert muß in folgendem Format eingegeben werden: yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Der Wert muß in folgendem Format eingegeben werden: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Sie laden im Augenblich Datein hoch. %sDas Wechseln der Seite würde diesen Prozess abbrechen. %sSind sie sicher, daß sie die Seite verlassen möchten?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Open Media Builder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "Bitte geben sie eine Zeit an '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Das Abspielen des folgenden Dateityps wird von ihrem Browser nicht unterstützt:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Bei einem Dynamischen Block ist keine Vorschau möglich"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Beschränkung auf:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlist durchgemischt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+"Airtime kann den Status dieser Datei nicht bestimmen.\n"
+"Das kann passieren, wenn die Datei auf einem nicht erreichbaren Netzlaufwerk liegt oder in einem Verzeichnis liegt, das nicht mehr überwacht wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Hörerzahl %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "In einer Woche erinnern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Niemals erinnern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Ja, Airtime helfen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Ein Bild muß jpg, jpeg, png, oder gif sein."
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+"Ein Statischer Smart Block speichert die Kriterien und erstellt den Block sofort.\n"
+"Dadurch kann der Inhalt in der Bibliothek eingesehen und verändert werden bevor der Smart Block einer Sendung hinzugefügt wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+"Ein Dynamischer Smart Block speichert nur die Kriterien.\n"
+"Dabei wird der Inhalt erst erstellt, wenn der Smart Block einer Sendung hinzugefügt wird. Der Inhalt des Smart Blocks kann in der Bibliothek nicht eingesehen oder verändert werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+"Wenn Airtime nicht genug einzigartige Titel findet, kann die gewünschte Dauer des Smart Blocks nicht erreicht werden.\n"
+"Aktivieren sie diese Option um das mehrfache Hinzufügen von Titel zum Smart Block zu erlauben."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart Block durchgemischt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart Block erstellt und Kriterien gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart Block gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "In Bearbeitung..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Wähle Modifikator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "enthält"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "enthält nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "ist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "ist nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "beginnt mit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "endet mit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "ist größer als"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "ist kleiner als"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "ist im Bereich"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Wähle Storage-Verzeichnis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Wähle zu überwachendes Verzeichnis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Wollen sie wirklich das Storage-Verzeichnis ändern?\n"
+"Dieser Vorgang entfernt alle Dateien der Airtime-Bibliothek!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Verwalte Medienverzeichnisse"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Wollen sie den überwachten Ordner wirklich entfernen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Dieser Pfad ist derzeit nicht erreichbar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Manche Stream-Typen erfordern zusätzlich Konfiguration. Details zur Aktivierung von %sAAC+ Support%s oder %sOpus Support%s sind bereitgestellt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Mit Streaming-Server verbunden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Der Stream ist deaktiviert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Erhalte Information vom Server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Verbindung mit Streaming-Server kann nicht hergestellt werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+"Falls sich Airtime hinter einem Router oder einer Firewall befindet, müssen sie gegebenenfalls eine Portweiterleitung konfigurieren. \n"
+"Der Wert sollte so geändert werden, daß host/port/mount den Zugangsdaten der DJ's entspricht. Der erlaubte Bereich liegt zwischen 1024 und 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Für weitere Information lesen sie bitte das %sAirtime Benutzerhandbuch%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+"Diese Option aktiviert Metadaten für Ogg-Streams.\n"
+"(Stream-Metadaten wie Titel, Interpret und Sendungsname können von Audioplayern angezeigt werden.)\n"
+"VLC und mplayer haben ernsthafte Probleme beim Abspielen von Ogg/Vorbis-Streams mit aktivierten Metadaten: Beide Anwendungen werden die Verbindung zum Stream nach jedem Titel verlieren. Sollten sie einen Ogg-Stream verwenden und ihre Hörer erwarten keinen Support für diese Audioplayer, können sie diese Option gerne aktivieren."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Aktivieren sie dieses Kästchen, um die Master-/Show-Quelle bei Unterbrechung der Leitung automatisch abzuschalten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Aktivieren sie dieses Kästchen, um die Master-/Show-Quelle bei Herstellung einer Leitung automatisch anzuschalten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Falls der Icecast-Server den Benutzernamen 'source' erwartet, kann dieses Feld leer gelassen werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Falls der Live-Streaming-Client keinen Benutzernamen verlangt, sollte in dieses Feld 'source' eingetragen werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Das sind Admin Benutzername und Passwort, für die Hörerstatistiken von Icecast/SHOUTcast."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Warnung: Dieses Feld kann nicht geändert werden, während die Sendung wiedergegeben wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Kein Ergebnis gefunden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Diese Einstellung folgt den Sicherheitsvorlagen für Shows: Nur Benutzer denen diese Sendung zugewiesen wurde, können sich verbinden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Hiermit aktiviert man eine benutzerdefinierte Authentifizierung, welche nur für diese Sendung funktionieren wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Die Sendungsinstanz existiert nicht mehr!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Warnung: Sendungen können nicht erneut verknüpft werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Beim Verknüpfen von wiederkehrenden Sendungen werden jegliche Medien, die in einer wiederkehrenden Sendung geplant sind, auch in den anderen Sendungen geplant."
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Die Zeitzone ist standardmäßig auf die Zeitzone der Radiostation eingestellt. Der Im Kalender werden die Sendungen in jener Ortszeit dargestellt, welche in den Benutzereinstellungen für das Interface festgelegt wurde."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Sendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Sendung ist leer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Daten werden vom Server abgerufen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Diese Sendung hat keinen geplanten Inhalt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Diese Sendung ist noch nicht vollständig mit Inhalt befüllt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Januar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Februar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "März"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Mai"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Juni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Juli"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "August"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "September"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Oktober"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Dezember"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mär"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Mai"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Okt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dez"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Sonntag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Montag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Dienstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Donnerstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Freitag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Samstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "SO"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "MO"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "DI"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "MI"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "DO"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "FR"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "SA"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Wenn der Inhalt einer Sendung länger ist als die Sendung im Kalender geplant ist, wird das Ende durch eine nachfolgende Sendung abgeschnitten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Aktuelle Sendung abbrechen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Aufzeichnung der aktuellen Sendung stoppen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "OK"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Sendungsinhalt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Gesamten Inhalt entfernen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Gewählte Objekte löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Beginn"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Ende"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Dauer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Sendung leer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Aufzeichnen von Line-In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Titelvorschau"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Es ist keine Planung außerhalb einer Sendung möglich."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Verschiebe 1 Objekt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Verschiebe %s Objekte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Speichern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Wellenform-Funktionen ist in Browsern möglich, welche die Web Audio API unterstützen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Alle markieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Nichts Markieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Gewähltes Objekt entfernen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Springe zu aktuellem Titel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Aktuelle Sendung abbrechen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Um Inhalte hinzuzufügen oder zu entfernen muß die Bibliothek geöffnet werden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Inhalt hinzufügen / entfernen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "In Verwendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Suchen in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Öffnen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programm Manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Gast"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Gäste können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Kalender betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Sendungsinhalt betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJ's können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Verwalten zugewiesener Sendungsinhalte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Mediendateien importieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Erstellen von Playlisten, Smart Blöcken und Webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Verwalten eigener Bibliotheksinhalte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Programm Manager können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Sendungsinhalte betrachten und verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Sendungen festlegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Verwalten der gesamten Bibliothek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Admins können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Einstellungen verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Benutzer verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Verwalten überwachter Ordner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Support Feedback senden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "System Status betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Zugriff auf Playout Verlauf"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Hörerstatistiken betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Spalten zeigen / verbergen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Von {from} bis {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "So"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Mo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Mi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Fr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Schließen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Stunde"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Fertig"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Dateien wählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Fügen sie zum Hochladen Dateien der Warteschlange hinzu und drücken Sie auf Start."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Dateien hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Hochladen stoppen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Hochladen starten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Dateien hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "%d/%d Dateien hochgeladen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "Nicht Verfügbar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Dateien hierher ziehen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Dateierweiterungsfehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Dateigrößenfehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Dateianzahlfehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init Fehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP-Fehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Sicherheitsfehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Allgemeiner Fehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO-Fehler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Datei: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d Dateien in der Warteschlange"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Datei: %f, Größe: %s, Maximale Dateigröße: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload-URL scheint falsch zu sein oder existiert nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Fehler: Datei zu groß"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Fehler: Ungültige Dateierweiterung:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Standard festlegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Eintrag erstellen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Verlaufsprotokoll bearbeiten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Keine Sendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s Reihen%s in die Zwischenablage kopiert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%sBitte verwenden Sie zum Ausdrucken dieser Tabelle die Browser-interne Druckfunktion. Drücken Sie die Escape-Taste nach Fertigstellung."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-Mail konnte nicht gesendet werden. Überprüfen sie die Einstellungen des Mail-Servers und versichern sie sich, daß dieser richtig konfiguriert ist."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Falscher Benutzername oder falsches Passwort eingegeben. Bitte versuchen sie es erneut."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2419,6 @@ msgstr "Sie haben zum Löschen der gewählten %s (s) nicht die erforderliche Ber
 msgid "You can only add tracks to smart block."
 msgstr "Sie können einem Smart Block nur Titel hinzufügen."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Sie können einer Playlist nur Titel, Smart Blocks und Webstreams hinzufügen."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Unbenannte Playlist"
@@ -384,2627 +2427,88 @@ msgstr "Unbenannte Playlist"
 msgid "Untitled Smart Block"
 msgstr "Unbenannter Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Unbenannte Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Sie haben nicht die erforderliche Berechtigung sich mit dieser Quelle zu verbinden."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Einstellungen aktualisiert"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Support-Einstellungen aktualisiert."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream-Einstellungen aktualisiert."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "Pfad muß angegeben werden"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem mit Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Sie haben nicht die erforderliche Berechtigung die Quelle zu trennen."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Mit diesem Eingang ist keine Quelle verbunden."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Sie haben nicht die erforderliche Berechtigung die Quelle zu wechseln."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Falscher Benutzername oder falsches Passwort eingegeben. Bitte versuchen sie es erneut."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-Mail konnte nicht gesendet werden. Überprüfen sie die Einstellungen des Mail-Servers und versichern sie sich, daß dieser richtig konfiguriert ist."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Sie haben nicht die erforderliche Berechtigung sich mit dieser Quelle zu verbinden."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Fehlerhafte Anfrage. Kein passender 'Mode'-Parameter."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Fehlerhafte Anfrage. 'Mode'-Parameter ist ungültig."
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Aufzeichnung:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nichts geplant"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Aktuelle Sendung:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Aktuell"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Sie verwenden die aktuellste Version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Neue Version verfügbar:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Diese Version wird in Kürze veraltet sein."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Diese Version wird technisch nicht mehr unterstützt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Bitte aktualisieren sie auf "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Zu aktueller Playlist hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Zu aktuellem Smart Block hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Füge 1 Objekt hinzu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Füge %s Objekte hinzu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Sie können einem Smart Block nur Titel hinzufügen (keine Playlist oa.)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Bitte wählen Sie eine Cursor-Position auf der Zeitleiste."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Zu gewählter Sendung hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Auswahl"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Ganze Seite markieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Ganze Seite nicht markieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Keines Markieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Wollen sie die gewählten Objekte wirklich löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Geplant"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bitrate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded By"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Zuletzt geändert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Zuletzt gespielt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Besitzer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Samplerate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Titelnummer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Hochgeladen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Webseite"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "wird geladen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Alle"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Dateien"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlisten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blöcke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Unbekannter Typ:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Wollen sie das gewählte Objekt wirklich löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Hochladen wird durchgeführt..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Daten werden vom Server abgerufen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Die SoundCloud ID für diese Datei ist:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Während dem Hochladen auf SoundCloud ist ein Fehler aufgetreten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Fehler Code:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Fehlermeldung:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Der eingegeben Wert muß eine positive Zahl sein"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Der eingegebene Wert muß eine Zahl sein"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Der Wert muß in folgendem Format eingegeben werden: yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Der Wert muß in folgendem Format eingegeben werden: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Sie laden im Augenblich Datein hoch. %sDas Wechseln der Seite würde diesen Prozess abbrechen. %sSind sie sicher, daß sie die Seite verlassen möchten?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Open Media Builder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "Bitte geben sie eine Zeit an '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "Bitte geben sie eine Zeit in Sekunden ein '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Das Abspielen des folgenden Dateityps wird von ihrem Browser nicht unterstützt:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Bei einem Dynamischen Block ist keine Vorschau möglich"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Beschränkung auf:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlist durchgemischt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime kann den Status dieser Datei nicht bestimmen.\nDas kann passieren, wenn die Datei auf einem nicht erreichbaren Netzlaufwerk liegt oder in einem Verzeichnis liegt, das nicht mehr überwacht wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Hörerzahl %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "In einer Woche erinnern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Niemals erinnern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Ja, Airtime helfen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Ein Bild muß jpg, jpeg, png, oder gif sein."
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Ein Statischer Smart Block speichert die Kriterien und erstellt den Block sofort.\nDadurch kann der Inhalt in der Bibliothek eingesehen und verändert werden bevor der Smart Block einer Sendung hinzugefügt wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Ein Dynamischer Smart Block speichert nur die Kriterien.\nDabei wird der Inhalt erst erstellt, wenn der Smart Block einer Sendung hinzugefügt wird. Der Inhalt des Smart Blocks kann in der Bibliothek nicht eingesehen oder verändert werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Wenn Airtime nicht genug einzigartige Titel findet, kann die gewünschte Dauer des Smart Blocks nicht erreicht werden.\nAktivieren sie diese Option um das mehrfache Hinzufügen von Titel zum Smart Block zu erlauben."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart Block durchgemischt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart Block erstellt und Kriterien gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart Block gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "In Bearbeitung..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Wähle Modifikator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "enthält"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "enthält nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "ist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "ist nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "beginnt mit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "endet mit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "ist größer als"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "ist kleiner als"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "ist im Bereich"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Wähle Storage-Verzeichnis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Wähle zu überwachendes Verzeichnis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Wollen sie wirklich das Storage-Verzeichnis ändern?\nDieser Vorgang entfernt alle Dateien der Airtime-Bibliothek!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Verwalte Medienverzeichnisse"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Wollen sie den überwachten Ordner wirklich entfernen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Dieser Pfad ist derzeit nicht erreichbar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Manche Stream-Typen erfordern zusätzlich Konfiguration. Details zur Aktivierung von %sAAC+ Support%s oder %sOpus Support%s sind bereitgestellt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Mit Streaming-Server verbunden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Der Stream ist deaktiviert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Erhalte Information vom Server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Verbindung mit Streaming-Server kann nicht hergestellt werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Falls sich Airtime hinter einem Router oder einer Firewall befindet, müssen sie gegebenenfalls eine Portweiterleitung konfigurieren. \nDer Wert sollte so geändert werden, daß host/port/mount den Zugangsdaten der DJ's entspricht. Der erlaubte Bereich liegt zwischen 1024 und 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Für weitere Information lesen sie bitte das %sAirtime Benutzerhandbuch%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Diese Option aktiviert Metadaten für Ogg-Streams.\n(Stream-Metadaten wie Titel, Interpret und Sendungsname können von Audioplayern angezeigt werden.)\nVLC und mplayer haben ernsthafte Probleme beim Abspielen von Ogg/Vorbis-Streams mit aktivierten Metadaten: Beide Anwendungen werden die Verbindung zum Stream nach jedem Titel verlieren. Sollten sie einen Ogg-Stream verwenden und ihre Hörer erwarten keinen Support für diese Audioplayer, können sie diese Option gerne aktivieren."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Aktivieren sie dieses Kästchen, um die Master-/Show-Quelle bei Unterbrechung der Leitung automatisch abzuschalten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Aktivieren sie dieses Kästchen, um die Master-/Show-Quelle bei Herstellung einer Leitung automatisch anzuschalten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Falls der Icecast-Server den Benutzernamen 'source' erwartet, kann dieses Feld leer gelassen werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Falls der Live-Streaming-Client keinen Benutzernamen verlangt, sollte in dieses Feld 'source' eingetragen werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Das sind Admin Benutzername und Passwort, für die Hörerstatistiken von Icecast/SHOUTcast."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Warnung: Dieses Feld kann nicht geändert werden, während die Sendung wiedergegeben wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Kein Ergebnis gefunden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Diese Einstellung folgt den Sicherheitsvorlagen für Shows: Nur Benutzer denen diese Sendung zugewiesen wurde, können sich verbinden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Hiermit aktiviert man eine benutzerdefinierte Authentifizierung, welche nur für diese Sendung funktionieren wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Die Sendungsinstanz existiert nicht mehr!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Warnung: Sendungen können nicht erneut verknüpft werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Beim Verknüpfen von wiederkehrenden Sendungen werden jegliche Medien, die in einer wiederkehrenden Sendung geplant sind, auch in den anderen Sendungen geplant."
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Die Zeitzone ist standardmäßig auf die Zeitzone der Radiostation eingestellt. Der Im Kalender werden die Sendungen in jener Ortszeit dargestellt, welche in den Benutzereinstellungen für das Interface festgelegt wurde."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Sendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Sendung ist leer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Daten werden vom Server abgerufen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Diese Sendung hat keinen geplanten Inhalt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Diese Sendung ist noch nicht vollständig mit Inhalt befüllt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Januar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Februar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "März"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Mai"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Juni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Juli"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "August"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "September"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Oktober"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Dezember"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mär"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Mai"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Okt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dez"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Sonntag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Montag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Dienstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Mittwoch"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Donnerstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Freitag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Samstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "SO"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "MO"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "DI"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "MI"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "DO"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "FR"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "SA"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Wenn der Inhalt einer Sendung länger ist als die Sendung im Kalender geplant ist, wird das Ende durch eine nachfolgende Sendung abgeschnitten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Aktuelle Sendung abbrechen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Aufzeichnung der aktuellen Sendung stoppen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "OK"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Sendungsinhalt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Gesamten Inhalt entfernen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Gewählte Objekte löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Beginn"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Ende"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Dauer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Sendung leer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Aufzeichnen von Line-In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Titelvorschau"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Es ist keine Planung außerhalb einer Sendung möglich."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Verschiebe 1 Objekt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Verschiebe %s Objekte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Speichern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Wellenform-Funktionen ist in Browsern möglich, welche die Web Audio API unterstützen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Alle markieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Nichts Markieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Gewähltes Objekt entfernen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Springe zu aktuellem Titel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Aktuelle Sendung abbrechen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Um Inhalte hinzuzufügen oder zu entfernen muß die Bibliothek geöffnet werden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Inhalt hinzufügen / entfernen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "In Verwendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Suchen in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Öffnen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programm Manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Gast"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Gäste können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Kalender betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Sendungsinhalt betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJ's können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Verwalten zugewiesener Sendungsinhalte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Mediendateien importieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Erstellen von Playlisten, Smart Blöcken und Webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Verwalten eigener Bibliotheksinhalte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Programm Manager können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Sendungsinhalte betrachten und verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Sendungen festlegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Verwalten der gesamten Bibliothek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Admins können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Einstellungen verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Benutzer verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Verwalten überwachter Ordner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Support Feedback senden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "System Status betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Zugriff auf Playout Verlauf"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Hörerstatistiken betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Spalten zeigen / verbergen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Von {from} bis {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "So"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Mo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Mi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Fr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Schließen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Stunde"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Fertig"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Dateien wählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Fügen sie zum Hochladen Dateien der Warteschlange hinzu und drücken Sie auf Start."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Dateien hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Hochladen stoppen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Hochladen starten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Dateien hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "%d/%d Dateien hochgeladen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "Nicht Verfügbar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Dateien hierher ziehen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Dateierweiterungsfehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Dateigrößenfehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Dateianzahlfehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init Fehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP-Fehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Sicherheitsfehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Allgemeiner Fehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO-Fehler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Datei: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d Dateien in der Warteschlange"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Datei: %f, Größe: %s, Maximale Dateigröße: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload-URL scheint falsch zu sein oder existiert nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Fehler: Datei zu groß"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Fehler: Ungültige Dateierweiterung:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Standard festlegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Eintrag erstellen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Verlaufsprotokoll bearbeiten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Keine Sendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s Reihen%s in die Zwischenablage kopiert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%sBitte verwenden Sie zum Ausdrucken dieser Tabelle die Browser-interne Druckfunktion. Drücken Sie die Escape-Taste nach Fertigstellung."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Cursor wählen"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Cursor entfernen"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "Sendung existiert nicht."
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Wiederholung der Sendung % s vom %s um %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Cursor wählen"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Cursor entfernen"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "Sendung existiert nicht."
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Benutzer erfolgreich hinzugefügt!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Benutzer erfolgreich aktualisiert!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Einstellungen erfolgreich aktualisiert!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Unbenannter Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream gespeichert"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Ungültiger Eingabewert"
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Das Jahr %s muß innerhalb des Bereichs von 1753 - 9999 liegen."
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s ist kein gültiges Datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s-%s-%s ist kein gültiger Zeitpunkt."
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Abspielen"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stopp"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Cue In setzen"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Cue Out setzen"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Teilen"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Stream wählen:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "Stumm schalten"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "Laut schalten"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Über"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Für weitere Hilfe bitte das %sBenutzerhandbuch%s lesen."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout Verlauf"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Protokoll"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Dateiübersicht"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Sendungsübersicht"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Statischen Block erweitern"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Dynamischen Block erweitern"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Name:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Beschreibung:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Dauer:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle Playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist Crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Playlist leeren"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Leeren"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade In:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade Out:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Playlist speichern"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Keine Playlist geöffnet"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Wellenform anzeigen"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Original Dauer:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Stream Einstellungen"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Anmeldung"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Neues Passwort"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Bitte in den nachstehenden Feldern das neue Passwort eingeben und bestätigen."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Benutzer verwalten"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Neuer Benutzer"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "ID"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Benutzername"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Vorname"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Nachname"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Benutzertyp"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Sendungen suchen"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Folge wählen"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Finden"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Wiederholungstage:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Entfernen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Hinzufügen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Show Quelle"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime registrieren"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Erforderlich)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(Ausschließlich zu Kontrollzwecken, wird nicht veröffentlicht)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Erinnerung: Sind Dateien größer als 600x600 Pixel, wird die Größe geändert."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Zeige mir was ich sende"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Geschäftsbedingungen und Rahmenverhältnisse"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Tag wählen:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "oder"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "and"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " bis "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "Dateien entsprechen den Kriterien"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter Verlauf"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Um ihre Radiostation bewerben zu können, muß 'Support Feedback senden' aktiviert sein)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Erweiterte Optionen"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Die Hörer werden folgende Information auf dem Display ihres Medien-Players sehen:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Webseite ihrer Radiostation)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Verzeichnis wählen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Wählen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktuelles Import-Verzeichnis:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Überwachten Ordner entfernen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Sie überwachen keine Medienverzeichnisse."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master Quelle"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Einstellungen"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Sendung hinzufügen"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Sendung aktualisieren"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Was"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Wann"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live-Stream Eingang"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Wer"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Style"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Speicherplatz"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Datei-Import in Bearbeitung..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Erweiterte Suchoptionen"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Titel"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Interpret:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Titelnummer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Dauer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Samplerate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bitrate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Stimmung:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Jahr:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Komponist:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dirigent:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC Number:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Webseite:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Sprache:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Dateipfad:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamischer Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statischer Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Titel"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Playlist Inhalt:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statischer Smart Block Inhalt:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamische Smart Block Kriterien:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Begrenzt auf "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Die Probelaufzeit läuft ab in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "Tage"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Vorher:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Danach:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Stream-Quellen"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Hören"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Abmelden"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Protokollvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Neue Protokollvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Keine Protokollvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Dateiübersichtsvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Neue Dateiübersichtsvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Keine Dateiübersichtsvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Erstelle Dateiübersichtsvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Erstelle Protokollvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Name"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Weitere Elemente hinzufügen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Neues Feld hinzufügen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Standardvorlage festlegen"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Beschreibung"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Standard Dauer:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Kein Webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Hilfe"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Seite nicht gefunden!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Scheinbar existiert die Seite die sie suchen nicht!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "Zurück"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "Abspielen"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "Pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "Nächster"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "Stopp"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "Maximale Lautstärke"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Aktualisierung erforderlich"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Um diese Datei abspielen zu können muß entweder der Browser oder das %sFlash Plugin%s aktualisiert werden."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Zeitpunkt Start:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2518,6 @@ msgstr "Zeitpunkt Start:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Ungültiges Zeichen eingeben"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Zeitpunkt Ende:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Alle meine Sendungen:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Benutzer suchen:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Sendername"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-Mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Sender-Webseite:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Land:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Stadt:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Sender Beschreibung:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Sender Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Sie müssen die Datenschutzrichtlinien akzeptieren."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Aufzeichnen von Line-In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Wiederholen?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Wert erforderlich. Feld darf nicht leer sein."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' ist keine gültige E-Mail-Adresse im Standardformat local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' wurde nicht im erforderlichen Datumsformat '%format%' eingegeben"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' ist kürzer als %min% Zeichen lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' ist mehr als %max% Zeichen lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' liegt nicht zwischen '%min%' und '%max%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Passwörter stimmen nicht überein"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2534,55 @@ msgstr "Zeit muß angegeben werden"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Passwort zurücksetzen"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Unbenannte Sendung"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Nummer:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Standarddauer Crossfade (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Standard Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Standard Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Deaktiviert"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Aktiviert"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Zeitzone Radiostation"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Woche startet mit "
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Benutzername:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Passwort:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Passwort bestätigen:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Vorname:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Nachname:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobiltelefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Benutzertyp:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Benutzername ist nicht einmalig."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Import Verzeichnis:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Überwachte Verzeichnisse:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Kein gültiges Verzeichnis"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Standard Lizenz:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Alle Rechte vorbehalten"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Das Werk ist in der öffentlichen Domäne"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Zuordnung"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Zuordnung Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Zuordnung No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Zuordnung Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Zuordnung Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Zuordnung Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Zeitzone Interface"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Jetzt"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Kriterien wählen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bitrate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (KHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "Stunden"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "Minuten"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "Objekte"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statisch"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamisch"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Playlist-Inhalt erstellen und Kriterien speichern"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Erstellen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Shuffle Playlist-Inhalt (Durchmischen)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Beschränkung kann nicht leer oder kleiner als 0 sein."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Beschränkung kann nicht größer als 24 Stunden sein"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Der Wert muß eine ganze Zahl sein."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Die Anzahl der Objekte ist auf 500 beschränkt."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Sie müssen Kriterium und Modifikator bestimmen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "Die 'Dauer' muß im Format '00:00:00' eingegeben werden"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Der Wert muß im Timestamp-Format eingegeben werden (zB. 0000-00-00 oder 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Der eingegebene Wert muß aus Ziffern bestehen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Der eingegebene Wert muß kleiner sein als 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Der eingegebene Wert muß aus weniger als %s Zeichen bestehen."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Wert kann nicht leer sein"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Streambezeichnung:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artist - Titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Sendung - Interpret - Titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Radiostation - Sendung"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Replay Gain aktivieren"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifikator"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Passwort"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Neues Passwort bestätigen"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Passwortbestätigung stimmt nicht mit Passwort überein"
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Aktiviert:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Typ:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Typ:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanäle:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Es sind nur Zahlen erlaubt"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin Benutzer"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Passwort"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server darf nicht leer sein."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port darf nicht leer sein."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount darf nicht leer sein, wenn Icecast-Server verwendet wird."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' ist nicht im Format 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Zeitzone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Wiederholungen?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Eine Sendung kann nicht für einen bereits vergangenen Zeitpunkt geplant werden"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Beginn- & Endzeit einer bereits laufenden Sendung können nicht geändert werden"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Enddatum / Endzeit darf nicht in der Vergangheit liegen."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Die Dauer einer Sendung kann nicht kürzer als 0 Minuten sein."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Die Dauer einer Sendung kann nicht 00h 00m sein"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Die Dauer einer Sendung kann nicht länger als 24h sein"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Benutzerdefinierte Authentifizierung:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Benutzerdefinierter Benutzername"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Benutzerdefiniertes Passwort"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Das Feld Benutzername darf nicht leer sein."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Das Feld Passwort darf nicht leer sein."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Hintergrundfarbe:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Textfarbe:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Geben sie die Zeichen ein, die im darunter liegenden Bild zu sehen sind."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "Tage"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2628,12 @@ msgstr "Tag des Monats"
 msgid "day of the week"
 msgstr "Tag der Woche"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Zeitpunkt Ende:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Kein Enddatum?"
@@ -3877,115 +2646,1174 @@ msgstr "Enddatum muß nach Startdatum liegen."
 msgid "Please select a repeat day"
 msgstr "Bitte Tag zum Wiederholen wählen"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Aufzeichnen von Line-In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Wiederholen?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Hintergrundfarbe:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Textfarbe:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalender"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Entfernen"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Benutzer"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Name:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Unbenannte Sendung"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Beschreibung:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Hörerstatistiken"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' ist nicht im Format 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Verlaufsvorlagen"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Dauer:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Zeitzone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Wiederholungen?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Eine Sendung kann nicht für einen bereits vergangenen Zeitpunkt geplant werden"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Beginn- & Endzeit einer bereits laufenden Sendung können nicht geändert werden"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Enddatum / Endzeit darf nicht in der Vergangheit liegen."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Die Dauer einer Sendung kann nicht kürzer als 0 Minuten sein."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Die Dauer einer Sendung kann nicht 00h 00m sein"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Die Dauer einer Sendung kann nicht länger als 24h sein"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Sendungen können nicht überlappend geplant werden."
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Benutzer suchen:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Benutzername:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Passwort:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Passwort bestätigen:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Vorname:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Nachname:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-Mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobiltelefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Benutzertyp:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Benutzername ist nicht einmalig."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Kurzanleitung"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Benutzerhandbuch"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Wert erforderlich. Feld darf nicht leer sein."
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Zeitpunkt Start:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Titel"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Interpret:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Jahr:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Komponist:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dirigent:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Stimmung:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Nummer:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Webseite:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Sprache:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Beginn"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Ende"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Zeitzone Interface"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Sendername"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Sender Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Erinnerung: Sind Dateien größer als 600x600 Pixel, wird die Größe geändert."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Standarddauer Crossfade (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Standard Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Standard Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Zeitzone Radiostation"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Woche startet mit "
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' ist keine gültige E-Mail-Adresse im Standardformat local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' wurde nicht im erforderlichen Datumsformat '%format%' eingegeben"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' ist kürzer als %min% Zeichen lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' ist mehr als %max% Zeichen lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' liegt nicht zwischen '%min%' und '%max%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Passwörter stimmen nicht überein"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Es sind nur Zahlen erlaubt"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Anmeldung"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Geben sie die Zeichen ein, die im darunter liegenden Bild zu sehen sind."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Passwort"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Neues Passwort bestätigen"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Passwortbestätigung stimmt nicht mit Passwort überein"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Benutzername"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Passwort zurücksetzen"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Jetzt"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Sender-Webseite:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Land:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Stadt:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Sender Beschreibung:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Sie müssen die Datenschutzrichtlinien akzeptieren."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Alle meine Sendungen:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Kriterien wählen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bitrate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Beschreibung"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (KHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "Stunden"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "Minuten"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "Objekte"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statisch"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamisch"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Playlist-Inhalt erstellen und Kriterien speichern"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Erstellen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Shuffle Playlist-Inhalt (Durchmischen)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Beschränkung kann nicht leer oder kleiner als 0 sein."
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Beschränkung kann nicht größer als 24 Stunden sein"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Der Wert muß eine ganze Zahl sein."
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Die Anzahl der Objekte ist auf 500 beschränkt."
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Sie müssen Kriterium und Modifikator bestimmen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "Die 'Dauer' muß im Format '00:00:00' eingegeben werden"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Der Wert muß im Timestamp-Format eingegeben werden (zB. 0000-00-00 oder 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Der eingegebene Wert muß aus Ziffern bestehen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Der eingegebene Wert muß kleiner sein als 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Der eingegebene Wert muß aus weniger als %s Zeichen bestehen."
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Wert kann nicht leer sein"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Standard Lizenz:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Alle Rechte vorbehalten"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Das Werk ist in der öffentlichen Domäne"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Zuordnung"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Zuordnung Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Zuordnung No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Zuordnung Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Zuordnung Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Zuordnung Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Streambezeichnung:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artist - Titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Sendung - Interpret - Titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Radiostation - Sendung"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Replay Gain aktivieren"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifikator"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Aktiviert:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Typ:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bitrate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Typ:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanäle:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Name"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin Benutzer"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Passwort"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server darf nicht leer sein."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port darf nicht leer sein."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount darf nicht leer sein, wenn Icecast-Server verwendet wird."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Import Verzeichnis:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Überwachte Verzeichnisse:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Kein gültiges Verzeichnis"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Abspielen"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stopp"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Cue In setzen"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Cue Out setzen"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue In und Cue Out sind Null."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Cue In darf nicht größer als die Gesamtdauer der Datei sein."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Cue In darf nicht größer als Cue Out sein."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Cue Out darf nicht kleiner als Cue In sein."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Wiederholung von %s am %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Land wählen"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3838,12 @@ msgstr "%s ist kein gültiges Verzeichnis."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Liste überwachter Verzeichnisse."
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Liste überwachter Verzeichnisse."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3851,18 @@ msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Li
 msgid "%s doesn't exist in the watched list."
 msgstr "%s existiert nicht in der Liste überwachter Verzeichnisse."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Land wählen"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Die Maximaldauer einer Sendung beträgt 24 Stunden."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Sendungen können nicht überlappend geplant werden.\nBeachte: Wird die Dauer einer wiederkehrenden Sendung verändert, wirkt sich das auch auf alle Wiederholungen aus."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3877,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Der Kalender den sie sehen ist nicht mehr aktuell! (Objekt falsch eingepasst)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Der Kalender den sie sehen ist nicht mehr aktuell."
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Sie haben nicht die erforderliche Berechtigung einen Termin für die Sendung %s zu festzulegen."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Einer Sendungsaufzeichnung können keine Dateien hinzugefügt werden."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Die Sendung %s ist beendet und kann daher nicht festgelegt werden."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Die Sendung %s wurde bereits aktualisiert."
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Eine verknüpfte Sendung kann nicht befüllt werden, während eine ihrer Instanzen  ausgestrahlt wird."
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Eine der gewählten Dateien existiert nicht!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Die Maximaldauer einer Sendung beträgt 24 Stunden."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Sendungen können nicht überlappend geplant werden.\n"
+"Beachte: Wird die Dauer einer wiederkehrenden Sendung verändert, wirkt sich das auch auf alle Wiederholungen aus."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Wiederholung von %s am %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3977,1049 @@ msgstr "Ungültiger Webstream - Die eingegebene URL scheint ein Dateidownload zu
 msgid "Unrecognized stream type: %s"
 msgstr "Unbekannter Stream-Typ: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Aufeichnung existiert nicht"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Metadaten der aufgezeichneten Datei ansehen"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Sendung bearbeiten"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Zugriff verweigert"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Wiederkehrende Sendungen können nicht per Drag'n'Drop verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Eine in der Vergangenheit liegende Sendung kann nicht verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Eine Sendung kann nicht in die Vergangenheit verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Eine aufgezeichnete Sendung kann nicht verschoben werden, wenn der Zeitpunkt der Wiederholung weniger als eine Stunde bevor liegt."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Die Sendung wurde gelöscht, weil die aufgezeichnete Sendung nicht existiert."
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Titel"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Abgespielt"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "Zurück"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "Abspielen"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "Pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "Nächster"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "Stopp"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "Stumm schalten"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "Laut schalten"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "Maximale Lautstärke"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Aktualisierung erforderlich"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Um diese Datei abspielen zu können muß entweder der Browser oder das %sFlash Plugin%s aktualisiert werden."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Über"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Für weitere Hilfe bitte das %sBenutzerhandbuch%s lesen."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Teilen"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Stream wählen:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Seite nicht gefunden!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Scheinbar existiert die Seite die sie suchen nicht!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Show Quelle"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Tag wählen:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Hinzufügen"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Wiederholungstage:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter Verlauf"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Folge wählen"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Finden"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Einstellungen"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master Quelle"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Verzeichnis wählen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Wählen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktuelles Import-Verzeichnis:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Überwachten Ordner entfernen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Sie überwachen keine Medienverzeichnisse."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime registrieren"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Erforderlich)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(Ausschließlich zu Kontrollzwecken, wird nicht veröffentlicht)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Zeige mir was ich sende"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Geschäftsbedingungen und Rahmenverhältnisse"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Sendungen suchen"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "oder"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "and"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " bis "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "Dateien entsprechen den Kriterien"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Erweiterte Optionen"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Die Hörer werden folgende Information auf dem Display ihres Medien-Players sehen:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Webseite ihrer Radiostation)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Um ihre Radiostation bewerben zu können, muß 'Support Feedback senden' aktiviert sein)"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Titelnummer:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Dauer:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Samplerate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC Number:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Dateipfad:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamischer Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statischer Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Titel"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Playlist Inhalt:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statischer Smart Block Inhalt:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamische Smart Block Kriterien:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Begrenzt auf "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Datei-Import in Bearbeitung..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Erweiterte Suchoptionen"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Neues Passwort"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Bitte in den nachstehenden Feldern das neue Passwort eingeben und bestätigen."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Vorher:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Danach:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Stream-Quellen"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Hören"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Abmelden"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Die Probelaufzeit läuft ab in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle Playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist Crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Playlist leeren"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Leeren"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade Out:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Playlist speichern"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Keine Playlist geöffnet"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Wellenform anzeigen"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Original Dauer:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade In:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Statischen Block erweitern"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Dynamischen Block erweitern"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Protokoll"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Dateiübersicht"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Sendungsübersicht"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Protokollvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Neue Protokollvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Keine Protokollvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Dateiübersichtsvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Neue Dateiübersichtsvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Keine Dateiübersichtsvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Erstelle Dateiübersichtsvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Erstelle Protokollvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Weitere Elemente hinzufügen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Neues Feld hinzufügen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Standardvorlage festlegen"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Stream Einstellungen"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Sendung hinzufügen"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Sendung aktualisieren"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Was"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Wann"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live-Stream Eingang"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Wer"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Style"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Speicherplatz"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Benutzer verwalten"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Neuer Benutzer"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "ID"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Vorname"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Nachname"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Benutzertyp"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Standard Dauer:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Kein Webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "Bitte geben sie eine Zeit in Sekunden ein '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Eine verknüpfte Sendung kann nicht befüllt werden, während eine ihrer Instanzen  ausgestrahlt wird."

--- a/airtime_mvc/locale/de_AT/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/de_AT/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/de_DE/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Daniel James <daniel@64studio.com>, 2014
 # Darius Kellermann <dariuskellermann+transifex@gmail.com>, 2015
@@ -11,266 +11,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: German (Germany) (http://www.transifex.com/sourcefabric/airtime/language/de_DE/)\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Aufzeichnung existiert nicht"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Das Jahr %s muß im Bereich zwischen 1753 und 9999 sein"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Metadaten der aufgezeichneten Datei anzeigen"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s ist kein gültiges Datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s-%s-%s ist kein gültiger Zeitpunkt."
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Ändern"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Sendung ändern"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Löschen"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Zugriff verweigert"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Wiederkehrende Sendungen können nicht per Drag'n'Drop verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Eine in der Vergangenheit liegende Sendung kann nicht verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Eine Sendung kann nicht in die Vergangenheit verschoben werden."
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Sendungen können nicht überlappend geplant werden."
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Eine aufgezeichnete Sendung kann nicht verschoben werden, wenn der Zeitpunkt der Wiederholung weniger als eine Stunde bevor liegt."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Die Sendung wurde gelöscht, weil die aufgezeichnete Sendung nicht existiert!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Titel"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Interpret"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Länge"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Stimmung"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Komponist"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Jahr"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Titel"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Sprache"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Startzeit"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Endzeit"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Abgespielt"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalender"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Benutzer"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout Verlauf"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Verlaufsvorlagen"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Hörerstatistiken"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Hilfe"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Kurzanleitung"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Benutzerhandbuch"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Sie sind nicht berechtigt, auf diese Resource zuzugreifen"
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Sie sind nicht berechtigt, auf diese Resource zuzugreifen. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Fehlerhafte Anfrage. Es wurde kein 'mode' Parameter übergeben."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Fehlerhafte Anfrage. 'Mode' Parameter ist ungültig"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Sie haben nicht die erforderliche Berechtigung, das Eingangssignal zu trennen."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Mit diesem Eingang ist kein Signal verbunden."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Sie haben nicht die erforderliche Berechtigung, das Signal umzuschalten."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nicht gefunden"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Etwas ist falsch gelaufen."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Vorschau"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Zur Playlist hinzufügen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Zum Smart Block hinzufügen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Metadaten ändern"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Löschen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -279,81 +893,1513 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplizierte Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Keine Aktion verfügbar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Sie haben nicht die erforderliche Berechtigung die gewählten Objekte zu löschen."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopie von %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Unbenannter Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream gespeichert."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Ungültige Formularwerte."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Bitte prüfen sie, ob der Admin Nutzer/Password unter System->Stream korrekt eingetragen ist."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Benutzer erfolgreich hinzugefügt!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Benutzer erfolgreich aktualisiert!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Einstellungen erfolgreich aktualisiert!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Aufnahme:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Es ist nichts geplant"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Aktuelle Sendung:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Jezt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Sie verwenden die neueste Version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Neue Version verfügbar: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Diese Version wird in Kürze veraltet sein."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Diese Version wird technisch nicht mehr unterstützt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Bitte aktualisieren sie auf "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Zu aktueller Playlist hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Zu aktuellem Smart Block hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "1 Objekt hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "%s Objekte hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Sie können einem Smart Block nur Titel hinzufügen (keine Playlist oa.)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Sie können einer Playlist nur Titel, Smart Blocks und Webstreams hinzufügen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Bitte wählen sie eine Cursor-Position auf der Zeitleiste."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Metadaten ändern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Zur ausgewählten Sendungen hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Auswählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Wählen sie diese Seite"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Wählen sie diese Seite ab"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Alle Abwählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Wollen sie die gewählten Objekte wirklich löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Geplant"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Titel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Interpret"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bitrate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Komponist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded By"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Sprache"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "geändert am"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Zuletzt gespielt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Länge"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Stimmung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Besitzer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Samplerate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Titelnummer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Hochgeladen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Webseite"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Jahr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "wird geladen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Alle"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Dateien"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlisten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blöcke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Unbekannter Typ: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Wollen sie das gewählte Objekt wirklich löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Upload wird durchgeführt..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Daten werden vom Server abgerufen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Die SoundCloud ID für diese Datei ist: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Während dem Hochladen auf SoundCloud ist ein Fehler aufgetreten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Fehlercode: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Fehlermeldung: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Der eingegeben Wert muß eine positive Zahl sein"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Der eingegebene Wert muß eine Zahl sein"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Der Wert muß in folgendem Format eingegeben werden: yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Der Wert muß in folgendem Format eingegeben werden: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Sie laden momentan Dateien hoch. %s Beim wechseln der Seite wird der Upload-Vorgang abgebrochen. %s Sind sie sicher, dass sie die Seite verlassen wollen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Medienordner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "Bitte geben sie eine Zeit an '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Das Abspielen des folgenden Dateityps wird von ihrem Browser nicht unterstützt: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Bei einem Dynamischen Block ist keine Vorschau möglich"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Beschränken auf: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playliste gemischt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+"Airtime kann den Status dieser Datei nicht bestimmen.\n"
+"Das kann passieren, wenn die Datei auf einem nicht erreichbaren Netzlaufwerk liegt oder in einem Verzeichnis liegt, das nicht mehr überwacht wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Hörerzahl %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "In einer Woche erinnern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Niemals erinnern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Ja, Airtime helfen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Ein Bild muß jpg, jpeg, png, oder gif sein"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+"Ein Statischer Smart Block speichert die Kriterien und erstellt den Block sofort.\n"
+"Dadurch kann der Inhalt in der Bibliothek eingesehen und verändert werden bevor der Smart Block einer Sendung hinzugefügt wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+"Ein Dynamischer Smart Block speichert nur die Kriterien.\n"
+"Dabei wird der Inhalt erst erstellt, wenn der Smart Block einer Sendung hinzugefügt wird. Der Inhalt des Smart Blocks kann daher nicht in der Bibliothek angezeigt oder bearbeitetet werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Wenn Airtime nicht genug einzigartige Titel findet, die Ihren Kriterien entsprechen, kann die gewünschte Länge des Smart Blocks nicht erreicht werden. Wenn sie möchten, dass Titel mehrfach zum Smart Block hinzugefügt werden können, aktivieren sie diese Option."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart Block gemischt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart Block erstellt und Kriterien gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart Block gespeichert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "In Bearbeitung..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr " - Attribut - "
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "enthält"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "enthält nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "ist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "ist nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "beginnt mit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "endet mit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "ist größer als"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "ist kleiner als"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "ist im Bereich"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Wähle Speicher-Verzeichnis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Wähle zu überwachendes Verzeichnis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Sind sie sicher, dass sie den Speicher-Verzeichnis ändern wollen?\n"
+"Dieser Vorgang entfernt alle Dateien der Airtime-Bibliothek!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Medienverzeichnisse verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Sind sie sicher, dass sie das überwachte Verzeichnis entfernen wollen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Dieser Pfad ist derzeit nicht erreichbar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Manche Stream-Typen erfordern zusätzliche Konfiguration. Details zum Aktivieren von %sAAC+ Support%s oder %sOpus Support%s sind in der WIKI bereitgestellt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Mit dem Streaming-Server verbunden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Der Stream ist deaktiviert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Erhalte Information vom Server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Verbindung mit Streaming-Server kann nicht hergestellt werden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+"Falls sich Airtime hinter einem Router oder einer Firewall befindet, müssen sie gegebenenfalls eine Portweiterleitung konfigurieren. \n"
+"In diesem Fall müssen sie die URL manuell eintragen, damit Ihren DJs der richtige Host/Port/Mount zur verbindung anzeigt wird. Der erlaubte Port-Bereich liegt zwischen 1024 und 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Für weitere Information lesen sie bitte das %sAirtime Benutzerhandbuch%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+"Diese Option aktiviert Metadaten für Ogg-Streams.\n"
+"(Stream-Metadaten wie Titel, Interpret und Sendungsname können von Audioplayern angezeigt werden.)\n"
+"VLC und mplayer haben ernsthafte Probleme beim Abspielen von Ogg/Vorbis-Streams mit aktivierten Metadaten: Beide Anwendungen werden die Verbindung zum Stream nach jedem Titel verlieren. Sollten sie einen Ogg-Stream verwenden und ihre Hörer keine Unterstützung für diese Audioplayer erwarten, können sie diese Option aktivieren."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Aktivieren sie dieses Kästchen, um die Master/Show-Source bei Unterbrechung der Leitung automatisch abzuschalten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Aktivieren sie dieses Kästchen, um automatisch  bei Verbindung einer Streameingabe umzuschalten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Wenn Ihr Icecast Server den Benutzernamen 'source' erwartet, kann dieses Feld leer bleiben."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Wenn Ihr Live-Streaming-Client nicht nach einem Benutzernamen fragt, sollten Sie hier 'source' eintragen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Admin Benutzer und Passwort, wird zur Abfrage der Zuhörerdaten in Icecast/SHOUTcast verwendet."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Warnung: Dieses Feld kann nicht geändert werden, während die Sendung wiedergegeben wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Kein Ergebnis gefunden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Diese Einstellung folgt den gleichen Sicherheitsvorlagen für Sendung: Nur Benutzer denen diese Sendung zugewiesen wurde, können sich verbinden."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Bestimmen einer benutzerdefinierten Anmeldung eintragen, welche nur für diese Sendung funktionieren wird."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Die Sendungsinstanz existiert nicht mehr!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Warnung: Verknüpfte Sendungen können nicht erneut verknüpft werden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Beim Verknüpfen von wiederkehrenden Sendungen werden jegliche Medien, die in einer wiederkehrenden Sendung geplant sind, auch in den anderen Sendungen geplant."
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Die Zeitzone ist standardmäßig auf die Zeitzone der Radiostation eingestellt. Der Im Kalender werden die Sendungen in jener Ortszeit dargestellt, welche in den Benutzereinstellungen für das Interface festgelegt wurde."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Sendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Sendung ist leer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Daten werden vom Server abgerufen..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Diese Sendung hat keinen festgelegten Inhalt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Diese Sendung ist noch nicht vollständig mit Inhalten gefüllt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Januar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Februar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "März"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Mai"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Juni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Juli"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "August"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "September"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Oktober"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Dezember"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan."
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb."
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mrz."
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr."
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun."
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul."
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug."
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep."
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Okt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov."
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dez."
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Sonntag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Montag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Dienstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Mittwoch"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Donnerstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Freitag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Samstag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "So."
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Mo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Di."
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Mi."
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Do."
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Fr."
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sa."
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Wenn der Inhalt einer Sendung länger ist als im Kalender festgelegt ist, wird das Ende durch eine nachfolgende Sendung abgschnitten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Aktuelle Sendung abbrechen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Aufnahme der aktuellen Sendung stoppen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Speichern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Sendungsinhalt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Gesamten Inhalt entfernen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Gewählte Objekte löschen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Beginn"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Ende"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Dauer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Sendung ist leer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Aufnehmen über Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Titel Vorschau"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Es ist keine Planung außerhalb einer Sendung möglich."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Verschiebe 1 Objekt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Verschiebe %s Objekte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Speichern"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Wellenform-Funktionen ist nur in Browsern möglich, welche die Web Audio API unterstützen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Alles auswählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Nichts auswählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Ausgewählte Elemente aus dem Programm entfernen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Springe zu aktuellem Titel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Aktuelle Sendung abbrechen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Um Inhalte hinzuzufügen oder zu entfernen muß die Bibliothek geöffnet werden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Inhalt hinzufügen / entfernen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "In Verwendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Suchen in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Öffnen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programm Manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Gast"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Gäste können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Kalender betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Sendungsinhalt betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJs können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Verwalten zugewiesener Sendungsinhalte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Mediendateien importieren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Erstellen von Playlisten, Smart Blöcken und Webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Verwalten eigener Bibliotheksinhalte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Programm Manager können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Sendungsinhalte betrachten und verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Sendungen festlegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Verwalten der gesamten Bibliothek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Admins können folgendes tun:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Einstellungen verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Benutzer verwalten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Verwalten überwachter Verzeichnisse"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Support Feedback senden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "System Status betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Zugriff auf Playlist Verlauf"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Hörerstatistiken betrachten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Spalten auswählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Von {from} bis {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "So"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Mo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Mi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Fr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Schließen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Stunde"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Fertig"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Dateien auswählen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Dateien zur Uploadliste hinzufügen und den Startbutton klicken."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Dateien hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Upload stoppen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Upload starten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Dateien hinzufügen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "%d/%d Dateien hochgeladen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Dateien in dieses Feld ziehen.(Drag & Drop)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Fehler in der Dateierweiterung."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Fehler in der Dateigröße."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Fehler in der Dateianzahl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init Fehler."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Fehler."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Sicherheitsfehler."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Allgemeiner Fehler."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO Fehler."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Datei: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d Dateien in der Warteschlange"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Datei: %f, Größe: %s, Maximale Dateigröße: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload-URL scheint falsch zu sein oder existiert nicht"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Fehler: Datei zu groß: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Fehler: ungültige Dateierweiterung: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Standard festlegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Eintrag erstellen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Verlaufsprotokoll bearbeiten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Keine Sendung"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s Reihen%s in die Zwischenablage kopiert"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sDruckansicht%sBenutzen sie bitte die Druckfunktion des Browsers, um diese Tabelle auszudrucken. Wenn sie fertig sind, drücken sie die Escape-Taste."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-Mail konnte nicht gesendet werden. Überprüfen sie die Einstellungen des E-Mail-Servers und vergwissern sie sich, dass dieser richtig konfiguriert wurde."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Falscher Benutzername oder Passwort. Bitte versuchen sie es erneut."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -373,11 +2419,6 @@ msgstr "Sie haben zum Löschen der gewählten %s (s) nicht die erforderliche Ber
 msgid "You can only add tracks to smart block."
 msgstr "Sie können einem Smart Block nur Titel hinzufügen."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Sie können einer Playlist nur Titel, Smart Blocks und Webstreams hinzufügen."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Unbenannte Playlist"
@@ -386,2627 +2427,88 @@ msgstr "Unbenannte Playlist"
 msgid "Untitled Smart Block"
 msgstr "Unbenannter Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Unbekannte Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Sie sind nicht berechtigt, auf diese Resource zuzugreifen"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Einstellungen aktualisiert."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Support-Einstellungen aktualisiert."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream-Einstellungen aktualisiert."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "Pfad muß angegeben werden"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem mit Liquidsoap ..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Sie haben nicht die erforderliche Berechtigung, das Eingangssignal zu trennen."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Mit diesem Eingang ist kein Signal verbunden."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Sie haben nicht die erforderliche Berechtigung, das Signal umzuschalten."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Falscher Benutzername oder Passwort. Bitte versuchen sie es erneut."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-Mail konnte nicht gesendet werden. Überprüfen sie die Einstellungen des E-Mail-Servers und vergwissern sie sich, dass dieser richtig konfiguriert wurde."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Sie sind nicht berechtigt, auf diese Resource zuzugreifen. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Fehlerhafte Anfrage. Es wurde kein 'mode' Parameter übergeben."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Fehlerhafte Anfrage. 'Mode' Parameter ist ungültig"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Aufnahme:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Es ist nichts geplant"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Aktuelle Sendung:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Jezt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Sie verwenden die neueste Version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Neue Version verfügbar: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Diese Version wird in Kürze veraltet sein."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Diese Version wird technisch nicht mehr unterstützt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Bitte aktualisieren sie auf "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Zu aktueller Playlist hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Zu aktuellem Smart Block hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "1 Objekt hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "%s Objekte hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Sie können einem Smart Block nur Titel hinzufügen (keine Playlist oa.)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Bitte wählen sie eine Cursor-Position auf der Zeitleiste."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Zur ausgewählten Sendungen hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Auswählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Wählen sie diese Seite"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Wählen sie diese Seite ab"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Alle Abwählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Wollen sie die gewählten Objekte wirklich löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Geplant"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bitrate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded By"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "geändert am"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Zuletzt gespielt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Besitzer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Samplerate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Titelnummer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Hochgeladen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Webseite"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "wird geladen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Alle"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Dateien"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlisten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blöcke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Unbekannter Typ: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Wollen sie das gewählte Objekt wirklich löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Upload wird durchgeführt..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Daten werden vom Server abgerufen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Die SoundCloud ID für diese Datei ist: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Während dem Hochladen auf SoundCloud ist ein Fehler aufgetreten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Fehlercode: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Fehlermeldung: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Der eingegeben Wert muß eine positive Zahl sein"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Der eingegebene Wert muß eine Zahl sein"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Der Wert muß in folgendem Format eingegeben werden: yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Der Wert muß in folgendem Format eingegeben werden: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Sie laden momentan Dateien hoch. %s Beim wechseln der Seite wird der Upload-Vorgang abgebrochen. %s Sind sie sicher, dass sie die Seite verlassen wollen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Medienordner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "Bitte geben sie eine Zeit an '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "Bitte geben sie eine Zeit in Sekunden ein '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Das Abspielen des folgenden Dateityps wird von ihrem Browser nicht unterstützt: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Bei einem Dynamischen Block ist keine Vorschau möglich"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Beschränken auf: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playliste gemischt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime kann den Status dieser Datei nicht bestimmen.\nDas kann passieren, wenn die Datei auf einem nicht erreichbaren Netzlaufwerk liegt oder in einem Verzeichnis liegt, das nicht mehr überwacht wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Hörerzahl %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "In einer Woche erinnern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Niemals erinnern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Ja, Airtime helfen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Ein Bild muß jpg, jpeg, png, oder gif sein"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Ein Statischer Smart Block speichert die Kriterien und erstellt den Block sofort.\nDadurch kann der Inhalt in der Bibliothek eingesehen und verändert werden bevor der Smart Block einer Sendung hinzugefügt wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Ein Dynamischer Smart Block speichert nur die Kriterien.\nDabei wird der Inhalt erst erstellt, wenn der Smart Block einer Sendung hinzugefügt wird. Der Inhalt des Smart Blocks kann daher nicht in der Bibliothek angezeigt oder bearbeitetet werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Wenn Airtime nicht genug einzigartige Titel findet, die Ihren Kriterien entsprechen, kann die gewünschte Länge des Smart Blocks nicht erreicht werden. Wenn sie möchten, dass Titel mehrfach zum Smart Block hinzugefügt werden können, aktivieren sie diese Option."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart Block gemischt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart Block erstellt und Kriterien gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart Block gespeichert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "In Bearbeitung..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr " - Attribut - "
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "enthält"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "enthält nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "ist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "ist nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "beginnt mit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "endet mit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "ist größer als"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "ist kleiner als"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "ist im Bereich"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Wähle Speicher-Verzeichnis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Wähle zu überwachendes Verzeichnis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Sind sie sicher, dass sie den Speicher-Verzeichnis ändern wollen?\nDieser Vorgang entfernt alle Dateien der Airtime-Bibliothek!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Medienverzeichnisse verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Sind sie sicher, dass sie das überwachte Verzeichnis entfernen wollen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Dieser Pfad ist derzeit nicht erreichbar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Manche Stream-Typen erfordern zusätzliche Konfiguration. Details zum Aktivieren von %sAAC+ Support%s oder %sOpus Support%s sind in der WIKI bereitgestellt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Mit dem Streaming-Server verbunden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Der Stream ist deaktiviert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Erhalte Information vom Server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Verbindung mit Streaming-Server kann nicht hergestellt werden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Falls sich Airtime hinter einem Router oder einer Firewall befindet, müssen sie gegebenenfalls eine Portweiterleitung konfigurieren. \nIn diesem Fall müssen sie die URL manuell eintragen, damit Ihren DJs der richtige Host/Port/Mount zur verbindung anzeigt wird. Der erlaubte Port-Bereich liegt zwischen 1024 und 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Für weitere Information lesen sie bitte das %sAirtime Benutzerhandbuch%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Diese Option aktiviert Metadaten für Ogg-Streams.\n(Stream-Metadaten wie Titel, Interpret und Sendungsname können von Audioplayern angezeigt werden.)\nVLC und mplayer haben ernsthafte Probleme beim Abspielen von Ogg/Vorbis-Streams mit aktivierten Metadaten: Beide Anwendungen werden die Verbindung zum Stream nach jedem Titel verlieren. Sollten sie einen Ogg-Stream verwenden und ihre Hörer keine Unterstützung für diese Audioplayer erwarten, können sie diese Option aktivieren."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Aktivieren sie dieses Kästchen, um die Master/Show-Source bei Unterbrechung der Leitung automatisch abzuschalten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Aktivieren sie dieses Kästchen, um automatisch  bei Verbindung einer Streameingabe umzuschalten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Wenn Ihr Icecast Server den Benutzernamen 'source' erwartet, kann dieses Feld leer bleiben."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Wenn Ihr Live-Streaming-Client nicht nach einem Benutzernamen fragt, sollten Sie hier 'source' eintragen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Admin Benutzer und Passwort, wird zur Abfrage der Zuhörerdaten in Icecast/SHOUTcast verwendet."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Warnung: Dieses Feld kann nicht geändert werden, während die Sendung wiedergegeben wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Kein Ergebnis gefunden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Diese Einstellung folgt den gleichen Sicherheitsvorlagen für Sendung: Nur Benutzer denen diese Sendung zugewiesen wurde, können sich verbinden."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Bestimmen einer benutzerdefinierten Anmeldung eintragen, welche nur für diese Sendung funktionieren wird."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Die Sendungsinstanz existiert nicht mehr!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Warnung: Verknüpfte Sendungen können nicht erneut verknüpft werden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Beim Verknüpfen von wiederkehrenden Sendungen werden jegliche Medien, die in einer wiederkehrenden Sendung geplant sind, auch in den anderen Sendungen geplant."
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Die Zeitzone ist standardmäßig auf die Zeitzone der Radiostation eingestellt. Der Im Kalender werden die Sendungen in jener Ortszeit dargestellt, welche in den Benutzereinstellungen für das Interface festgelegt wurde."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Sendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Sendung ist leer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Daten werden vom Server abgerufen..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Diese Sendung hat keinen festgelegten Inhalt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Diese Sendung ist noch nicht vollständig mit Inhalten gefüllt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Januar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Februar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "März"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Mai"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Juni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Juli"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "August"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "September"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Oktober"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Dezember"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan."
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb."
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mrz."
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr."
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun."
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul."
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug."
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep."
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Okt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov."
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dez."
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Sonntag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Montag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Dienstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Mittwoch"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Donnerstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Freitag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Samstag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "So."
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Mo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Di."
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Mi."
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Do."
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Fr."
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sa."
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Wenn der Inhalt einer Sendung länger ist als im Kalender festgelegt ist, wird das Ende durch eine nachfolgende Sendung abgschnitten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Aktuelle Sendung abbrechen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Aufnahme der aktuellen Sendung stoppen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Speichern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Sendungsinhalt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Gesamten Inhalt entfernen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Gewählte Objekte löschen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Beginn"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Ende"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Dauer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Sendung ist leer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Aufnehmen über Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Titel Vorschau"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Es ist keine Planung außerhalb einer Sendung möglich."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Verschiebe 1 Objekt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Verschiebe %s Objekte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Speichern"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Wellenform-Funktionen ist nur in Browsern möglich, welche die Web Audio API unterstützen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Alles auswählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Nichts auswählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Ausgewählte Elemente aus dem Programm entfernen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Springe zu aktuellem Titel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Aktuelle Sendung abbrechen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Um Inhalte hinzuzufügen oder zu entfernen muß die Bibliothek geöffnet werden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Inhalt hinzufügen / entfernen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "In Verwendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Suchen in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Öffnen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programm Manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Gast"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Gäste können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Kalender betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Sendungsinhalt betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJs können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Verwalten zugewiesener Sendungsinhalte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Mediendateien importieren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Erstellen von Playlisten, Smart Blöcken und Webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Verwalten eigener Bibliotheksinhalte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Programm Manager können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Sendungsinhalte betrachten und verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Sendungen festlegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Verwalten der gesamten Bibliothek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Admins können folgendes tun:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Einstellungen verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Benutzer verwalten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Verwalten überwachter Verzeichnisse"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Support Feedback senden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "System Status betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Zugriff auf Playlist Verlauf"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Hörerstatistiken betrachten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Spalten auswählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Von {from} bis {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "So"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Mo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Mi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Fr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Schließen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Stunde"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Fertig"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Dateien auswählen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Dateien zur Uploadliste hinzufügen und den Startbutton klicken."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Dateien hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Upload stoppen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Upload starten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Dateien hinzufügen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "%d/%d Dateien hochgeladen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Dateien in dieses Feld ziehen.(Drag & Drop)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Fehler in der Dateierweiterung."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Fehler in der Dateigröße."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Fehler in der Dateianzahl"
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init Fehler."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Fehler."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Sicherheitsfehler."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Allgemeiner Fehler."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO Fehler."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Datei: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d Dateien in der Warteschlange"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Datei: %f, Größe: %s, Maximale Dateigröße: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload-URL scheint falsch zu sein oder existiert nicht"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Fehler: Datei zu groß: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Fehler: ungültige Dateierweiterung: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Standard festlegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Eintrag erstellen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Verlaufsprotokoll bearbeiten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Keine Sendung"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s Reihen%s in die Zwischenablage kopiert"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sDruckansicht%sBenutzen sie bitte die Druckfunktion des Browsers, um diese Tabelle auszudrucken. Wenn sie fertig sind, drücken sie die Escape-Taste."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Cursor wählen"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Cursor entfernen"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "Sendung existiert nicht"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Wiederholung der Sendung %s vom %s um %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Cursor wählen"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Cursor entfernen"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "Sendung existiert nicht"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Benutzer erfolgreich hinzugefügt!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Benutzer erfolgreich aktualisiert!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Einstellungen erfolgreich aktualisiert!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Unbenannter Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream gespeichert."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Ungültige Formularwerte."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Das Jahr %s muß im Bereich zwischen 1753 und 9999 sein"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s ist kein gültiges Datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s-%s-%s ist kein gültiger Zeitpunkt."
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Play"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Set Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Set Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Teilen"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Stream wählen:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "Stummschalten"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "Lautschalten"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Über"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Für weitere ausführliche Hilfe, lesen sie bitte das %sBenutzerhandbuch%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout Verlauf"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Protokoll"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Dateiübersicht"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Sendungsübersicht"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Statischen Block erweitern"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Dynamischen Block erweitern"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Name:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Beschreibung:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Dauer:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Playlist mischen"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Mischen"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist Crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Playlist leeren"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Leeren"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade In: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Playlist speichern"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Keine Playlist geöffnet"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Wellenform anzeigen"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Originallänge:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Stream Einstellungen"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Anmeldung"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Neues Passwort"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Bitte geben sie Ihr neues Passwort ein und bestätigen es im folgenden Feld."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Benutzer verwalten"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Neuer Benutzer"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "ID"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Benutzername"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Vorname"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Nachname"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Benutzertyp"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Suche Sendungen"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Folge wählen"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Finden"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Wiederholen Tage:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Entfernen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Hinzufüg."
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Show Source"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime registrieren"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Erforderlich)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(Ausschließlich zu Kontrollzwecken, wird nicht veröffentlicht)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Hinweis: Grafiken, die größer als 600x600 sind, werden verkleinert."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Zeige mir was ich sende "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Allgemeine Geschäftsbedingungen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Tage wählen:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "oder"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "und"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " bis "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "Dateien entsprechen den Kriterien"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter Verlauf"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Um ihre Radiostation bewerben zu können, muß 'Support Feedback senden' aktiviert sein)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Erweiterte Optionen"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Die folgenden Informationen werden den Zuhörern in ihren Playern angezeigt:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Webseite Ihres Radiosenders)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Ordner wählen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Festlegen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktueller Import Ordner:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Überwachten Ordner entfernen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Sie überwachen keine Medienordner."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master Source"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Einstellungen"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Sendung hinzufügen"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Sendung aktualisieren"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Was"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Wann"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live Stream Input"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Wer"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Farbe"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Speicherplatz"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Datei-Import in Bearbeitung..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Erweiterte Suchoptionen"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Titel:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Interpret:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Titel-Nr.:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Länge:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Samplerate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bitrate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Stimmung:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Jahr:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Komponist:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dirigent:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC-Nr.:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Webseite:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Sprache:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Dateipfad:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamischer Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statischer Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Titel-Nr."
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Playlist Inhalt: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statischer Smart Block Inhalt: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamische Smart Block Kriterien: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Beschränken auf "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Ihre Testperiode endet in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "Tage"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Zuvor:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Danach:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Source Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Anhören"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Abmelden"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Protokollvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Neue Protokollvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Keine Protokollvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Dateiübersichtsvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Neue Dateiübersichtsvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Keine Dateiübersichtsvorlagen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Erstelle Dateiübersichtsvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Erstelle Protokollvorlage"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Name"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Weitere Elemente hinzufügen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Neues Feld hinzufügen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Standardvorlage wählen"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Beschreibung"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Standard Dauer:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Kein Webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Hilfe"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Seite nicht gefunden!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Scheinbar existiert die Seite die sie suchen nicht!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "zurück"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "Wiedergabe"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "Pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "weiter"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "Maximale Lautstärke"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Update erforderlich"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Um die Medien zu spielen, müssen sie entweder Ihren Browser oder Ihr %s Flash-Plugin %s aktualisieren."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Zeitpunkt Beginn:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3016,127 +2518,6 @@ msgstr "Zeitpunkt Beginn:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Ungültiges Zeichen eingegeben"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Zeitpunkt Ende:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Alle meine Sendungen:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Suche Benutzer:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Sendername"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-Mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Sender-Webseite:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Land:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Stadt:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Sender Beschreibung:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Sender Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Sie müssen die Datenschutzrichtlinien akzeptieren."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Aufzeichnen von Line-In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Wiederholen?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Wert ist erforderlich und darf nicht leer sein"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' ist keine gültige E-Mail-Adresse im Format local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' entspricht nicht dem erforderlichen Datumsformat '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' ist kürzer als %min% Zeichen lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' ist mehr als %max% Zeichen lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' liegt nicht zwischen '%min%' und '%max%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Passwörter stimmen nicht überein"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3153,675 +2534,55 @@ msgstr "Zeit muß angegeben werden"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Passwort zurücksetzen"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Unbenannte Sendung"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC-Nr.:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Standard Crossfade Dauer (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Standard Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Standard Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Deaktiviert"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Aktiviert"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Sendestation Zeitzone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Woche beginnt am"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Benutzername:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Passwort:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Passwort bestätigen:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Vorname:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Nachname:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobiltelefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Benutzertyp:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Benutzername ist bereits vorhanden."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Import Verzeichnis:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Überwachte Verzeichnisse:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Kein gültiges Verzeichnis"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Standard Lizenz:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Alle Rechte vorbehalten"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Die Rechte an dieser Arbeit sind gemeinfrei"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "[CC-BY] Creative Commons Namensnennung"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "[CC-BY-NC] Creative Commons Namensnennung, keine kommerzielle Nutzung"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "[CC-BY-ND] Creative Commons Namensnennung, keine Bearbeitung"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "[CC-BY-SA] Creative Commons Namensnennung, Weitergabe unter gleichen Bedingungen"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "[CC-BY-NC-ND] Creative Commons Namensnennung, keine kommerzielle Nutzung, keine Bearbeitung"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "[CC-BY-NC-SA] Creative Commons Namensnennung, keine kommerzielle Nutzung, Weitergabe unter gleichen Bedingungen"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface Zeitzone:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Jetzt"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr " - Kriterien - "
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "Stunden"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "Minuten"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "Titel"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statisch"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamisch"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Playlist-Inhalt erstellen und Kriterien speichern"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Erstellen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Inhalt der Playlist Mischen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Beschränkung kann nicht leer oder kleiner als 0 sein"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Beschränkung kann nicht größer als 24 Stunden sein"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Der Wert muß eine ganze Zahl sein"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Die Anzahl der Objekte ist auf 500 beschränkt"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Sie müssen Kriterium und Modifikator bestimmen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "Die 'Dauer' muß im Format '00:00:00' eingegeben werden"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Der Wert muß im Timestamp-Format eingegeben werden (zB. 0000-00-00 oder 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Der eingegebene Wert muß aus Ziffern bestehen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Der eingegebene Wert muß kleiner sein als 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Der eingegebene Wert muß aus weniger als %s Zeichen bestehen."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Der Wert darf nicht leer sein"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Streambezeichnung:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artist - Titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Sendung - Artist - Titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Sender - Sendung"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadaten"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Replay Gain aktivieren"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifikator"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Passwort"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Neues Passwort bestätigen"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Passwortbestätigung stimmt nicht mit Passwort überein."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Aktiviert:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Typ:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Typ:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanäle:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Es sind nur Zahlen erlaubt"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin Benutzer"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Passwort"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server darf nicht leer sein."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port darf nicht leer sein."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount darf nicht leer sein, wenn Icecast-Server verwendet wird."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' ist nicht im Format 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Zeitzone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Wiederholungen?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Es kann keine Sendung für einen vergangenen Zeitpunkt geplant werden"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Startdatum/Zeit können nicht geändert werden, wenn die Sendung bereits begonnen hat."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Datum/Uhrzeit des Endes darf nicht in der Vergangenheit liegen"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Die Dauer einer Sendung kann nicht kürzer als 0 Minuten sein."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Die Dauer einer Sendung kann nicht 00h 00m sein"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Die Dauer einer Sendung kann nicht länger als 24h sein"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Benutzerdefiniertes Login:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Benutzerdefinierter Benutzername"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Benutzerdefiniertes Passwort"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Das Feld Benutzername darf nicht leer sein."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Das Feld Passwort darf nicht leer sein."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Hintergrundfarbe:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Textfarbe:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Geben sie die Zeichen aus dem Bild unten ein."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "Tage"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3867,6 +2628,12 @@ msgstr "Tag des Monats"
 msgid "day of the week"
 msgstr "Tag der Woche"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Zeitpunkt Ende:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Kein Enddatum?"
@@ -3879,115 +2646,1174 @@ msgstr "Enddatum muß nach dem Startdatum liegen"
 msgid "Please select a repeat day"
 msgstr "Bitte einen Tag zum Wiederholen wählen"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Aufzeichnen von Line-In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Wiederholen?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Hintergrundfarbe:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Textfarbe:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalender"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Entfernen"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Benutzer"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Name:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Unbenannte Sendung"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Beschreibung:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Hörerstatistiken"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' ist nicht im Format 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Verlaufsvorlagen"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Dauer:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Zeitzone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Wiederholungen?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Es kann keine Sendung für einen vergangenen Zeitpunkt geplant werden"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Startdatum/Zeit können nicht geändert werden, wenn die Sendung bereits begonnen hat."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Datum/Uhrzeit des Endes darf nicht in der Vergangenheit liegen"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Die Dauer einer Sendung kann nicht kürzer als 0 Minuten sein."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Die Dauer einer Sendung kann nicht 00h 00m sein"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Die Dauer einer Sendung kann nicht länger als 24h sein"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Sendungen können nicht überlappend geplant werden."
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Suche Benutzer:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Benutzername:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Passwort:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Passwort bestätigen:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Vorname:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Nachname:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-Mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobiltelefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Benutzertyp:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Benutzername ist bereits vorhanden."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Kurzanleitung"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Benutzerhandbuch"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Wert ist erforderlich und darf nicht leer sein"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Zeitpunkt Beginn:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Titel:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Interpret:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Jahr:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Komponist:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dirigent:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Stimmung:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC-Nr.:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Webseite:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Sprache:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Startzeit"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Endzeit"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface Zeitzone:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Sendername"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Sender Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Hinweis: Grafiken, die größer als 600x600 sind, werden verkleinert."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Standard Crossfade Dauer (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Standard Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Standard Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Aktiviert"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Sendestation Zeitzone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Woche beginnt am"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' ist keine gültige E-Mail-Adresse im Format local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' entspricht nicht dem erforderlichen Datumsformat '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' ist kürzer als %min% Zeichen lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' ist mehr als %max% Zeichen lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' liegt nicht zwischen '%min%' und '%max%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Passwörter stimmen nicht überein"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Es sind nur Zahlen erlaubt"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Anmeldung"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Geben sie die Zeichen aus dem Bild unten ein."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Passwort"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Neues Passwort bestätigen"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Passwortbestätigung stimmt nicht mit Passwort überein."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Benutzername"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Passwort zurücksetzen"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Jetzt"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Sender-Webseite:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Land:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Stadt:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Sender Beschreibung:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Sie müssen die Datenschutzrichtlinien akzeptieren."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Alle meine Sendungen:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr " - Kriterien - "
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Beschreibung"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "Stunden"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "Minuten"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "Titel"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statisch"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamisch"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Playlist-Inhalt erstellen und Kriterien speichern"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Erstellen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Inhalt der Playlist Mischen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Mischen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Beschränkung kann nicht leer oder kleiner als 0 sein"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Beschränkung kann nicht größer als 24 Stunden sein"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Der Wert muß eine ganze Zahl sein"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Die Anzahl der Objekte ist auf 500 beschränkt"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Sie müssen Kriterium und Modifikator bestimmen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "Die 'Dauer' muß im Format '00:00:00' eingegeben werden"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Der Wert muß im Timestamp-Format eingegeben werden (zB. 0000-00-00 oder 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Der eingegebene Wert muß aus Ziffern bestehen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Der eingegebene Wert muß kleiner sein als 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Der eingegebene Wert muß aus weniger als %s Zeichen bestehen."
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Der Wert darf nicht leer sein"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Standard Lizenz:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Alle Rechte vorbehalten"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Die Rechte an dieser Arbeit sind gemeinfrei"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "[CC-BY] Creative Commons Namensnennung"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "[CC-BY-NC] Creative Commons Namensnennung, keine kommerzielle Nutzung"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "[CC-BY-ND] Creative Commons Namensnennung, keine Bearbeitung"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "[CC-BY-SA] Creative Commons Namensnennung, Weitergabe unter gleichen Bedingungen"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "[CC-BY-NC-ND] Creative Commons Namensnennung, keine kommerzielle Nutzung, keine Bearbeitung"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "[CC-BY-NC-SA] Creative Commons Namensnennung, keine kommerzielle Nutzung, Weitergabe unter gleichen Bedingungen"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Streambezeichnung:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artist - Titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Sendung - Artist - Titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Sender - Sendung"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadaten"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Replay Gain aktivieren"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifikator"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Aktiviert:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Typ:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bitrate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Typ:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanäle:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Name"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin Benutzer"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Passwort"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server darf nicht leer sein."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port darf nicht leer sein."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount darf nicht leer sein, wenn Icecast-Server verwendet wird."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Import Verzeichnis:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Überwachte Verzeichnisse:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Kein gültiges Verzeichnis"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Play"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Set Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Set Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue In und Cue Out sind Null."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Cue In darf nicht größer als die Gesamtlänge der Datei sein."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Cue In darf nicht größer als Cue Out sein."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Cue Out darf nicht kleiner als Cue In sein."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Wiederholung der Sendung %s von %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Land wählen"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4012,14 +3838,12 @@ msgstr "%s ist kein gültiges Verzeichnis."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Liste überwachter Verzeichnisse"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Liste überwachter Verzeichnisse."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4027,28 +3851,18 @@ msgstr "%s ist bereits als aktuelles Speicherverzeichnis bestimmt oder in der Li
 msgid "%s doesn't exist in the watched list."
 msgstr "%s existiert nicht in der Liste überwachter Verzeichnisse."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Land wählen"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Die Maximaldauer einer Sendung beträgt 24 Stunden."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Sendungen können nicht überlappend geplant werden.\nBeachte: Wird die Dauer einer wiederkehrenden Sendung verändert, wirkt sich das auch auf alle Wiederholungen aus."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4063,48 +3877,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Der Kalender den sie sehen ist nicht mehr aktuell! (Instanz falsch zugeordnet)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Der Kalender den sie sehen ist nicht mehr aktuell!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Sie haben nicht die erforderliche Berechtigung einen Termin für die Sendung %s zu festzulegen."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Einer Sendungsaufzeichnung können keine Dateien hinzugefügt werden."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Die Sendung %s ist beendet und kann daher nicht verändert werden."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Die Sendung %s wurde bereits aktualisiert!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Inhalte in verknüpften Sendungen können nicht während der Sendung geändert werden"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Eine der gewählten Dateien existiert nicht!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Die Maximaldauer einer Sendung beträgt 24 Stunden."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Sendungen können nicht überlappend geplant werden.\n"
+"Beachte: Wird die Dauer einer wiederkehrenden Sendung verändert, wirkt sich das auch auf alle Wiederholungen aus."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Wiederholung der Sendung %s von %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4151,8 +3977,1049 @@ msgstr "Ungültiger Webstream - Die eingegebene URL scheint ein Dateidownload zu
 msgid "Unrecognized stream type: %s"
 msgstr "Unbekannter Stream-Typ: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Aufzeichnung existiert nicht"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Metadaten der aufgezeichneten Datei anzeigen"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Ändern"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Sendung ändern"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Zugriff verweigert"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Wiederkehrende Sendungen können nicht per Drag'n'Drop verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Eine in der Vergangenheit liegende Sendung kann nicht verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Eine Sendung kann nicht in die Vergangenheit verschoben werden."
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Eine aufgezeichnete Sendung kann nicht verschoben werden, wenn der Zeitpunkt der Wiederholung weniger als eine Stunde bevor liegt."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Die Sendung wurde gelöscht, weil die aufgezeichnete Sendung nicht existiert!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Das Wiederholen einer Sendung ist erst nach einer Stunde Wartezeit möglich."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Titel"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Abgespielt"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "zurück"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "Wiedergabe"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "Pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "weiter"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "Stummschalten"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "Lautschalten"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "Maximale Lautstärke"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Update erforderlich"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Um die Medien zu spielen, müssen sie entweder Ihren Browser oder Ihr %s Flash-Plugin %s aktualisieren."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Über"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Für weitere ausführliche Hilfe, lesen sie bitte das %sBenutzerhandbuch%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Teilen"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Stream wählen:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Seite nicht gefunden!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Scheinbar existiert die Seite die sie suchen nicht!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Show Source"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Tage wählen:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Hinzufüg."
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Wiederholen Tage:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter Verlauf"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Folge wählen"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Finden"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Einstellungen"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master Source"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Ordner wählen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Festlegen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktueller Import Ordner:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Überwachten Ordner entfernen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Sie überwachen keine Medienordner."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime registrieren"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Erforderlich)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(Ausschließlich zu Kontrollzwecken, wird nicht veröffentlicht)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Zeige mir was ich sende "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Allgemeine Geschäftsbedingungen"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Suche Sendungen"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "oder"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "und"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " bis "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "Dateien entsprechen den Kriterien"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Erweiterte Optionen"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Die folgenden Informationen werden den Zuhörern in ihren Playern angezeigt:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Webseite Ihres Radiosenders)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Um ihre Radiostation bewerben zu können, muß 'Support Feedback senden' aktiviert sein)"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Titel-Nr.:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Länge:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Samplerate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC-Nr.:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Dateipfad:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamischer Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statischer Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Titel-Nr."
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Playlist Inhalt: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statischer Smart Block Inhalt: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamische Smart Block Kriterien: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Beschränken auf "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Datei-Import in Bearbeitung..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Erweiterte Suchoptionen"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Neues Passwort"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Bitte geben sie Ihr neues Passwort ein und bestätigen es im folgenden Feld."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Zuvor:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Danach:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Source Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Anhören"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Abmelden"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Ihre Testperiode endet in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Playlist mischen"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist Crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Playlist leeren"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Leeren"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Playlist speichern"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Keine Playlist geöffnet"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Wellenform anzeigen"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Originallänge:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade In: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Statischen Block erweitern"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Dynamischen Block erweitern"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Protokoll"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Dateiübersicht"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Sendungsübersicht"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Protokollvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Neue Protokollvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Keine Protokollvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Dateiübersichtsvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Neue Dateiübersichtsvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Keine Dateiübersichtsvorlagen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Erstelle Dateiübersichtsvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Erstelle Protokollvorlage"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Weitere Elemente hinzufügen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Neues Feld hinzufügen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Standardvorlage wählen"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Stream Einstellungen"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Sendung hinzufügen"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Sendung aktualisieren"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Was"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Wann"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live Stream Input"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Wer"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Farbe"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Speicherplatz"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Benutzer verwalten"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Neuer Benutzer"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "ID"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Vorname"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Nachname"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Benutzertyp"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Standard Dauer:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Kein Webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "Bitte geben sie eine Zeit in Sekunden ein '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Inhalte in verknüpften Sendungen können nicht während der Sendung geändert werden"

--- a/airtime_mvc/locale/de_DE/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/de_DE/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/el_GR/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Katerina Michailidi <katerina.michailidis@sourcefabric.org>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2013
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Greek (Greece) (http://www.transifex.com/sourcefabric/airtime/language/el_GR/)\n"
+"Language: el_GR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el_GR\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Το αρχείο δεν υπάρχει"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Το έτος %s πρέπει να είναι εντός του εύρους 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Προβολή εγγεγραμμένων Αρχείων Μεταδεδομένων "
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s δεν αποτελεί έγκυρη ημερομηνία"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s : %s : %s δεν αποτελεί έγκυρη ώρα"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Επεξεργασία"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Επεξεργασία Εκπομπής"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Διαγραφή"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Δεν έχετε δικαίωμα πρόσβασης"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Δεν είναι δυνατό το drag and drop επαναλαμβανόμενων εκπομπών"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Δεν είναι δυνατή η μετακίνηση περασμένης εκπομπής"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Δεν είναι δυνατή η μετακίνηση εκπομπής στο παρελθόν"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Δεν είναι δυνατός ο προγραμματισμός αλληλοεπικαλυπτόμενων εκπομπών"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Δεν είναι δυνατή η μετακίνηση ηχογραφημένης εκπομπής σε λιγότερο από 1 ώρα πριν από την αναμετάδοση της."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Η εκπομπή διεγράφη επειδή δεν υπάρχει ηχογραφημένη εκπομπή!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Πρέπει να περιμένετε 1 ώρα για την αναμετάδοση."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Τίτλος"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Δημιουργός"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Διάρκεια"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Είδος"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Διάθεση"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Εταιρεία"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Συνθέτης"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Έτος"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Κομμάτι"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Ενορχήστρωση"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Γλώσσα"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Ώρα Έναρξης"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Ώρα Τέλους"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Παίχτηκε"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Ημερολόγιο"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Xρήστες"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Κατάσταση"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Ιστορικό Playout"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Ιστορικό Template"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Στατιστικές Ακροατών"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Βοήθεια"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Έναρξη"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Εγχειρίδιο Χρήστη"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Δεν έχετε δικαίωμα πρόσβασης σε αυτό το βοήθημα"
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Δεν έχετε δικαίωμα πρόσβασης σε αυτό το βοήθημα. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Λανθασμένο αίτημα. Η παράμετρος «κατάσταση» δεν πέρασε."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Λανθασμένο αίτημα. Η παράμετρος «κατάσταση» δεν είναι έγκυρη"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Δεν έχετε άδεια για αποσύνδεση πηγής."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Δεν υπάρχει καμία πηγή που είναι συνδεδεμένη σε αυτή την είσοδο."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Δεν έχετε άδεια για αλλαγή πηγής."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s δεν βρέθηκε"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Κάτι πήγε στραβά."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Προεπισκόπηση"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Προσθήκη στη λίστα αναπαραγωγής"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Προσθήκη στο Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Επεξεργασία Μεταδεδομένων"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Διαγραφή"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Λήψη"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Αντιγραφή Λίστας Αναπαραγωγής"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Καμία διαθέσιμη δράση"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Δεν έχετε άδεια διαγραφής των επιλεγμένων στοιχείων."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Αντιγραφή από %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Webstream χωρίς Τίτλο"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Το Webstream αποθηκεύτηκε."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Άκυρες μορφές αξίας."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Παρακαλούμε σιγουρευτείτε ότι ο χρήστης/κωδικός πρόσβασης διαχειριστή είναι σωστός στη σελίδα Σύστημα>Streams."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Ο χρήστης προστέθηκε επιτυχώς!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Αναπαραγωγή ήχου"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Ο χρήστης ενημερώθηκε με επιτυχία!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Οι ρυθμίσεις ενημερώθηκαν επιτυχώς!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Εγγραφή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Κύριο Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Τίποτα δεν έχει προγραμματιστεί"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Τρέχουσα Εκπομπή:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Τρέχουσα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Χρησιμοποιείτε την τελευταία έκδοση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Νέα έκδοση διαθέσιμη: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Αυτή η έκδοση θα παρωχηθεί σύντομα."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Αυτή η έκδοση δεν υποστηρίζεται πλέον."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Παρακαλούμε να αναβαθμίσετε σε "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Προσθήκη στην τρέχουσα λίστα αναπαραγωγής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Προσθήκη στο τρέχον smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Προσθήκη 1 Στοιχείου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Προσθήκη %s στοιχείου/ων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Μπορείτε να προσθέσετε μόνο κομμάτια στα smart blocks."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Μπορείτε να προσθέσετε μόνο κομμάτια, smart blocks και webstreams σε λίστες αναπαραγωγής."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Παρακαλούμε επιλέξτε μια θέση δρομέα στο χρονοδιάγραμμα."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Επεξεργασία Μεταδεδομένων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Προσθήκη στην επιλεγμένη εκπομπή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Επιλογή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Επιλέξτε αυτή τη σελίδα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Καταργήστε αυτήν την σελίδα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Κατάργηση όλων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το επιλεγμένο στοιχείο/α;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Προγραμματισμένο"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Τίτλος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Δημιουργός"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Ρυθμός Bit:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Συνθέτης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Ενορχήστρωση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Κωδικοποιήθηκε από"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Είδος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Εταιρεία"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Γλώσσα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Τελευταία τροποποίηση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Τελευταία αναπαραγωγή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Διάρκεια"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Μίμος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Διάθεση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Ιδιοκτήτης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Κέρδος Επανάληψης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Ρυθμός δειγματοληψίας"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Αριθμός Κομματιού"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Φορτώθηκε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Ιστοσελίδα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Έτος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Φόρτωση..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Όλα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Αρχεία"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Λίστες αναπαραγωγής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Άγνωστος τύπος: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το επιλεγμένο στοιχείο;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Ανέβασμα σε εξέλιξη..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Ανάκτηση δεδομένων από τον διακομιστή..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Η ταυτότητα SoundCloud για αυτό το αρχείο είναι: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Υπήρξε ένα σφάλμα κατά το ανέβασμα στο SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Κωδικός σφάλματος: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Μήνυμα σφάλματος: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Το input πρέπει να είναι θετικός αριθμός"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Το input πρέπει να είναι αριθμός"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Το input πρέπει να είναι υπό μορφής: εεεε-μμ-ηη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Το input πρέπει να είναι υπό μορφής: ωω: λλ: ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Προς το παρόν ανεβάζετε αρχεία. %sΠηγαίνοντας σε μια άλλη οθόνη θα ακυρώσετε τη διαδικασία του ανεβάσματος.%sΕίστε σίγουροι ότι θέλετε να εγκαταλείψετε τη σελίδα;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Άνοιγμα Δημιουργού Πολυμέσων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "παρακαλούμε εισάγετε τιμή ώρας '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Ο περιηγητής ιστού σας δεν υποστηρίζει την αναπαραγωγή αρχείων αυτού του τύπου: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Αδύνατη η προεπισκόπιση του δυναμικού block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Όριο για: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Οι λίστες αναπαραγωγής αποθηκεύτηκαν"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Ανασχηματισμός λίστας αναπαραγωγής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "To Airtime είναι αβέβαιο για την κατάσταση αυτού του αρχείου. Αυτό μπορεί να συμβεί όταν το αρχείο είναι σε μια απομακρυσμένη μονάδα δίσκου που είναι απροσπέλαστη ή το αρχείο είναι σε ευρετήριο που δεν «προβάλλεται» πια."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Καταμέτρηση Ακροατών για %s : %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Υπενθύμιση σε 1 εβδομάδα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Καμία υπενθύμιση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Ναι, βοηθώ το Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Η εικόνα πρέπει να είναι jpg, jpeg, png ή gif "
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Ένα στατικό smart block θα αποθηκεύσει τα κριτήρια και θα δημιουργήσει αμέσως το περιεχόμενο του block. Αυτό σας επιτρέπει να το επεξεργαστείτε και να το προβάλεται στη Βιβλιοθήκη πριν το προσθέσετε σε μια εκπομπή."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Ένα στατικό smart block θα αποθηκεύσει μόνο τα κριτήρια. Το περιεχόμενο του block θα δημιουργηθεί κατά την προσθήκη του σε μια εκπομπή. Δεν θα μπορείτε να δείτε και να επεξεργαστείτε το περιεχόμενο στη Βιβλιοθήκη."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Η επιθυμητή διάρκεια του block δεν θα επιτευχθεί αν το Airtime δεν μπορέσει να βρεί αρκετά μοναδικά κομμάτια που να ταιριάζουν στα κριτήριά σας. Ενεργοποιήστε αυτή την επιλογή αν θέλετε να επιτρέψετε την πολλαπλή προσθήκη κομματιών στο smart block."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Το Smart block δημιουργήθηκε και τα κριτήρια αποθηκεύτηκαν"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Το Smart block αποθηκεύτηκε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Επεξεργασία..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Επιλέξτε τροποποιητή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "περιέχει"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "δεν περιέχει"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "είναι"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "δεν είναι"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "ξεκινά με"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "τελειώνει με"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "είναι μεγαλύτερος από"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "είναι μικρότερος από"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "είναι στην κλίμακα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Επιλογή Φακέλου Αποθήκευσης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Επιλογή Φακέλου για Προβολή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Είστε βέβαιοι ότι θέλετε να αλλάξετε το φάκελο αποθήκευσης;\n"
+"Αυτό θα αφαιρέσει τα αρχεία από τη βιβλιοθήκη του Airtime!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Διαχείριση Φακέλων Πολυμέσων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Είστε βέβαιοι ότι θέλετε να αφαιρέσετε το φάκελο που προβάλλεται;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Αυτή η διαδρομή δεν είναι προς το παρόν προσβάσιμη."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Κάποιοι τύποι stream απαιτούν επιπλέον ρυθμίσεις. Λεπτομέρειες για την ενεργοποίηση %sAAC+ Support%s ή %sOpus Support%s παρέχονται."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Συνδέθηκε με τον διακομιστή streaming "
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Το stream είναι απενεργοποιημένο"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Λήψη πληροφοριών από το διακομιστή..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Αδύνατη η σύνδεση με τον διακομιστή streaming "
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Αν το Airtime είναι πίσω από ένα τείχος προστασίας ή router, ίσως χρειαστεί να ρυθμίσετε την προώθηση port και οι πληροφορίες πεδίου θα είναι λανθασμένες. Σε αυτή την περίπτωση θα πρέπει να ενημερώσετε αυτό το πεδίο, ώστε να δείχνει το σωστό host/port/mount που χρειάζονται οι DJ σας για να συνδεθούν. Το επιτρεπόμενο εύρος είναι μεταξύ 1024 και 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Για περισσότερες λεπτομέρειες, παρακαλούμε διαβάστε το %sAirtime Εγχειρίδιο%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Τσεκάρετε αυτή την επιλογή για να ενεργοποιήσετε τα μεταδεδομένα για OGG streams (τα stream μεταδεδομένα είναι ο τίτλος του κομματιού και του καλλιτέχνη, που εμφανίζονται σε ένα audio player). VLC και mplayer προκαλούν βλάβες κατά την αναπαραγωγή ενός OGG / Vorbis stream, το οποίο έχει ενεργοποιημένες τις πληροφορίες μεταδεδομένων: θα αποσυνδέονται από το stream μετά από κάθε κομμάτι. Εάν χρησιμοποιείτε ένα OGG stream και οι ακροατές σας δεν απαιτούν υποστήριξη για αυτές τις συσκευές αναπαραγωγής ήχου, τότε μπορείτε να ενεργοποιήσετε αυτή την επιλογή."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Επιλέξτε αυτό το πλαίσιο για να σβήσει αυτόματα η Κύρια/Εμφάνιση πηγής κατά την αποσύνδεση πηγής."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Επιλέξτε αυτό το πλαίσιο για να ενεργοποιηθεί αυτόματα η η Κύρια/Εμφάνιση πηγής κατά την σύνδεση πηγής."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Εάν ο διακομιστής Icecast περιμένει ένα όνομα χρήστη από την «πηγή», αυτό το πεδίο μπορεί να μείνει κενό."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Εάν ο live streaming πελάτη σας δεν ζητά ένα όνομα χρήστη, το πεδίο αυτό θα πρέπει να είναι η «πηγή»."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Αυτό είναι το Icecast/SHOUTcast όνομα χρήστη και ο κωδικός πρόσβασης διαχειριστή για τις στατιστικές ακροατών."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Προειδοποίηση: Δεν μπορείτε να κάνετε αλλαγές κατά την διάρκεια της εκπομπής "
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Δεν βρέθηκαν αποτελέσματα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Αυτό ακολουθεί το ίδιο πρότυπο ασφαλείας για τις εκπομπές: μόνο οι χρήστες της συγκεκριμένης εκπομπής μπορούν να συνδεθούν."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Καθορίστε την προσαρμόσιμη πιστοποίηση, η οποία θα λειτουργήσει μόνο για αυτή την εκπομπή."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Η εκπομπή δεν υπάρχει πια!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Προειδοποίηση: οι εκπομπές δεν μπορούν να συνδεθούν εκ νέου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Κατά τη διασύνδεση επαναλαμβανόμενων εκπομπών, όλα τα προγραμματισμένα στοιχεία πολυμέσων κάθε εκπομπής θα προγραμματιστούν σε όλες τις επαναλαμβανόμενες εκπομπές"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Η ζώνη ώρας είναι ρυθμισμένη ανάλογα με τη τοποθεσία του σταθμού. Οι εκμπομπές θα μεταδίδονται στην τοπική ώρα, ρυθμισμένη από το Interface Ζώνης ώρας στις ρυθμίσεις χρήστη "
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Εκπομπή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Η εκπομπή είναι άδεια"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60λ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Ανάκτηση δεδομένων από το διακομιστή..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Αυτή η εκπομπή δεν έχει προγραμματισμένο περιεχόμενο."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Η εκπομπή δεν εντελώς γεμάτη με περιεχόμενο "
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Ιανουάριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Φεβρουάριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Μάρτιος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Απρίλης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Μάιος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Ιούνιος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Ιούλιος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Αύγουστος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Σεπτέμβριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Οκτώβριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Νοέμβριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Δεκέμβριος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Ιαν"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Φεβ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Μαρ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Απρ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Ιουν"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Ιουλ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Αυγ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Σεπ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Οκτ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Νοε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Δεκ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Κυριακή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Δευτέρα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Τρίτη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Τετάρτη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Πέμπτη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Παρασκευή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Σάββατο"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Κυρ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Δευ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Τρι"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Τετ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Πεμ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Παρ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Σαβ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Εκπομπές μεγαλύτερες από την προγραμματισμένη διάρκειά τους θα διακόπτονται από την επόμενη εκπομπή."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Ακύρωση Τρέχουσας Εκπομπής;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Πάυση ηχογράφησης τρέχουσας εκπομπής;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Οκ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Περιεχόμενα Εκπομπής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Αφαίρεση όλου του περιεχομένου;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Διαγραφή επιλεγμένου στοιχείου/ων;"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Έναρξη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Τέλος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Διάρκεια"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Η εκπομπή είναι άδεια"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Ηχογράφηση Από Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Προεπισκόπηση κομματιού"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Δεν είναι δυνατός ο προγραμματισμός εκτός εκπομπής."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Μετακίνηση 1 Στοιχείου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Μετακίνηση Στοιχείων %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Αποθήκευση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Ακύρωση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Επεξεργαστής Fade"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Επεξεργαστής Cue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Τα χαρακτηριστικά της κυμματοειδούς μορφής είναι διαθέσιμα σε πρόγραμμα πλοήγησης που υποστηρίζει Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Επιλογή όλων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Καμία Επιλογή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Αφαίρεση επιλεγμένων προγραμματισμένων στοιχείων "
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Μετάβαση στο τρέχον κομμάτι "
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Ακύρωση τρέχουσας εκπομπής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Άνοιγμα βιβλιοθήκης για προσθήκη ή αφαίρεση περιεχομένου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Προσθήκη / Αφαίρεση Περιεχομένου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "σε χρήση"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Δίσκος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Κοιτάξτε σε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Άνοιγμα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Διαχειριστής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Διευθυντής Προγράμματος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Επισκέπτης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Οι επισκέπτες μπορούν να κάνουν τα παρακάτω"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Προβολή Προγράμματος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Προβολή περιεχομένου εκπομπής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Οι DJ μπορούν να κάνουν τα παρακάτω"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Διαχείριση ανατεθημένου περιεχομένου εκπομπής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Εισαγωγή αρχείων πολυμέσων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Δημιουργία λιστών αναπαραγωγής, smart blocks, και webstreams "
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Διαχείριση δικού τους περιεχομένου βιβλιοθήκης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Οι Μάνατζερ Προγράμματος μπορούν να κάνουν τα παρακάτω:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Προβολή και διαχείριση περιεχομένου εκπομπής"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Πρόγραμμα εκπομπών"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Διαχείριση όλου του περιεχομένου βιβλιοθήκης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "ΟΙ Διαχειριστές μπορούν να κάνουν τα παρακάτω:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Διαχείριση προτιμήσεων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Διαχείριση Χρηστών"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Διαχείριση προβεβλημένων φακέλων "
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Αποστολή Σχολίων Υποστήριξης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Προβολή κατάστασης συστήματος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Πρόσβαση στην ιστορία playout"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Προβολή στατιστικών των ακροατών"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Εμφάνιση / απόκρυψη στηλών"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Από {από} σε {σε}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "Kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "εεεε-μμ-ηη"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "ωω:λλ:δδ.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Κυ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Δε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Τρ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Τε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Πε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Πα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Σα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Κλείσιμο"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Ώρα"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Λεπτό"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Ολοκληρώθηκε"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Επιλογή αρχείων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Προσθέστε αρχεία στην ουρά ανεβάσματος και κάντε κλίκ στο κουμπί έναρξης"
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Προσθήκη Αρχείων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Στάση Ανεβάσματος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Έναρξη ανεβάσματος"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Προσθήκη αρχείων"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Ανέβηκαν %d/%d αρχεία"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Σύρετε αρχεία εδώ."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Σφάλμα επέκτασης αρχείου."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Σφάλμα μεγέθους αρχείου."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Σφάλμα μέτρησης αρχείων."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Σφάλμα αρχικοποίησης."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Σφάλμα HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Σφάλμα ασφάλειας."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Γενικό σφάλμα."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Σφάλμα IO"
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Αρχείο: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d αρχεία σε αναμονή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Αρχείο: %f, μέγεθος: %s, μέγιστο μέγεθος αρχείου: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Το URL είτε είναι λάθος ή δεν υφίσταται"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Σφάλμα: Πολύ μεγάλο αρχείο: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Σφάλμα: Μη έγκυρη προέκταση αρχείου: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Ως Προεπιλογή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Δημιουργία Εισόδου"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Επεξεργασία Ιστορικού"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Καμία Εκπομπή"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Αντιγράφηκαν %s σειρές%s στο πρόχειρο"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sΕκτύπωση προβολής%sΠαρακαλούμε να χρησιμοποιείσετε την λειτουργία εκτύπωσης του περιηγητή σας για να τυπώσετε τον πίνακα. Όταν τελειώσετε πατήστε escape"
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Το e-mail δεν μπόρεσε να σταλεί. Ελέγξτε τις ρυθμίσεις email του διακομιστή σας και βεβαιωθείτε ότι έχει ρυθμιστεί σωστά."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Άκυρο όνομα χρήστη ή κωδικός πρόσβασης. Παρακαλώ δοκιμάστε ξανά."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "Δεν έχετε άδεια διαγραφής επιλεγμένων %
 msgid "You can only add tracks to smart block."
 msgstr "Μπορείτε να προσθέσετε κομμάτια μόνο σε smart block."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Μπορείτε να προσθέσετε μόνο κομμάτια, smart blocks και webstreams σε λίστες αναπαραγωγής."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Λίστα Αναπαραγωγλης χωρίς Τίτλο"
@@ -384,2627 +2414,88 @@ msgstr "Λίστα Αναπαραγωγλης χωρίς Τίτλο"
 msgid "Untitled Smart Block"
 msgstr "Smart Block χωρίς Τίτλο"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Άγνωστη λίστα αναπαραγωγής"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Δεν έχετε δικαίωμα πρόσβασης σε αυτό το βοήθημα"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Οι προτιμήσεις ενημερώθηκαν."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Η ρύθμιση υποστήριξης ενημερώθηκε."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Σχόλια Υποστήριξης"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Η Ρύθμιση Stream Ενημερώθηκε."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "η διαδρομή πρέπει να καθοριστεί"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Πρόβλημα με Liquidsoap ..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Δεν έχετε άδεια για αποσύνδεση πηγής."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Δεν υπάρχει καμία πηγή που είναι συνδεδεμένη σε αυτή την είσοδο."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Δεν έχετε άδεια για αλλαγή πηγής."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Άκυρο όνομα χρήστη ή κωδικός πρόσβασης. Παρακαλώ δοκιμάστε ξανά."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Το e-mail δεν μπόρεσε να σταλεί. Ελέγξτε τις ρυθμίσεις email του διακομιστή σας και βεβαιωθείτε ότι έχει ρυθμιστεί σωστά."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Δεν έχετε δικαίωμα πρόσβασης σε αυτό το βοήθημα. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Λανθασμένο αίτημα. Η παράμετρος «κατάσταση» δεν πέρασε."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Λανθασμένο αίτημα. Η παράμετρος «κατάσταση» δεν είναι έγκυρη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Αναπαραγωγή ήχου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Εγγραφή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Κύριο Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Τίποτα δεν έχει προγραμματιστεί"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Τρέχουσα Εκπομπή:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Τρέχουσα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Χρησιμοποιείτε την τελευταία έκδοση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Νέα έκδοση διαθέσιμη: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Αυτή η έκδοση θα παρωχηθεί σύντομα."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Αυτή η έκδοση δεν υποστηρίζεται πλέον."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Παρακαλούμε να αναβαθμίσετε σε "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Προσθήκη στην τρέχουσα λίστα αναπαραγωγής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Προσθήκη στο τρέχον smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Προσθήκη 1 Στοιχείου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Προσθήκη %s στοιχείου/ων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Μπορείτε να προσθέσετε μόνο κομμάτια στα smart blocks."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Παρακαλούμε επιλέξτε μια θέση δρομέα στο χρονοδιάγραμμα."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Προσθήκη στην επιλεγμένη εκπομπή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Επιλογή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Επιλέξτε αυτή τη σελίδα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Καταργήστε αυτήν την σελίδα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Κατάργηση όλων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το επιλεγμένο στοιχείο/α;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Προγραμματισμένο"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Ρυθμός Bit:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Κωδικοποιήθηκε από"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Τελευταία τροποποίηση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Τελευταία αναπαραγωγή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Μίμος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Ιδιοκτήτης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Κέρδος Επανάληψης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Ρυθμός δειγματοληψίας"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Αριθμός Κομματιού"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Φορτώθηκε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Ιστοσελίδα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Φόρτωση..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Όλα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Αρχεία"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Λίστες αναπαραγωγής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Άγνωστος τύπος: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Είστε σίγουροι ότι θέλετε να διαγράψετε το επιλεγμένο στοιχείο;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Ανέβασμα σε εξέλιξη..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Ανάκτηση δεδομένων από τον διακομιστή..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Η ταυτότητα SoundCloud για αυτό το αρχείο είναι: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Υπήρξε ένα σφάλμα κατά το ανέβασμα στο SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Κωδικός σφάλματος: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Μήνυμα σφάλματος: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Το input πρέπει να είναι θετικός αριθμός"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Το input πρέπει να είναι αριθμός"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Το input πρέπει να είναι υπό μορφής: εεεε-μμ-ηη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Το input πρέπει να είναι υπό μορφής: ωω: λλ: ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Προς το παρόν ανεβάζετε αρχεία. %sΠηγαίνοντας σε μια άλλη οθόνη θα ακυρώσετε τη διαδικασία του ανεβάσματος.%sΕίστε σίγουροι ότι θέλετε να εγκαταλείψετε τη σελίδα;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Άνοιγμα Δημιουργού Πολυμέσων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "παρακαλούμε εισάγετε τιμή ώρας '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "παρακαλούμε εισάγετε τιμή ώρας σε δευτερόλεπτα '00 (0,0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Ο περιηγητής ιστού σας δεν υποστηρίζει την αναπαραγωγή αρχείων αυτού του τύπου: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Αδύνατη η προεπισκόπιση του δυναμικού block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Όριο για: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Οι λίστες αναπαραγωγής αποθηκεύτηκαν"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Ανασχηματισμός λίστας αναπαραγωγής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "To Airtime είναι αβέβαιο για την κατάσταση αυτού του αρχείου. Αυτό μπορεί να συμβεί όταν το αρχείο είναι σε μια απομακρυσμένη μονάδα δίσκου που είναι απροσπέλαστη ή το αρχείο είναι σε ευρετήριο που δεν «προβάλλεται» πια."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Καταμέτρηση Ακροατών για %s : %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Υπενθύμιση σε 1 εβδομάδα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Καμία υπενθύμιση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Ναι, βοηθώ το Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Η εικόνα πρέπει να είναι jpg, jpeg, png ή gif "
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Ένα στατικό smart block θα αποθηκεύσει τα κριτήρια και θα δημιουργήσει αμέσως το περιεχόμενο του block. Αυτό σας επιτρέπει να το επεξεργαστείτε και να το προβάλεται στη Βιβλιοθήκη πριν το προσθέσετε σε μια εκπομπή."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Ένα στατικό smart block θα αποθηκεύσει μόνο τα κριτήρια. Το περιεχόμενο του block θα δημιουργηθεί κατά την προσθήκη του σε μια εκπομπή. Δεν θα μπορείτε να δείτε και να επεξεργαστείτε το περιεχόμενο στη Βιβλιοθήκη."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Η επιθυμητή διάρκεια του block δεν θα επιτευχθεί αν το Airtime δεν μπορέσει να βρεί αρκετά μοναδικά κομμάτια που να ταιριάζουν στα κριτήριά σας. Ενεργοποιήστε αυτή την επιλογή αν θέλετε να επιτρέψετε την πολλαπλή προσθήκη κομματιών στο smart block."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Το Smart block δημιουργήθηκε και τα κριτήρια αποθηκεύτηκαν"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Το Smart block αποθηκεύτηκε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Επεξεργασία..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Επιλέξτε τροποποιητή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "περιέχει"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "δεν περιέχει"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "είναι"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "δεν είναι"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "ξεκινά με"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "τελειώνει με"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "είναι μεγαλύτερος από"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "είναι μικρότερος από"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "είναι στην κλίμακα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Επιλογή Φακέλου Αποθήκευσης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Επιλογή Φακέλου για Προβολή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Είστε βέβαιοι ότι θέλετε να αλλάξετε το φάκελο αποθήκευσης;\nΑυτό θα αφαιρέσει τα αρχεία από τη βιβλιοθήκη του Airtime!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Διαχείριση Φακέλων Πολυμέσων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Είστε βέβαιοι ότι θέλετε να αφαιρέσετε το φάκελο που προβάλλεται;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Αυτή η διαδρομή δεν είναι προς το παρόν προσβάσιμη."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Κάποιοι τύποι stream απαιτούν επιπλέον ρυθμίσεις. Λεπτομέρειες για την ενεργοποίηση %sAAC+ Support%s ή %sOpus Support%s παρέχονται."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Συνδέθηκε με τον διακομιστή streaming "
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Το stream είναι απενεργοποιημένο"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Λήψη πληροφοριών από το διακομιστή..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Αδύνατη η σύνδεση με τον διακομιστή streaming "
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Αν το Airtime είναι πίσω από ένα τείχος προστασίας ή router, ίσως χρειαστεί να ρυθμίσετε την προώθηση port και οι πληροφορίες πεδίου θα είναι λανθασμένες. Σε αυτή την περίπτωση θα πρέπει να ενημερώσετε αυτό το πεδίο, ώστε να δείχνει το σωστό host/port/mount που χρειάζονται οι DJ σας για να συνδεθούν. Το επιτρεπόμενο εύρος είναι μεταξύ 1024 και 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Για περισσότερες λεπτομέρειες, παρακαλούμε διαβάστε το %sAirtime Εγχειρίδιο%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Τσεκάρετε αυτή την επιλογή για να ενεργοποιήσετε τα μεταδεδομένα για OGG streams (τα stream μεταδεδομένα είναι ο τίτλος του κομματιού και του καλλιτέχνη, που εμφανίζονται σε ένα audio player). VLC και mplayer προκαλούν βλάβες κατά την αναπαραγωγή ενός OGG / Vorbis stream, το οποίο έχει ενεργοποιημένες τις πληροφορίες μεταδεδομένων: θα αποσυνδέονται από το stream μετά από κάθε κομμάτι. Εάν χρησιμοποιείτε ένα OGG stream και οι ακροατές σας δεν απαιτούν υποστήριξη για αυτές τις συσκευές αναπαραγωγής ήχου, τότε μπορείτε να ενεργοποιήσετε αυτή την επιλογή."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Επιλέξτε αυτό το πλαίσιο για να σβήσει αυτόματα η Κύρια/Εμφάνιση πηγής κατά την αποσύνδεση πηγής."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Επιλέξτε αυτό το πλαίσιο για να ενεργοποιηθεί αυτόματα η η Κύρια/Εμφάνιση πηγής κατά την σύνδεση πηγής."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Εάν ο διακομιστής Icecast περιμένει ένα όνομα χρήστη από την «πηγή», αυτό το πεδίο μπορεί να μείνει κενό."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Εάν ο live streaming πελάτη σας δεν ζητά ένα όνομα χρήστη, το πεδίο αυτό θα πρέπει να είναι η «πηγή»."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Αυτό είναι το Icecast/SHOUTcast όνομα χρήστη και ο κωδικός πρόσβασης διαχειριστή για τις στατιστικές ακροατών."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Προειδοποίηση: Δεν μπορείτε να κάνετε αλλαγές κατά την διάρκεια της εκπομπής "
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Δεν βρέθηκαν αποτελέσματα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Αυτό ακολουθεί το ίδιο πρότυπο ασφαλείας για τις εκπομπές: μόνο οι χρήστες της συγκεκριμένης εκπομπής μπορούν να συνδεθούν."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Καθορίστε την προσαρμόσιμη πιστοποίηση, η οποία θα λειτουργήσει μόνο για αυτή την εκπομπή."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Η εκπομπή δεν υπάρχει πια!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Προειδοποίηση: οι εκπομπές δεν μπορούν να συνδεθούν εκ νέου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Κατά τη διασύνδεση επαναλαμβανόμενων εκπομπών, όλα τα προγραμματισμένα στοιχεία πολυμέσων κάθε εκπομπής θα προγραμματιστούν σε όλες τις επαναλαμβανόμενες εκπομπές"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Η ζώνη ώρας είναι ρυθμισμένη ανάλογα με τη τοποθεσία του σταθμού. Οι εκμπομπές θα μεταδίδονται στην τοπική ώρα, ρυθμισμένη από το Interface Ζώνης ώρας στις ρυθμίσεις χρήστη "
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Εκπομπή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Η εκπομπή είναι άδεια"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60λ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Ανάκτηση δεδομένων από το διακομιστή..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Αυτή η εκπομπή δεν έχει προγραμματισμένο περιεχόμενο."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Η εκπομπή δεν εντελώς γεμάτη με περιεχόμενο "
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Ιανουάριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Φεβρουάριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Μάρτιος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Απρίλης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Μάιος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Ιούνιος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Ιούλιος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Αύγουστος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Σεπτέμβριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Οκτώβριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Νοέμβριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Δεκέμβριος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Ιαν"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Φεβ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Μαρ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Απρ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Ιουν"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Ιουλ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Αυγ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Σεπ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Οκτ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Νοε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Δεκ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Κυριακή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Δευτέρα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Τρίτη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Τετάρτη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Πέμπτη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Παρασκευή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Σάββατο"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Κυρ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Δευ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Τρι"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Τετ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Πεμ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Παρ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Σαβ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Εκπομπές μεγαλύτερες από την προγραμματισμένη διάρκειά τους θα διακόπτονται από την επόμενη εκπομπή."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Ακύρωση Τρέχουσας Εκπομπής;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Πάυση ηχογράφησης τρέχουσας εκπομπής;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Οκ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Περιεχόμενα Εκπομπής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Αφαίρεση όλου του περιεχομένου;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Διαγραφή επιλεγμένου στοιχείου/ων;"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Έναρξη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Τέλος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Διάρκεια"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Η εκπομπή είναι άδεια"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Ηχογράφηση Από Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Προεπισκόπηση κομματιού"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Δεν είναι δυνατός ο προγραμματισμός εκτός εκπομπής."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Μετακίνηση 1 Στοιχείου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Μετακίνηση Στοιχείων %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Αποθήκευση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Ακύρωση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Επεξεργαστής Fade"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Επεξεργαστής Cue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Τα χαρακτηριστικά της κυμματοειδούς μορφής είναι διαθέσιμα σε πρόγραμμα πλοήγησης που υποστηρίζει Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Επιλογή όλων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Καμία Επιλογή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Αφαίρεση επιλεγμένων προγραμματισμένων στοιχείων "
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Μετάβαση στο τρέχον κομμάτι "
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Ακύρωση τρέχουσας εκπομπής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Άνοιγμα βιβλιοθήκης για προσθήκη ή αφαίρεση περιεχομένου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Προσθήκη / Αφαίρεση Περιεχομένου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "σε χρήση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Δίσκος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Κοιτάξτε σε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Άνοιγμα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Διαχειριστής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Διευθυντής Προγράμματος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Επισκέπτης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Οι επισκέπτες μπορούν να κάνουν τα παρακάτω"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Προβολή Προγράμματος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Προβολή περιεχομένου εκπομπής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Οι DJ μπορούν να κάνουν τα παρακάτω"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Διαχείριση ανατεθημένου περιεχομένου εκπομπής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Εισαγωγή αρχείων πολυμέσων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Δημιουργία λιστών αναπαραγωγής, smart blocks, και webstreams "
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Διαχείριση δικού τους περιεχομένου βιβλιοθήκης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Οι Μάνατζερ Προγράμματος μπορούν να κάνουν τα παρακάτω:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Προβολή και διαχείριση περιεχομένου εκπομπής"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Πρόγραμμα εκπομπών"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Διαχείριση όλου του περιεχομένου βιβλιοθήκης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "ΟΙ Διαχειριστές μπορούν να κάνουν τα παρακάτω:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Διαχείριση προτιμήσεων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Διαχείριση Χρηστών"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Διαχείριση προβεβλημένων φακέλων "
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Αποστολή Σχολίων Υποστήριξης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Προβολή κατάστασης συστήματος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Πρόσβαση στην ιστορία playout"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Προβολή στατιστικών των ακροατών"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Εμφάνιση / απόκρυψη στηλών"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Από {από} σε {σε}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "Kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "εεεε-μμ-ηη"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "ωω:λλ:δδ.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Κυ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Δε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Τρ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Τε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Πε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Πα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Σα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Κλείσιμο"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Ώρα"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Λεπτό"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Ολοκληρώθηκε"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Επιλογή αρχείων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Προσθέστε αρχεία στην ουρά ανεβάσματος και κάντε κλίκ στο κουμπί έναρξης"
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Κατάσταση"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Προσθήκη Αρχείων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Στάση Ανεβάσματος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Έναρξη ανεβάσματος"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Προσθήκη αρχείων"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Ανέβηκαν %d/%d αρχεία"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Σύρετε αρχεία εδώ."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Σφάλμα επέκτασης αρχείου."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Σφάλμα μεγέθους αρχείου."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Σφάλμα μέτρησης αρχείων."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Σφάλμα αρχικοποίησης."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Σφάλμα HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Σφάλμα ασφάλειας."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Γενικό σφάλμα."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Σφάλμα IO"
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Αρχείο: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d αρχεία σε αναμονή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Αρχείο: %f, μέγεθος: %s, μέγιστο μέγεθος αρχείου: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Το URL είτε είναι λάθος ή δεν υφίσταται"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Σφάλμα: Πολύ μεγάλο αρχείο: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Σφάλμα: Μη έγκυρη προέκταση αρχείου: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Ως Προεπιλογή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Δημιουργία Εισόδου"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Επεξεργασία Ιστορικού"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Καμία Εκπομπή"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Αντιγράφηκαν %s σειρές%s στο πρόχειρο"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sΕκτύπωση προβολής%sΠαρακαλούμε να χρησιμοποιείσετε την λειτουργία εκτύπωσης του περιηγητή σας για να τυπώσετε τον πίνακα. Όταν τελειώσετε πατήστε escape"
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Επιλέξτε cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Αφαίρεση cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "η εκπομπή δεν υπάρχει"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Αναμετάδοση της εκπομπής %s από %s σε %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Επιλέξτε cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Αφαίρεση cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "η εκπομπή δεν υπάρχει"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Ο χρήστης προστέθηκε επιτυχώς!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Ο χρήστης ενημερώθηκε με επιτυχία!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Οι ρυθμίσεις ενημερώθηκαν επιτυχώς!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Webstream χωρίς Τίτλο"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Το Webstream αποθηκεύτηκε."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Άκυρες μορφές αξίας."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Το έτος %s πρέπει να είναι εντός του εύρους 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s δεν αποτελεί έγκυρη ημερομηνία"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s : %s : %s δεν αποτελεί έγκυρη ώρα"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Ζωντανό Stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Αναπαραγωγή"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Παύση"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Ρύθμιση Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Ρύθμιση Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Μοιραστείτε"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Επιλέξτε stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "Σίγαση"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "Κατάργηση σίγασης"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Σχετικά"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Για περισσότερες αναλυτικές οδηγίες, διαβάστε το %sεγχειρίδιο%s ."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Ιστορικό Playout"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Σελίδα Σύνδεσης"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Περίληψη Αρχείων"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Προβολή Περίληψης"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Επέκταση Στατικών Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Επέκταση Δυναμικών Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Όνομα:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Περιγραφή:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Διάρκεια:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle λίστα αναπαραγωγής"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Crossfade λίστας αναπαραγωγής"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Άδειασμα περιεχομένου λίστας αναπαραγωγής"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Εκκαθάριση"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Αποθήκευση λίστας αναπαραγωγής"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Καμία ανοικτή λίστα αναπαραγωγής"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Εμφάνιση κυμματοειδούς μορφής"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(Ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(ωω:λλ:δδ.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Αρχική Διάρκεια:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Ρυθμίσεις Stream"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "βΔ"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Σύνδεση"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Νέος κωδικός πρόσβασης"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Παρακαλώ εισάγετε και επαληθεύστε τον νέο κωδικό πρόσβασής σας στα παρακάτω πεδία. "
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Διαχείριση Χρηστών"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Νέος Χρήστης"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "ταυτότητα"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Όνομα Χρήστη"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Όνομα"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Επώνυμο"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Τύπος Χρήστη"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Εύρεση Εκπομπών"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Επιλογή Παρουσίας Εκπομπής"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Εύρεση"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Επανάληψη Ημερών:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Αφαίρεση"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Προσθήκη"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Εμφάνιση Πηγής "
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Εγγραφή σε Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Απαιτείται)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(Μόνο για σκοπούς επαλήθευσης, δεν θα δημοσιευθεί)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Σημείωση: Οτιδήποτε μεγαλύτερο από 600x600 θα αλλάξει μέγεθος."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Δείξε μου τι στέλνω "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Όροι και Προϋποθέσεις"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Επιλέξτε Ημέρες:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "ή"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "και"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " να "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "τα αρχεία πληρούν τα κριτήρια"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Φιλτράρισμα Ιστορίας"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Για να προωθήσετε τον σταθμό σας, η 'Αποστολή σχολίων υποστήριξης» πρέπει να είναι ενεργοποιημένη)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream  "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Πρόσθετες επιλογές"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Η παρακάτω πληροφορία θα εμφανίζεται στις συσκευές αναπαραγωγής πολυμέσων των ακροατών σας:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Ιστοσελίδα του Ραδιοφωνικού σταθμού)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL Stream: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Επιλέξτε φάκελο"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Ορισμός"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Τρέχων Φάκελος Εισαγωγής:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Αφαίρεση προβεβλημμένου ευρετηρίου"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Δεν παρακολουθείτε κανέναν φάκελο πολυμέσων."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Κύρια Πηγή "
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Ρυθμίσεις SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Προσθήκη αυτής της εκπομπής "
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Ενημέρωση εκπομπής"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Τι"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Πότε"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Είσοδος Live Stream "
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Ποιός"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Στυλ"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Χώρος δίσκου"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Εισαγωγή αρχείου σε εξέλιξη..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Προηγμένες Επιλογές Αναζήτησης"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Τίτλος:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Δημιουργός:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Κομμάτι:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Διάρκεια:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Ρυθμός δειγματοληψίας:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Ρυθμός Δεδομένων:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Διάθεση:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Είδος:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Έτος"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Δισκογραφική:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Συνθέτης:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Μαέστρος:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Αριθμός ISRC:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Ιστοσελίδα:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Γλώσσα:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Διαδρομή Αρχείου"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Δυναμικά Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Στατικά Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Κομμάτι Ήχου"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Περιεχόμενα Λίστας Αναπαραγωγής: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Περιεχόμενα Στατικών Smart Block : "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Κριτήρια Δυναμικών Smart Block: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Όριο για "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "Διεύθυνση URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Το δοκιμαστικό λήγει σε"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "ημέρες"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Προηγούμενο"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Επόμενο"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Πηγή Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Ακούστε!"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Έξοδος"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Template Φόρμας Σύνδεσης"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Νέο Template Φόρμας Σύνδεσης"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Κανένα Template Φόρμας Σύνδεσης"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Template Περίληψης Αρχείου"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Νέο Template Περίληψης Αρχείου"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Κανένα Template Περίληψης Αρχείου"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Δημιουργία Αρχείου Περίληψης Template "
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Δημιουργία Template Φόρμας Σύνδεσης"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Ονομασία"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Προσθήκη περισσότερων στοιχείων"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Προσθήκη Νέου Πεδίου"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Ορισμός Προεπιλεγμένου Template "
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Περιγραφή"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL Stream:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Προεπιλεγμένη Διάρκεια:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Κανένα webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Βοήθεια"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Η σελίδα δεν βρέθηκε!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Η σελίδα που ψάχνατε δεν υπάρχει!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "προηγούμενο"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "αναπαραγωγή"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "παύση"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "επόμενο"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "στάση"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "μέγιστη ένταση"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Απαιτείται Ενημέρωση "
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Για να παίξετε τα πολυμέσα θα πρέπει είτε να αναβαθμίστε το πρόγραμμα περιήγησηής σας σε μια πρόσφατη έκδοση ή να ενημέρώσετε το %sFlash plugin %s σας."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Ημερομηνία Έναρξης:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Ημερομηνία Έναρξης:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Εισαγωγή άκυρου χαρακτήρα"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Ημερομηνία Λήξης:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Όλες οι Εκπομπές μου:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Αναζήτηση Χρηστών:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Όνομα Σταθμού"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Τηλέφωνο:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Ιστοσελίδα Σταθμού:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Χώρα"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Πόλη"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Περιγραφή Σταθμού:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Λογότυπο Σταθμού:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Πρέπει να συμφωνείτε με την πολιτική προστασίας προσωπικών δεδομένων."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Ηχογράφηση από Line In;"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Αναμετάδοση;"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Απαιτείται αξία και δεν μπορεί να είναι κενή"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' δεν αποτελεί έγκυρη διεύθυνση ηλεκτρονικού ταχυδρομείου στη βασική μορφή local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' δεν ταιριάζει με τη μορφή ημερομηνίας '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' είναι λιγότερο από %min% χαρακτήρες "
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' είναι περισσότερο από  %max% χαρακτήρες "
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' δεν είναι μεταξύ '%min%' και '%max%', συνολικά"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Οι κωδικοί πρόσβασης δεν συμπίπτουν"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "Η ώρα πρέπει να προσδιοριστεί"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Πρέπει να περιμένετε τουλάχιστον 1 ώρα για την αναμετάδοση"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Επαναφορά κωδικού πρόσβασης"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Εκπομπή χωρίς Τίτλο"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Αριθμός ISRC:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "ΟΚ"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Προεπιλεγμένη Διάρκεια Crossfade (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Προεπιλεγμένο Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Προεπιλεγμένο Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Απενεργοποιημένο"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Ενεργοποιημένο"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Ζώνη Ώρας Σταθμού"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Η Εβδομάδα αρχίζει "
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Όνομα Χρήστη:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Κωδικός πρόσβασης:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Επαλήθευση κωδικού πρόσβασης"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Όνομα:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Επώνυμο:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Κινητό Τηλέφωνο:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Τύπος Χρήστη:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Το όνομα εισόδου δεν είναι μοναδικό."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Εισαγωγή Φακέλου:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Παροβεβλημμένοι Φάκελοι:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Μη έγκυρο Ευρετήριο"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Προεπιλεγμένη Άδεια :"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Διατήρηση όλων των δικαιωμάτων"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Εργασία δημόσιας χρήσης"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Απόδοση Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Απόδοση Creative Commons Όχι Παράγωγα Έργα"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Απόδοση Creative Commons Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση Όχι Παράγωγα Έργα"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface Ζώνης ώρας:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Αναπαραγωγή σε Εξέλιξη"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Επιλέξτε κριτήρια"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Ρυθμός Δειγματοληψίας (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "ώρες"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "λεπτά"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "στοιχεία"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Στατικό"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Δυναμικό"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Δημιουργία λίστας αναπαραγωγής περιεχομένου και αποθήκευση κριτηρίων"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Δημιουργία"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Περιεχόμενο λίστας Shuffle "
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Το όριο δεν μπορεί να είναι κενό ή μικρότερο από 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Το όριο δεν μπορεί να είναι ξεπερνάει τις 24 ώρες"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Η τιμή πρέπει να είναι ακέραιος αριθμός"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Το 500 είναι η μέγιστη οριακή τιμή σημείου, που μπορείτε να ορίσετε"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Θα πρέπει να επιλέξετε Κριτήρια και Τροποποιητή"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "Το «Μήκος» θα πρέπει να είναι σε υπό μορφής  '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Η τιμή θα πρέπει να είναι υπο μορφής ώρας (π.χ. 0000-00-00 ή 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Η τιμή πρέπει να είναι αριθμός"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Η τιμή πρέπει να είναι μικρότερη από 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Η τιμή πρέπει να είναι μικρότερη από %s χαρακτήρες"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Η αξία δεν μπορεί να είναι κενή"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Μεταδεδομένα Icecast Vorbis "
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Stream Label:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Καλλιτέχνης - Τίτλος"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Εκπομπή - Καλλιτέχνης - Τίτλος"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Όνομα Σταθμού - Όνομα Εκπομπής"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Μεταδεδομένα Off Air"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Ενεργοποίηση Επανάληψη Κέρδους"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Τροποποιητής Επανάληψης Κέρδους"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Κωδικός πρόσβασης"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Επιβεβαίωση νέου κωδικού πρόσβασης"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Η επιβεβαίωση κωδικού δεν ταιριάζει με τον κωδικό πρόσβασής σας."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Ενεργοποιημένο"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Τύπος Stream:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Τύπος Υπηρεσίας:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Κανάλια"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Διακομιστής"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Θύρα"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Επιτρέπονται μόνο αριθμοί."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "Διεύθυνση URL:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Σημείο Προσάρτησης"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Διαχειριστής Χρήστης"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Κωδικός πρόσβασης Διαχειριστή"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Ο διακομιστής δεν μπορεί να είναι κενός."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Το Port δεν μπορεί να είναι κενό."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Η προσάρτηση δεν μπορεί να είναι κενή με διακομιστή Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' δεν ταιριάζει με τη μορφή της ώρας 'ΩΩ:λλ'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Ζώνη Ώρας"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Επαναλήψεις;"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Δεν είναι δυνατή η δημιουργία εκπομπής στο παρελθόν"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Αδύνατη η τροποποίηση ημερομηνίας/ώρας έναρξης της  εκπομπής που έχει ήδη αρχίσει"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Η λήξη ημερομηνίας/χρόνου δεν μπορεί να είναι στο παρελθόν"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Δεν μπορεί να έχει διάρκεια < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Δεν μπορεί να έχει διάρκεια 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Δεν μπορεί να έχει διάρκεια μεγαλύτερη από 24 ώρες"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Χρήση Προσαρμοσμένης Ταυτοποίησης:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Προσαρμοσμένο Όνομα Χρήστη"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Προσαρμοσμένος Κωδικός Πρόσβασης"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Το πεδίο 'Όνομα Χρήστη' δεν μπορεί να είναι κενό."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Το πεδίο 'Κωδικός Πρόσβασης' δεν μπορεί να είναι κενό."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Χρώμα Φόντου:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Χρώμα Κειμένου:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Πληκτρολογήστε τους χαρακτήρες που βλέπετε στην παρακάτω εικόνα."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "ημέρες"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr "ημέρα του μήνα"
 msgid "day of the week"
 msgstr "ημέρα της εβδομάδας"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Ημερομηνία Λήξης:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Χωρίς Τέλος;"
@@ -3877,115 +2633,1174 @@ msgstr "Η ημερομηνία λήξης πρέπει να είναι μετά
 msgid "Please select a repeat day"
 msgstr "Επιλέξτε ημέρα επανάληψης"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Ηχογράφηση από Line In;"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Αναμετάδοση;"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Χρώμα Φόντου:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Χρώμα Κειμένου:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Ημερολόγιο"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Αφαίρεση"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Xρήστες"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Όνομα:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Εκπομπή χωρίς Τίτλο"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "Διεύθυνση URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Είδος:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Περιγραφή:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Στατιστικές Ακροατών"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' δεν ταιριάζει με τη μορφή της ώρας 'ΩΩ:λλ'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Ιστορικό Template"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Διάρκεια:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Ζώνη Ώρας"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Επαναλήψεις;"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Δεν είναι δυνατή η δημιουργία εκπομπής στο παρελθόν"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Αδύνατη η τροποποίηση ημερομηνίας/ώρας έναρξης της  εκπομπής που έχει ήδη αρχίσει"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Η λήξη ημερομηνίας/χρόνου δεν μπορεί να είναι στο παρελθόν"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Δεν μπορεί να έχει διάρκεια < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Δεν μπορεί να έχει διάρκεια 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Δεν μπορεί να έχει διάρκεια μεγαλύτερη από 24 ώρες"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Δεν είναι δυνατός ο προγραμματισμός αλληλοεπικαλυπτόμενων εκπομπών"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Αναζήτηση Χρηστών:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Όνομα Χρήστη:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Κωδικός πρόσβασης:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Επαλήθευση κωδικού πρόσβασης"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Όνομα:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Επώνυμο:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Κινητό Τηλέφωνο:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Τύπος Χρήστη:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Το όνομα εισόδου δεν είναι μοναδικό."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Έναρξη"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Εγχειρίδιο Χρήστη"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Απαιτείται αξία και δεν μπορεί να είναι κενή"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Ημερομηνία Έναρξης:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Τίτλος:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Δημιουργός:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Έτος"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Δισκογραφική:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Συνθέτης:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Μαέστρος:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Διάθεση:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Αριθμός ISRC:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Ιστοσελίδα:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Γλώσσα:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Ώρα Έναρξης"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Ώρα Τέλους"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface Ζώνης ώρας:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Όνομα Σταθμού"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Λογότυπο Σταθμού:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Σημείωση: Οτιδήποτε μεγαλύτερο από 600x600 θα αλλάξει μέγεθος."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Προεπιλεγμένη Διάρκεια Crossfade (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Προεπιλεγμένο Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Προεπιλεγμένο Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Απενεργοποιημένο"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Ενεργοποιημένο"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Ζώνη Ώρας Σταθμού"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Η Εβδομάδα αρχίζει "
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' δεν αποτελεί έγκυρη διεύθυνση ηλεκτρονικού ταχυδρομείου στη βασική μορφή local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' δεν ταιριάζει με τη μορφή ημερομηνίας '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' είναι λιγότερο από %min% χαρακτήρες "
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' είναι περισσότερο από  %max% χαρακτήρες "
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' δεν είναι μεταξύ '%min%' και '%max%', συνολικά"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Οι κωδικοί πρόσβασης δεν συμπίπτουν"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Επιτρέπονται μόνο αριθμοί."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Σύνδεση"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Πληκτρολογήστε τους χαρακτήρες που βλέπετε στην παρακάτω εικόνα."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Κωδικός πρόσβασης"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Επιβεβαίωση νέου κωδικού πρόσβασης"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Η επιβεβαίωση κωδικού δεν ταιριάζει με τον κωδικό πρόσβασής σας."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Όνομα Χρήστη"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Επαναφορά κωδικού πρόσβασης"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Αναπαραγωγή σε Εξέλιξη"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Τηλέφωνο:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Ιστοσελίδα Σταθμού:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Χώρα"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Πόλη"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Περιγραφή Σταθμού:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Πρέπει να συμφωνείτε με την πολιτική προστασίας προσωπικών δεδομένων."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Όλες οι Εκπομπές μου:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Επιλέξτε κριτήρια"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Περιγραφή"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Ρυθμός Δειγματοληψίας (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "ώρες"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "λεπτά"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "στοιχεία"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Στατικό"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Δυναμικό"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Δημιουργία λίστας αναπαραγωγής περιεχομένου και αποθήκευση κριτηρίων"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Δημιουργία"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Περιεχόμενο λίστας Shuffle "
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Το όριο δεν μπορεί να είναι κενό ή μικρότερο από 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Το όριο δεν μπορεί να είναι ξεπερνάει τις 24 ώρες"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Η τιμή πρέπει να είναι ακέραιος αριθμός"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Το 500 είναι η μέγιστη οριακή τιμή σημείου, που μπορείτε να ορίσετε"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Θα πρέπει να επιλέξετε Κριτήρια και Τροποποιητή"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "Το «Μήκος» θα πρέπει να είναι σε υπό μορφής  '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Η τιμή θα πρέπει να είναι υπο μορφής ώρας (π.χ. 0000-00-00 ή 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Η τιμή πρέπει να είναι αριθμός"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Η τιμή πρέπει να είναι μικρότερη από 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Η τιμή πρέπει να είναι μικρότερη από %s χαρακτήρες"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Η αξία δεν μπορεί να είναι κενή"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Προεπιλεγμένη Άδεια :"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Διατήρηση όλων των δικαιωμάτων"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Εργασία δημόσιας χρήσης"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Απόδοση Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Απόδοση Creative Commons Όχι Παράγωγα Έργα"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Απόδοση Creative Commons Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση Όχι Παράγωγα Έργα"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Απόδοση Creative Commons Μη Εμπορική Χρήση Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Μεταδεδομένα Icecast Vorbis "
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Stream Label:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Καλλιτέχνης - Τίτλος"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Εκπομπή - Καλλιτέχνης - Τίτλος"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Όνομα Σταθμού - Όνομα Εκπομπής"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Μεταδεδομένα Off Air"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Ενεργοποίηση Επανάληψη Κέρδους"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Τροποποιητής Επανάληψης Κέρδους"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Ενεργοποιημένο"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Τύπος Stream:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Ρυθμός Δεδομένων:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Τύπος Υπηρεσίας:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Κανάλια"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Διακομιστής"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Θύρα"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "Διεύθυνση URL:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Ονομασία"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Σημείο Προσάρτησης"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Διαχειριστής Χρήστης"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Κωδικός πρόσβασης Διαχειριστή"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Ο διακομιστής δεν μπορεί να είναι κενός."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Το Port δεν μπορεί να είναι κενό."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Η προσάρτηση δεν μπορεί να είναι κενή με διακομιστή Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Εισαγωγή Φακέλου:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Παροβεβλημμένοι Φάκελοι:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Μη έγκυρο Ευρετήριο"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Αναπαραγωγή"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Παύση"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Ρύθμιση Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Ρύθμιση Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Ζωντανό Stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in και cue out είναι μηδέν."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Το cue out δεν μπορεί να είναι μεγαλύτερο από το μήκος του αρχείου."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Το cue in δεν μπορεί να είναι μεγαλύτερης διάρκειας από το cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Το cue out δεν μπορεί να είναι μικρότερο από το cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Αναμετάδοση του %s από %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Επιλέξτε Χώρα"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s μη έγκυρο ευρετήριο."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s έχει ήδη οριστεί ως το τρέχον ευρετήριο αποθήκευσης ή βρίσκεται στη λίστα προβεβλημένων φακέλων"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s έχει ήδη οριστεί ως το τρέχον ευρετήριο αποθήκευσης ή βρίσκεται στη λίστα προβεβλημένων φακέλων."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s έχει ήδη οριστεί ως το τρέχον ευρετήρ�
 msgid "%s doesn't exist in the watched list."
 msgstr "%s δεν υπάρχει στη λίστα προβεβλημένων."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Επιλέξτε Χώρα"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Η μέγιστη διάρκει εκπομπών είναι 24 ώρες."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Δεν είναι δυνατός ο προγραμματισμός αλληλοεπικαλυπτώμενων εκπομπών.\n Σημείωση: Η αλλαγή μεγέθους μιας εκπομπής επηρεάζει όλες τις επαναλήψεις της."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Το πρόγραμμα που βλέπετε δεν είναι ενημερωμένο! (αναντιστοιχία παραδείγματος)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Το πρόγραμμα που βλέπετε δεν είναι ενημερωμένο!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Δεν έχετε δικαίωμα προγραμματισμού εκπομπής%s.."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Δεν μπορείτε να προσθεσετε αρχεία σε ηχογραφημένες εκπομπές."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Η εκπομπή %s έχει τελειώσει και δεν μπορεί να προγραμματιστεί."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Η εκπομπή %s έχει ενημερωθεί πρόσφατα!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Το περιεχόμενο συνδεδεμένων εκπομπών πρέπει να να προγραμματιστεί πριν ή μετά την αναμετάδοσή τους"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Ένα επιλεγμένο αρχείο δεν υπάρχει!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Η μέγιστη διάρκει εκπομπών είναι 24 ώρες."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Δεν είναι δυνατός ο προγραμματισμός αλληλοεπικαλυπτώμενων εκπομπών.\n"
+" Σημείωση: Η αλλαγή μεγέθους μιας εκπομπής επηρεάζει όλες τις επαναλήψεις της."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Αναμετάδοση του %s από %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1049 @@ msgstr "Μη έγκυρο webstream - Αυτό φαίνεται να αποτε�
 msgid "Unrecognized stream type: %s"
 msgstr "Άγνωστος τύπος stream: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Το αρχείο δεν υπάρχει"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Προβολή εγγεγραμμένων Αρχείων Μεταδεδομένων "
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Επεξεργασία"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Επεξεργασία Εκπομπής"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Δεν έχετε δικαίωμα πρόσβασης"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Δεν είναι δυνατό το drag and drop επαναλαμβανόμενων εκπομπών"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Δεν είναι δυνατή η μετακίνηση περασμένης εκπομπής"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Δεν είναι δυνατή η μετακίνηση εκπομπής στο παρελθόν"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Δεν είναι δυνατή η μετακίνηση ηχογραφημένης εκπομπής σε λιγότερο από 1 ώρα πριν από την αναμετάδοση της."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Η εκπομπή διεγράφη επειδή δεν υπάρχει ηχογραφημένη εκπομπή!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Πρέπει να περιμένετε 1 ώρα για την αναμετάδοση."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Κομμάτι"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Παίχτηκε"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "προηγούμενο"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "αναπαραγωγή"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "παύση"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "επόμενο"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "στάση"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "Σίγαση"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "Κατάργηση σίγασης"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "μέγιστη ένταση"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Απαιτείται Ενημέρωση "
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Για να παίξετε τα πολυμέσα θα πρέπει είτε να αναβαθμίστε το πρόγραμμα περιήγησηής σας σε μια πρόσφατη έκδοση ή να ενημέρώσετε το %sFlash plugin %s σας."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Σχετικά"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Για περισσότερες αναλυτικές οδηγίες, διαβάστε το %sεγχειρίδιο%s ."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Μοιραστείτε"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Επιλέξτε stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Η σελίδα δεν βρέθηκε!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Η σελίδα που ψάχνατε δεν υπάρχει!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Εμφάνιση Πηγής "
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Επιλέξτε Ημέρες:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Προσθήκη"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Επανάληψη Ημερών:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Φιλτράρισμα Ιστορίας"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Επιλογή Παρουσίας Εκπομπής"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Εύρεση"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Ρυθμίσεις SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Κύρια Πηγή "
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "ΟΚ"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Επιλέξτε φάκελο"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Ορισμός"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Τρέχων Φάκελος Εισαγωγής:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Αφαίρεση προβεβλημμένου ευρετηρίου"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Δεν παρακολουθείτε κανέναν φάκελο πολυμέσων."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Εγγραφή σε Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Απαιτείται)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(Μόνο για σκοπούς επαλήθευσης, δεν θα δημοσιευθεί)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Δείξε μου τι στέλνω "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Όροι και Προϋποθέσεις"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Εύρεση Εκπομπών"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "ή"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "και"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " να "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "τα αρχεία πληρούν τα κριτήρια"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream  "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Πρόσθετες επιλογές"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Η παρακάτω πληροφορία θα εμφανίζεται στις συσκευές αναπαραγωγής πολυμέσων των ακροατών σας:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Ιστοσελίδα του Ραδιοφωνικού σταθμού)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL Stream: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Για να προωθήσετε τον σταθμό σας, η 'Αποστολή σχολίων υποστήριξης» πρέπει να είναι ενεργοποιημένη)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Κομμάτι:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Διάρκεια:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Ρυθμός δειγματοληψίας:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Αριθμός ISRC:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Διαδρομή Αρχείου"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Δυναμικά Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Στατικά Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Κομμάτι Ήχου"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Περιεχόμενα Λίστας Αναπαραγωγής: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Περιεχόμενα Στατικών Smart Block : "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Κριτήρια Δυναμικών Smart Block: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Όριο για "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Εισαγωγή αρχείου σε εξέλιξη..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Προηγμένες Επιλογές Αναζήτησης"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Νέος κωδικός πρόσβασης"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Παρακαλώ εισάγετε και επαληθεύστε τον νέο κωδικό πρόσβασής σας στα παρακάτω πεδία. "
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Προηγούμενο"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Επόμενο"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Πηγή Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Ακούστε!"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Έξοδος"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Το δοκιμαστικό λήγει σε"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle λίστα αναπαραγωγής"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Crossfade λίστας αναπαραγωγής"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Άδειασμα περιεχομένου λίστας αναπαραγωγής"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Εκκαθάριση"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Αποθήκευση λίστας αναπαραγωγής"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Καμία ανοικτή λίστα αναπαραγωγής"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Εμφάνιση κυμματοειδούς μορφής"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(ωω:λλ:δδ.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Αρχική Διάρκεια:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(Ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Επέκταση Στατικών Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Επέκταση Δυναμικών Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Σελίδα Σύνδεσης"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Περίληψη Αρχείων"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Προβολή Περίληψης"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Template Φόρμας Σύνδεσης"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Νέο Template Φόρμας Σύνδεσης"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Κανένα Template Φόρμας Σύνδεσης"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Template Περίληψης Αρχείου"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Νέο Template Περίληψης Αρχείου"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Κανένα Template Περίληψης Αρχείου"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Δημιουργία Αρχείου Περίληψης Template "
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Δημιουργία Template Φόρμας Σύνδεσης"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Προσθήκη περισσότερων στοιχείων"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Προσθήκη Νέου Πεδίου"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Ορισμός Προεπιλεγμένου Template "
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Ρυθμίσεις Stream"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "βΔ"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Προσθήκη αυτής της εκπομπής "
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Ενημέρωση εκπομπής"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Τι"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Πότε"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Είσοδος Live Stream "
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Ποιός"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Στυλ"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Χώρος δίσκου"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Διαχείριση Χρηστών"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Νέος Χρήστης"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "ταυτότητα"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Όνομα"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Επώνυμο"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Τύπος Χρήστη"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL Stream:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Προεπιλεγμένη Διάρκεια:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Κανένα webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "παρακαλούμε εισάγετε τιμή ώρας σε δευτερόλεπτα '00 (0,0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Το περιεχόμενο συνδεδεμένων εκπομπών πρέπει να να προγραμματιστεί πριν ή μετά την αναμετάδοσή τους"

--- a/airtime_mvc/locale/el_GR/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/el_GR/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_CA/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Daniel James <daniel@64studio.com>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: English (Canada) (http://www.transifex.com/sourcefabric/airtime/language/en_CA/)\n"
+"Language: en_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_CA\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "The year %s must be within the range of 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s is not a valid date"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s is not a valid time"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edit"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edit Show"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Delete"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendar"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Users"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout History"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "History Templates"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Listener Stats"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Help"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Getting Started"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "User Manual"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "You are not allowed to access this resource."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "You are not allowed to access this resource. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Bad request. no 'mode' parameter passed."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Bad request. 'mode' parameter is invalid"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "You don't have permission to disconnect source."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "There is no source connected to this input."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "You don't have permission to switch source."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s not found"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Something went wrong."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Preview"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Add to Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Add to Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Delete"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplicate Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "No action available"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "You don't have permission to delete selected items."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Copy of %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Untitled Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream saved."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Invalid form values."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Please make sure Admin User and Admin Password for the streaming server are present and correct under Stream -> Additional Options on the System -> Streams page."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Recording:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nothing Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Current Show:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Current"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "You are running the latest version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "New version available: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "This version will soon be obsolete."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "This version is no longer supported."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Please upgrade to "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Add to current playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Add to current smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Adding 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Adding %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "You can only add tracks to smart blocks."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Please select a cursor position on timeline."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edit Metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Add to selected show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Select"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Select this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Deselect this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Deselect all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Are you sure you want to delete the selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Title"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Creator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bit Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Composer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Conductor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded By"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Language"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Last Modified"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Last Played"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Length"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Mood"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Owner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Track Number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Uploaded"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Year"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Loading..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "All"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlists"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Unknown type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Are you sure you want to delete the selected item?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Uploading in progress..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "The soundcloud id for this file is: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "There was an error while uploading to soundcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Error code: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Error msg: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Input must be a positive number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Input must be a number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Input must be in the format: yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Input must be in the format: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Open Media Builder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "please put in a time '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Your browser does not support playing this file type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dynamic block is not previewable"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limit to: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlist shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Listener Count on %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Remind me in 1 week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Remind me never"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Yes, help Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Image must be one of jpg, jpeg, png, or gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block generated and criteria saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Processing..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Select modifier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contains"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "does not contain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "is"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "is not"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "starts with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "ends with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "is greater than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "is less than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "is in the range"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Choose Storage Folder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Choose Folder to Watch"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Manage Media Folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Are you sure you want to remove the watched folder?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "This path is currently not accessible."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Connected to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "The stream is disabled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Getting information from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Can not connect to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "For more details, please read the %sAirtime Manual%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Check this box to automatically switch on Master/Show source upon source connection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Warning: You cannot change this field while the show is currently playing"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "No result found"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Specify custom authentication which will work only for this show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "The show instance doesn't exist anymore!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Warning: Shows cannot be re-linked"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Show is empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "This show has no scheduled content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "This show is not completely filled with content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "January"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "February"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "March"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "May"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "June"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "July"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "August"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "September"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "October"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "December"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Oct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Sunday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Monday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Tuesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Wednesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Thursday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Friday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Saturday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Sun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Mon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Tue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Wed"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Thu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Fri"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Shows longer than their scheduled time will be cut off by a following show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Cancel Current Show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Stop recording current show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contents of Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Remove all content?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Delete selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Start"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "End"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duration"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show Empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Recording From Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Track preview"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Cannot schedule outside a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Moving 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Moving %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Save"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Waveform features are available in a browser supporting the Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Select all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Select none"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Remove selected scheduled items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Jump to the current playing track"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancel current show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Open library to add or remove content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Add / Remove Content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "in use"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Look in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Open"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Program Manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Guest"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Guests can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "View schedule"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "View show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJs can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Manage assigned show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Import media files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Create playlists, smart blocks, and webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Manage their own library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Progam Managers can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "View and manage show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Schedule shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Manage all library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Admins can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Manage preferences"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Manage users"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Manage watched folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Send support feedback"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "View system status"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Access playout history"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "View listener stats"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Show / hide columns"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "From {from} to {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Su"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Mo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Tu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "We"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Th"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Fr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Close"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hour"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Done"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Select files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Add files to the upload queue and click the start button."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Add Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Stop Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Start upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Add files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Uploaded %d/%d files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Drag files here."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "File extension error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "File size error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "File count error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Security error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generic error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "File: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d files queued"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "File: %f, size: %s, max file size: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload URL might be wrong or doesn't exist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Error: File too large: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Error: Invalid file extension: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Set Default"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Create Entry"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Edit History Record"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "No Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Copied %s row%s to the clipboard"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Wrong username or password provided. Please try again."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "You don't have permission to delete selected %s(s)."
 msgid "You can only add tracks to smart block."
 msgstr "You can only add tracks to smart block."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Untitled Playlist"
@@ -384,2627 +2414,88 @@ msgstr "Untitled Playlist"
 msgid "Untitled Smart Block"
 msgstr "Untitled Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Unknown Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "You are not allowed to access this resource."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preferences updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Support setting updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream Setting Updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "path should be specified"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem with Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "You don't have permission to disconnect source."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "There is no source connected to this input."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "You don't have permission to switch source."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Wrong username or password provided. Please try again."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "You are not allowed to access this resource. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Bad request. no 'mode' parameter passed."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Bad request. 'mode' parameter is invalid"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Recording:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nothing Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Current Show:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Current"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "You are running the latest version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "New version available: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "This version will soon be obsolete."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "This version is no longer supported."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Please upgrade to "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Add to current playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Add to current smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Adding 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Adding %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "You can only add tracks to smart blocks."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Please select a cursor position on timeline."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Add to selected show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Select"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Select this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Deselect this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Deselect all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Are you sure you want to delete the selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bit Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded By"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Last Modified"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Last Played"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Owner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Sample Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Track Number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Uploaded"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Loading..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "All"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlists"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Unknown type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Are you sure you want to delete the selected item?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Uploading in progress..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "The soundcloud id for this file is: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "There was an error while uploading to soundcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Error code: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Error msg: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Input must be a positive number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Input must be a number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Input must be in the format: yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Input must be in the format: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Open Media Builder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "please put in a time '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "please put in a time in seconds '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Your browser does not support playing this file type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dynamic block is not previewable"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limit to: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlist shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Listener Count on %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Remind me in 1 week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Remind me never"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Yes, help Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Image must be one of jpg, jpeg, png, or gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block generated and criteria saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Processing..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Select modifier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contains"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "does not contain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "is"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "is not"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "starts with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "ends with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "is greater than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "is less than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "is in the range"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Choose Storage Folder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Choose Folder to Watch"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Are you sure you want to change the storage folder?\nThis will remove the files from your Airtime library!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Manage Media Folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Are you sure you want to remove the watched folder?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "This path is currently not accessible."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Connected to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "The stream is disabled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Getting information from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Can not connect to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "For more details, please read the %sAirtime Manual%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Check this box to automatically switch on Master/Show source upon source connection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Warning: You cannot change this field while the show is currently playing"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "No result found"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Specify custom authentication which will work only for this show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "The show instance doesn't exist anymore!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Warning: Shows cannot be re-linked"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Show is empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "This show has no scheduled content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "This show is not completely filled with content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "January"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "February"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "March"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "May"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "June"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "July"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "August"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "September"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "October"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "December"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Oct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Sunday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Monday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Tuesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Wednesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Thursday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Friday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Saturday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Sun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Mon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Tue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Wed"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Thu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Fri"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Shows longer than their scheduled time will be cut off by a following show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Cancel Current Show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Stop recording current show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contents of Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Remove all content?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Delete selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Start"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "End"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duration"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show Empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Recording From Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Track preview"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Cannot schedule outside a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Moving 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Moving %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Save"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Waveform features are available in a browser supporting the Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Select all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Select none"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Remove selected scheduled items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Jump to the current playing track"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancel current show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Open library to add or remove content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Add / Remove Content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "in use"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Look in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Open"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Program Manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Guest"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Guests can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "View schedule"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "View show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJs can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Manage assigned show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Import media files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Create playlists, smart blocks, and webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Manage their own library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Progam Managers can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "View and manage show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Schedule shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Manage all library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Admins can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Manage preferences"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Manage users"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Manage watched folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Send support feedback"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "View system status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Access playout history"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "View listener stats"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Show / hide columns"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "From {from} to {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Su"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Mo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Tu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "We"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Th"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Fr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Close"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hour"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Done"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Select files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Add files to the upload queue and click the start button."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Add Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Stop Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Start upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Add files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Uploaded %d/%d files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Drag files here."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "File extension error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "File size error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "File count error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Security error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generic error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "File: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d files queued"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "File: %f, size: %s, max file size: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload URL might be wrong or doesn't exist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Error: File too large: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Error: Invalid file extension: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Set Default"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Create Entry"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Edit History Record"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "No Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Copied %s row%s to the clipboard"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Select cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Remove cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "show does not exist"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Rebroadcast of show %s from %s at %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Select cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Remove cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "show does not exist"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "User added successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "User updated successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Settings updated successfully!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Untitled Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream saved."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Invalid form values."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "The year %s must be within the range of 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s is not a valid date"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s is not a valid time"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Play"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Set Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Set Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Share"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Select stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "mute"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "unmute"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "About"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "For more detailed help, read the %suser manual%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout History"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Log Sheet"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "File Summary"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Show Summary"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Expand Static Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Expand Dynamic Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Name:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Description:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Duration:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Empty playlist content"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Clear"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Save playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "No open playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Show Waveform"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Original Length:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Stream Settings"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Login"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "New password"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Please enter and confirm your new password in the fields below."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Manage Users"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "New User"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Username"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "First Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Last Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "User Type"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Find Shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Choose Show Instance"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Find"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Repeat Days:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Remove"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Add"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Show Source"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Register Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Required)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(for verification purposes only, will not be published)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Note: Anything larger than 600x600 will be resized."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Show me what I am sending "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Choose Days:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "or"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "and"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " to "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "files meet the criteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter History"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Additional Options"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "The following info will be displayed to listeners in their media player:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Your radio station website)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Choose folder"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Set"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Current Import Folder:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Remove watched directory"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "You are not watching any media folders."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master Source"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Settings"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Add this show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Update show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "What"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "When"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live Stream Input"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Who"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Style"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Disk Space"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "File import in progress..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Advanced Search Options"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Title:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Creator:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Track:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Length:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Sample Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Mood:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Year:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Composer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conductor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Number:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Website:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Language:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "File Path:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamic Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Static Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audio Track"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Playlist Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Static Smart Block Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamic Smart Block Criteria: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limit to "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Your trial expires in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "days"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Previous:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Next:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Source Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Listen"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Logout"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "New Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "No Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "New File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "No File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Creating File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Creating Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Name"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Add more elements"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Add New Field"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Set Default Template"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Description"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Default Length:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "No webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Help"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Page not found!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Looks like the page you were looking for doesn't exist!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "previous"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "play"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "next"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max volume"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Update Required"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Date Start:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Date Start:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Invalid character entered"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Date End:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "All My Shows:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Search Users:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Station Name"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Phone:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Station Web Site:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Country:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "City:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Station Description:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Station Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "You have to agree to privacy policy."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Record from Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Rebroadcast?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Value is required and can't be empty"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' does not fit the date format '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' is less than %min% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' is more than %max% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Passwords do not match"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "Time must be specified"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Reset password"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Untitled Show"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Number:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Default Crossfade Duration (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Default Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Default Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Disabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Enabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Station Timezone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Week Starts On"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Username:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Verify Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "First name:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Last name:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobile Phone:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "User Type:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Login name is not unique."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Import Folder:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Watched Folders:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Not a valid Directory"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Default License:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "All rights are reserved"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "The work is in the public domain"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface Timezone:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Now Playing"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Select criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "hours"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutes"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "items"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Static"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamic"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generate playlist content and save criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generate"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Shuffle playlist content"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limit cannot be empty or smaller than 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limit cannot be more than 24 hrs"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "The value should be an integer"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 is the max item limit value you can set"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "You must select Criteria and Modifier"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Length' should be in '00:00:00' format"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "The value has to be numeric"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "The value should be less then 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "The value should be less than %s characters"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Value cannot be empty"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Stream Label:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Station name - Show name"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Enable Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifier"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirm new password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Password confirmation does not match your password."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Enabled:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Channels:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Only numbers are allowed."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin User"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Password"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount cannot be empty with Icecast server."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' does not fit the time format 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Timezone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Repeats?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Cannot create show in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Cannot modify start date/time of the show that is already started"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "End date/time cannot be in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Cannot have duration < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Cannot have duration 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Cannot have duration greater than 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Use Custom Authentication:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Custom Username"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Custom Password"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Username field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Password field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Background Colour:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Text Colour:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Type the characters you see in the picture below."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "days"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr "day of the month"
 msgid "day of the week"
 msgstr "day of the week"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Date End:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "No End?"
@@ -3877,115 +2633,1174 @@ msgstr "End date must be after start date"
 msgid "Please select a repeat day"
 msgstr "Please select a repeat day"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Record from Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Rebroadcast?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Background Colour:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Text Colour:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendar"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Remove"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Users"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Name:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Untitled Show"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Description:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Listener Stats"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' does not fit the time format 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "History Templates"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Duration:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Timezone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Repeats?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Cannot create show in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Cannot modify start date/time of the show that is already started"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "End date/time cannot be in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Cannot have duration < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Cannot have duration 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Cannot have duration greater than 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Cannot schedule overlapping shows"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Search Users:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Username:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Verify Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "First name:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Last name:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobile Phone:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "User Type:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Login name is not unique."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Getting Started"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "User Manual"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Value is required and can't be empty"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Date Start:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Title:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Creator:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Year:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Composer:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conductor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Mood:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Number:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Website:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Language:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Start Time"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "End Time"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface Timezone:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Station Name"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Station Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Note: Anything larger than 600x600 will be resized."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Default Crossfade Duration (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Default Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Default Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Disabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Enabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Station Timezone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Week Starts On"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' does not fit the date format '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' is less than %min% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' is more than %max% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Only numbers are allowed."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Login"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Type the characters you see in the picture below."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirm new password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Password confirmation does not match your password."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Username"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Reset password"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Now Playing"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Phone:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Station Web Site:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Country:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "City:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Station Description:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "You have to agree to privacy policy."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "All My Shows:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Select criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Description"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "hours"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutes"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "items"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Static"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamic"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generate playlist content and save criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generate"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Shuffle playlist content"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limit cannot be empty or smaller than 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limit cannot be more than 24 hrs"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "The value should be an integer"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 is the max item limit value you can set"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "You must select Criteria and Modifier"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Length' should be in '00:00:00' format"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "The value has to be numeric"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "The value should be less then 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "The value should be less than %s characters"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Value cannot be empty"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Default License:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "All rights are reserved"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "The work is in the public domain"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Stream Label:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Station name - Show name"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Enable Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifier"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Enabled:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Rate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Channels:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Name"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin User"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Password"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount cannot be empty with Icecast server."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Import Folder:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Watched Folders:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Not a valid Directory"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Play"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Set Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Set Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in and cue out are null."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Can't set cue out to be greater than file length."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Can't set cue in to be larger than cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Can't set cue out to be smaller than cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Rebroadcast of %s from %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Select Country"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s is not a valid directory."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s is already set as the current storage dir or in the watched folders list"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s is already set as the current storage dir or in the watched folders list."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s is already set as the current storage dir or in the watched folders l
 msgid "%s doesn't exist in the watched list."
 msgstr "%s doesn't exist in the watched list."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Select Country"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Shows can have a max length of 24 hours."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Cannot schedule overlapping shows.\nNote: Resizing a repeating show affects all of its repeats."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "The schedule you're viewing is out of date! (instance mismatch)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "The schedule you're viewing is out of date!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "You are not allowed to schedule show %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "You cannot add files to recording shows."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "The show %s is over and cannot be scheduled."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "The show %s has been previously updated!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "A selected File does not exist!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Shows can have a max length of 24 hours."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Rebroadcast of %s from %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1049 @@ msgstr "Invalid webstream - This appears to be a file download."
 msgid "Unrecognized stream type: %s"
 msgstr "Unrecognized stream type: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Record file doesn't exist"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "View Recorded File Metadata"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edit"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edit Show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Permission denied"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Can't drag and drop repeating shows"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Can't move a past show"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Can't move show into past"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Show was deleted because recorded show does not exist!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Must wait 1 hour to rebroadcast."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Track"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Played"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "previous"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "play"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "next"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "mute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "unmute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max volume"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Update Required"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "About"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "For more detailed help, read the %suser manual%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Share"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Select stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Page not found!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Looks like the page you were looking for doesn't exist!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Show Source"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Choose Days:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Add"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Repeat Days:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter History"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Choose Show Instance"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Find"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Settings"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master Source"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Choose folder"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Set"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Current Import Folder:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Remove watched directory"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "You are not watching any media folders."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Register Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Required)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(for verification purposes only, will not be published)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Show me what I am sending "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Terms and Conditions"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Find Shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "or"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "and"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " to "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "files meet the criteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Additional Options"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "The following info will be displayed to listeners in their media player:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Your radio station website)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Track:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Length:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Sample Rate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Number:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "File Path:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamic Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Static Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audio Track"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Playlist Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Static Smart Block Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamic Smart Block Criteria: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limit to "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "File import in progress..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Advanced Search Options"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "New password"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Please enter and confirm your new password in the fields below."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Previous:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Next:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Source Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Listen"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Logout"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Your trial expires in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Empty playlist content"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Clear"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Save playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "No open playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Show Waveform"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Original Length:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Expand Static Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Expand Dynamic Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Log Sheet"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "File Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Show Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "New Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "No Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "New File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "No File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Creating File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Creating Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Add more elements"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Add New Field"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Set Default Template"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Stream Settings"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Add this show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Update show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "What"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "When"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live Stream Input"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Who"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Style"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Disk Space"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Manage Users"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "New User"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "First Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Last Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "User Type"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Default Length:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "No webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "please put in a time in seconds '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"

--- a/airtime_mvc/locale/en_CA/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/en_CA/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_GB/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Daniel James <daniel@64studio.com>, 2014
 # Daniel James <daniel@64studio.com>, 2014-2015
@@ -10,266 +10,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-07 10:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/sourcefabric/airtime/language/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "The year %s must be within the range of 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s is not a valid date"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
-msgstr "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s is not a valid time"
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
-msgstr "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
-msgstr "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
-msgstr "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
-msgstr "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
-msgstr "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
-msgstr "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr "Upload some tracks below to add them to your library!"
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr "Please click the 'New Show' button and fill out the required fields."
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr "It looks like you don't have any shows scheduled yet. %sCreate a show now%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr "Linked shows need to be filled with tracks before they start. To start broadcasting cancel the current linked show and schedule an unlinked show. %sCreate an unlinked show now%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr "Click on the show starting next and select 'Schedule Tracks'"
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr "It looks like the next show is empty. %sAdd tracks to your show now%s."
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr "Radio Page"
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendar"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr "Widgets"
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr "Player"
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr "Weekly Schedule"
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr "Settings"
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr "General"
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr "My Profile"
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Users"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr "Analytics"
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout History"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "History Templates"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Listener Stats"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr "Billing"
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr "Account Plans"
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr "Account Details"
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr "View Invoices"
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Help"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Getting Started"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr "FAQ"
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "User Manual"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr "File a Support Ticket"
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "You are not allowed to access this resource."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "You are not allowed to access this resource. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr "File does not exist in %s"
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Bad request. no 'mode' parameter passed."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Bad request. 'mode' parameter is invalid"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "You don't have permission to disconnect source."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "There is no source connected to this input."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "You don't have permission to switch source."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr "Page not found."
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr "The requested action is not supported."
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr "You do not have permission to access this resource."
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr "An internal application error has occurred."
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s not found"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Something went wrong."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Preview"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Add to Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Add to Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Delete"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -278,81 +892,1502 @@ msgid "View track"
 msgstr "View track"
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
-msgstr "Remove track"
+msgid "Update track"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr "Upload track"
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplicate Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "No action available"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "You don't have permission to delete selected items."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr "Could not delete file because it is scheduled in the future."
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr "Could not delete file(s)."
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Copy of %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Untitled Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream saved."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Invalid form values."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr "To configure and use the embeddable player you must:<br><br>\n            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n            2. Enable the Public Airtime API under System -> Preferences"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr "To use the embeddable weekly schedule widget you must:<br><br>\n            Enable the Public Airtime API under System -> Preferences"
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Please make sure admin user/password is correct on System->Streams page."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr "Something went wrong!"
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Recording:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nothing Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Current Show:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Current"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "You are running the latest version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "New version available: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "This version will soon be obsolete."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "This version is no longer supported."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Please upgrade to "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Add to current playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Add to current smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Adding 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Adding %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "You can only add tracks to smart blocks."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Please select a cursor position on timeline."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr "You haven't added any tracks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr "You haven't added any playlists"
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr "You haven't added any smart blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr "You haven't added any webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr "Learn about tracks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr "Learn about playlists"
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr "Learn about smart blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr "Learn about webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr "Click 'New' to create one."
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edit Metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Add to selected show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Select"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Select this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Deselect this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Deselect all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Are you sure you want to delete the selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr "Tracks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr "Playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Title"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Creator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bit Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Composer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Conductor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded By"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Language"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Last Modified"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Last Played"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Length"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Mood"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Owner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Track Number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Uploaded"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Year"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Loading..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "All"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlists"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Unknown type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Are you sure you want to delete the selected item?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Uploading in progress..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "The SoundCloud id for this file is: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "There was an error while uploading to SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Error code: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Error msg: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Input must be a positive number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Input must be a number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Input must be in the format: yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Input must be in the format: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Open Media Builder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "please put in a time '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Your browser does not support playing this file type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dynamic block is not previewable"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limit to: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlist shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Listener Count on %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Remind me in 1 week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Remind me never"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Yes, help Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Image must be one of jpg, jpeg, png, or gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block generated and criteria saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Processing..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Select modifier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contains"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "does not contain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "is"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "is not"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "starts with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "ends with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "is greater than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "is less than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "is in the range"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Choose Storage Folder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Choose Folder to Watch"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Manage Media Folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Are you sure you want to remove the watched folder?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "This path is currently not accessible."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Connected to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "The stream is disabled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Getting information from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Can not connect to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "For more details, please read the %sAirtime Manual%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Check this box to automatically switch on Master/Show source upon source connection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Warning: You cannot change this field while the show is currently playing"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "No result found"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Specify custom authentication which will work only for this show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "The show instance doesn't exist anymore!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Warning: Shows cannot be re-linked"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Show is empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "This show has no scheduled content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "This show is not completely filled with content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "January"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "February"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "March"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "May"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "June"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "July"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "August"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "September"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "October"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "December"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Oct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr "Today"
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr "Day"
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr "Week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr "Month"
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Sunday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Monday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Tuesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Wednesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Thursday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Friday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Saturday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Sun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Mon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Tue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Wed"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Thu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Fri"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Shows longer than their scheduled time will be cut off by a following show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Cancel Current Show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Stop recording current show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contents of Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Remove all content?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Delete selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Start"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "End"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duration"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr "Filtering out "
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr " of "
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr " records"
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show Empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Recording From Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Track preview"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Cannot schedule outside a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Moving 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Moving %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Save"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Waveform features are available in a browser supporting the Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Select all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Select none"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr "Trim overbooked shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Remove selected scheduled items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Jump to the current playing track"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancel current show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Open library to add or remove content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Add / Remove Content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "in use"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Look in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Open"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Program Manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Guest"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Guests can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "View schedule"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "View show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJs can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Manage assigned show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Import media files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Create playlists, smart blocks, and webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Manage their own library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Progam Managers can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "View and manage show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Schedule shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Manage all library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Admins can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Manage preferences"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Manage users"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Manage watched folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Send support feedback"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "View system status"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Access playout history"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "View listener stats"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Show / hide columns"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "From {from} to {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Su"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Mo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Tu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "We"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Th"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Fr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Close"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hour"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Done"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Select files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Add files to the upload queue and click the start button."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Add Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Stop Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Start upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Add files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Uploaded %d/%d files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Drag files here."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "File extension error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "File size error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "File count error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Security error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generic error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "File: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d files queued"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "File: %f, size: %s, max file size: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload URL might be wrong or doesn't exist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Error: File too large: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Error: Invalid file extension: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Set Default"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Create Entry"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Edit History Record"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "No Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Copied %s row%s to the clipboard"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press the Escape key when finished."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr "New Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr "New Log Entry"
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr "Please enter your username and password."
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr "There was a problem with the username or email address you entered."
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Wrong username or password provided. Please try again."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2407,6 @@ msgstr "You don't have permission to delete selected %s(s)."
 msgid "You can only add tracks to smart block."
 msgstr "You can only add tracks to smart block."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Untitled Playlist"
@@ -385,2627 +2415,88 @@ msgstr "Untitled Playlist"
 msgid "Untitled Smart Block"
 msgstr "Untitled Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Unknown Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr "Page not found."
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr "The requested action is not supported."
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr "You do not have permission to access this resource."
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr "An internal application error has occurred."
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "You are not allowed to access this resource."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preferences updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Support setting updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream Setting Updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "path should be specified"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem with Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr "Request method not accepted"
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "You don't have permission to disconnect source."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "There is no source connected to this input."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "You don't have permission to switch source."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr "Please enter your username and password."
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Wrong username or password provided. Please try again."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr "There was a problem with the username or email address you entered."
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "You are not allowed to access this resource. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr "File does not exist in %s"
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Bad request. no 'mode' parameter passed."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Bad request. 'mode' parameter is invalid"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Recording:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nothing Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Current Show:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Current"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "You are running the latest version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "New version available: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "This version will soon be obsolete."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "This version is no longer supported."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Please upgrade to "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Add to current playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Add to current smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Adding 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Adding %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "You can only add tracks to smart blocks."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Please select a cursor position on timeline."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr "You haven't added any tracks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr "You haven't added any playlists"
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr "You haven't added any smart blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr "You haven't added any webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr "Learn about tracks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr "Learn about playlists"
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr "Learn about smart blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr "Learn about webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr "Click 'New' to create one."
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Add to selected show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Select"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Select this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Deselect this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Deselect all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Are you sure you want to delete the selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr "Tracks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr "Playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bit Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded By"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Last Modified"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Last Played"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Owner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Sample Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Track Number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Uploaded"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Loading..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "All"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlists"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Unknown type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Are you sure you want to delete the selected item?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Uploading in progress..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "The SoundCloud id for this file is: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "There was an error while uploading to SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Error code: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Error msg: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Input must be a positive number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Input must be a number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Input must be in the format: yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Input must be in the format: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Open Media Builder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "please put in a time '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "please put in a time in seconds '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Your browser does not support playing this file type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dynamic block is not previewable"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limit to: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlist shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Listener Count on %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Remind me in 1 week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Remind me never"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Yes, help Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Image must be one of jpg, jpeg, png, or gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block generated and criteria saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Processing..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Select modifier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contains"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "does not contain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "is"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "is not"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "starts with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "ends with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "is greater than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "is less than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "is in the range"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Choose Storage Folder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Choose Folder to Watch"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Are you sure you want to change the storage folder?\nThis will remove the files from your Airtime library!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Manage Media Folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Are you sure you want to remove the watched folder?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "This path is currently not accessible."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Connected to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "The stream is disabled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Getting information from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Can not connect to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "For more details, please read the %sAirtime Manual%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Check this box to automatically switch on Master/Show source upon source connection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Warning: You cannot change this field while the show is currently playing"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "No result found"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Specify custom authentication which will work only for this show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "The show instance doesn't exist anymore!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Warning: Shows cannot be re-linked"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Show is empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "This show has no scheduled content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "This show is not completely filled with content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "January"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "February"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "March"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "May"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "June"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "July"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "August"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "September"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "October"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "December"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Oct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr "Today"
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr "Day"
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr "Week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr "Month"
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Sunday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Monday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Tuesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Wednesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Thursday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Friday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Saturday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Sun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Mon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Tue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Wed"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Thu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Fri"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Shows longer than their scheduled time will be cut off by a following show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Cancel Current Show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Stop recording current show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contents of Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Remove all content?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Delete selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Start"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "End"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duration"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr "Filtering out "
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr " of "
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr " records"
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show Empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Recording From Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Track preview"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Cannot schedule outside a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Moving 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Moving %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Save"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Waveform features are available in a browser supporting the Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Select all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Select none"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr "Trim overbooked shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Remove selected scheduled items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Jump to the current playing track"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancel current show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Open library to add or remove content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Add / Remove Content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "in use"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Look in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Open"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Program Manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Guest"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Guests can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "View schedule"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "View show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJs can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Manage assigned show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Import media files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Create playlists, smart blocks, and webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Manage their own library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Progam Managers can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "View and manage show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Schedule shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Manage all library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Admins can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Manage preferences"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Manage users"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Manage watched folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Send support feedback"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "View system status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Access playout history"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "View listener stats"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Show / hide columns"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "From {from} to {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Su"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Mo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Tu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "We"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Th"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Fr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Close"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hour"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Done"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Select files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Add files to the upload queue and click the start button."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Add Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Stop Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Start upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Add files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Uploaded %d/%d files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Drag files here."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "File extension error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "File size error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "File count error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Security error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generic error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "File: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d files queued"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "File: %f, size: %s, max file size: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload URL might be wrong or doesn't exist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Error: File too large: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Error: Invalid file extension: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Set Default"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Create Entry"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Edit History Record"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "No Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Copied %s row%s to the clipboard"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press the Escape key when finished."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr "New Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr "New Log Entry"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Select cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Remove cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "show does not exist"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Rebroadcast of show %s from %s at %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Select cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Remove cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "show does not exist"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "User added successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "User updated successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Settings updated successfully!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Untitled Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream saved."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Invalid form values."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr "Please click the 'New Show' button and fill out the required fields."
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr "It looks like you don't have any shows scheduled yet. %sCreate a show now%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr "Linked shows need to be filled with tracks before they start. To start broadcasting cancel the current linked show and schedule an unlinked show. %sCreate an unlinked show now%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr "To start broadcasting, click on the current show and select 'Schedule Tracks'"
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr "Click on the show starting next and select 'Schedule Tracks'"
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr "It looks like the next show is empty. %sAdd tracks to your show now%s."
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "The year %s must be within the range of 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s is not a valid date"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s is not a valid time"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr "Smart Block"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr "Webstream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr "Upload"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr "Dashboard"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr "Webstreams"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Play"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Set Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Set Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr "Drop files here or click to browse your computer."
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr "Failed"
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr "Pending"
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr "Recent Uploads"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Share"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Select stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "mute"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "unmute"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "About"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr "%1$s %2$s, the open radio software for scheduling and remote station management."
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr "%1$s %2$s is distributed under the %3$s"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr "Welcome to %s!"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr "Here's how you can get started using %s to automate your broadcasts: "
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr "Upload audio tracks"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr "Click the 'Upload' button in the left corner to upload tracks to your library."
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr "Schedule a show"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr "Add tracks to your show"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr "Now you're good to go!"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "For more detailed help, read the %suser manual%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr "Weekly Schedule"
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr "Preview:"
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr "Player"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout History"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Log Sheet"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "File Summary"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Show Summary"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Expand Static Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Expand Dynamic Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr "Choose some search criteria above and click Generate to create this playlist."
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr "A track list will be generated when you schedule this smart block into a show."
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr "Drag tracks here from your library to add them to the playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr "Editing "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Name:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Description:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Duration:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr "Toggle Details"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Empty playlist content"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Clear"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Save playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "No open playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Show Waveform"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr "Remove all content from this smart block"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr "No smart block currently open"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Original Length:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr "General"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Stream Settings"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr "Global"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr "Output Streams"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Login"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr "Email Sent!"
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr "Back"
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr "Password Reset"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "New password"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Please enter and confirm your new password in the fields below."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Manage Users"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "New User"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Username"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "First Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Last Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "User Type"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Find Shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Choose Show Instance"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Find"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr "My Profile"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Repeat Days:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Remove"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Add"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Show Source"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Register Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr "Click the box below to promote your station on %s."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Required)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(for verification purposes only, will not be published)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Note: Anything larger than 600x600 will be resized."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Show me what I am sending "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Choose Days:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr "Search Criteria:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr "New Criteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "or"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "and"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr "New Modifier"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " to "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "files meet the criteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr "file meets the criteria"
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter History"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr "Forgot your password?"
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Additional Options"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "The following info will be displayed to listeners in their media player:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Your radio station website)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Choose folder"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Set"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Current Import Folder:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr "Rescan watched directory (This is useful if it is a network mount and may be out of sync with %s)"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Remove watched directory"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "You are not watching any media folders."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr "Live Broadcasting"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master Source"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr "Use these settings in your broadcasting software to stream live at any time."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr "TuneIn Settings"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Settings"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr "Dangerous Options"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Add this show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Update show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "What"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "When"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live Stream Input"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Who"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Style"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Disk Space"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "File import in progress..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Advanced Search Options"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Title:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Creator:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Track:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Length:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Sample Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Mood:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Year:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Composer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conductor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Number:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Website:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Language:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "File Path:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamic Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Static Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audio Track"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Playlist Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Static Smart Block Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamic Smart Block Criteria: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limit to "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr "Viewing "
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr "Listeners"
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr "Stream Data Collection Status"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Your trial expires in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "days"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Previous:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Next:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Source Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Listen"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Logout"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr "Playout History Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "New Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "No Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "New File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "No File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Creating File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Creating Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Name"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Add more elements"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Add New Field"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Set Default Template"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Description"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Default Length:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "No webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr "An error has occurred."
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr "Access Denied!"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr "You do not have permission to access this page!"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Help"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr "Oops!"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr "Something went wrong!"
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr "Bad Request!"
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr "The requested action is not supported!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Page not found!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr "We couldn't find the page you were looking for."
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Looks like the page you were looking for doesn't exist!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "previous"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "play"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "next"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max volume"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Update Required"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr "Plan type:"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr "Billing cycle:"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr "Payment method:"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr "PayPal"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr "Credit Card via 2Checkout"
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Date Start:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2506,6 @@ msgstr "Date Start:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Invalid character entered"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Date End:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr "Filter by Show"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "All My Shows:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Search Users:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Station Name"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Phone:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Station Web Site:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Country:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "City:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Station Description:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Station Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Promote my station on %s"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "By checking this box, I agree to %s's %sprivacy policy%s."
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "You have to agree to privacy policy."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Record from Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Rebroadcast?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Value is required and can't be empty"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' does not fit the date format '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' is less than %min% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' is more than %max% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Passwords do not match"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2522,55 @@ msgstr "Time must be specified"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
-msgstr "Email"
-
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Reset password"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Untitled Show"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr "Instance Description:"
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr "Delete All Tracks in Library"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Number:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr "Station Description"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Default Crossfade Duration (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr "Please enter a time in seconds (e.g. 0.5)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Default Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Default Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr "Public Airtime API"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr "Required for embeddable schedule widget."
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Disabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Enabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr "Enabling this feature will allow Airtime to provide schedule data to external widgets that can be embedded in your website."
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr "Default Language"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Station Timezone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Week Starts On"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr "Display login button on your Radio Page?"
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Username:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Verify Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Firstname:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Lastname:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobile Phone:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "User Type:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Login name is not unique."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Import Folder:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Watched Folders:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Not a valid Directory"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr "What was the name of your favourite childhood friend?"
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr "Which school did you attend when you were twelve years old?"
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr "In which city, town or village did you meet the love of your life?"
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr "Which road did you live on when you were in primary school?"
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr "What was the first name of the first boy or girl that you kissed?"
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr "In which city or town did you have your first job?"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Default License:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "All rights are reserved"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "The work is in the public domain"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr "Default Sharing Type:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr "Public"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr "Private"
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface Timezone:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Now Playing"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr "Select Stream:"
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr "Auto-detect the most appropriate stream to use."
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr "Select a stream:"
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr " - Mobile friendly"
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr " - The player does not support Opus streams."
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr "Embeddable code:"
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr "Copy this code and paste it into your website's HTML to embed the player in your site."
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Select criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "hours"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutes"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "items"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr "Randomly"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr "Newest"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr "Oldest"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr "Type:"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Static"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamic"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr "Allow Repeated Tracks:"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr "Sort Tracks:"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr "Limit to:"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generate playlist content and save criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generate"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Shuffle playlist content"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limit cannot be empty or smaller than 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limit cannot be more than 24 hrs"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "The value should be an integer"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 is the max item limit value you can set"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "You must select Criteria and Modifier"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Length' should be in '00:00:00' format"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "The value has to be numeric"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "The value should be less then 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "The value should be less than %s characters"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Value cannot be empty"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Stream Label:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Station name - Show name"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Enable Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifier"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr "Streaming Server:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr "Airtime Pro Streaming"
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr "Custom / 3rd Party Streaming"
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirm new password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Password confirmation does not match your password."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr "Station Language"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Enabled:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr "Mobile:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Channels:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Only numbers are allowed."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin User"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Password"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount cannot be empty with Icecast server."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' does not fit the time format 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr "Start Time:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr "In the Future:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr "End Time:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Timezone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Repeats?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Cannot create show in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Cannot modify start date/time of the show that is already started"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "End date/time cannot be in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Cannot have duration < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Cannot have duration 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Cannot have duration greater than 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr "Push metadata to your station on TuneIn?"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr "Station ID:"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr "Partner Key:"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr "Partner Id:"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "Use %s Authentication:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Use Custom Authentication:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Custom Username"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Custom Password"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr "Host:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr "Port:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr "Mount:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Username field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Password field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Background Colour:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Text Colour:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr "Current Logo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr "Show Logo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr "Logo Preview:"
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Type the characters you see in the picture below."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr "Auto Switch Off:"
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr "Auto Switch On:"
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "days"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2616,12 @@ msgstr "day of the month"
 msgid "day of the week"
 msgstr "day of the week"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Date End:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "No End?"
@@ -3878,115 +2634,1177 @@ msgstr "End date must be after start date"
 msgid "Please select a repeat day"
 msgstr "Please select a repeat day"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
-msgstr "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Record from Line In?"
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Rebroadcast?"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
-msgstr "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Background Colour:"
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
-msgstr "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Text Colour:"
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
+msgstr "Current Logo:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Remove"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
-msgstr "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
+msgstr "Show Logo:"
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
+msgstr "Logo Preview:"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Name:"
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
-msgstr "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Untitled Show"
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
-msgstr "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
-msgstr "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
-msgstr "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Description:"
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
+msgstr "Instance Description:"
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
-msgstr "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' does not fit the time format 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
+msgstr "Start Time:"
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
-msgstr "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
+msgstr "In the Future:"
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr "End Time:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Duration:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Timezone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Repeats?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Cannot create show in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Cannot modify start date/time of the show that is already started"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "End date/time cannot be in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Cannot have duration < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Cannot have duration 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Cannot have duration greater than 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Cannot schedule overlapping shows"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Search Users:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Username:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Verify Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Firstname:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Lastname:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobile Phone:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "User Type:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Login name is not unique."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr "What was the name of your favourite childhood friend?"
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr "Which school did you attend when you were twelve years old?"
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr "In which city, town or village did you meet the love of your life?"
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr "Which road did you live on when you were in primary school?"
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr "What was the first name of the first boy or girl that you kissed?"
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr "In which city or town did you have your first job?"
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr "Plan type:"
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr "Billing cycle:"
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr "Payment method:"
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr "PayPal"
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr "Credit Card via 2Checkout"
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Value is required and can't be empty"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr "Delete All Tracks in Library"
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Date Start:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Title:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Creator:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Year:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Composer:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conductor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Mood:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Number:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Website:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Language:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Start Time"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "End Time"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface Timezone:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Station Name"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr "Station Description"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Station Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Note: Anything larger than 600x600 will be resized."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Default Crossfade Duration (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr "Please enter a time in seconds (e.g. 0.5)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Default Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Default Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Disabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Enabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr "Public Airtime API"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr "Required for embeddable schedule widget."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr "Enabling this feature will allow Airtime to provide schedule data to external widgets that can be embedded in your website."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr "Default Language"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Station Timezone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Week Starts On"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr "Display login button on your Radio Page?"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' does not fit the date format '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' is less than %min% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' is more than %max% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr "Auto Switch Off:"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr "Auto Switch On:"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr "Switch Transition Fade (s):"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Only numbers are allowed."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Login"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Type the characters you see in the picture below."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirm new password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Password confirmation does not match your password."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr "Email"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Username"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Reset password"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr "Back"
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Now Playing"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr "Select Stream:"
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr "Auto-detect the most appropriate stream to use."
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr "Select a stream:"
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr " - Mobile friendly"
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr " - The player does not support Opus streams."
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr "Embeddable code:"
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr "Copy this code and paste it into your website's HTML to embed the player in your site."
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr "Preview:"
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr "Public"
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr "Private"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Phone:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Station Web Site:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Country:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "City:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Station Description:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Promote my station on %s"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "By checking this box, I agree to %s's %sprivacy policy%s."
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "You have to agree to privacy policy."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr "Station Language"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr "Filter by Show"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "All My Shows:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Select criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Description"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "hours"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutes"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "items"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr "Randomly"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr "Newest"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr "Oldest"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr "Type:"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Static"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamic"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr "Allow Repeated Tracks:"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr "Sort Tracks:"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr "Limit to:"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generate playlist content and save criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generate"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Shuffle playlist content"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limit cannot be empty or smaller than 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limit cannot be more than 24 hrs"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "The value should be an integer"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 is the max item limit value you can set"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "You must select Criteria and Modifier"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Length' should be in '00:00:00' format"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "The value has to be numeric"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "The value should be less then 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "The value should be less than %s characters"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Value cannot be empty"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Default License:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "All rights are reserved"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "The work is in the public domain"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr "Default Sharing Type:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Stream Label:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Station name - Show name"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Enable Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifier"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr "Streaming Server:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr "Custom / 3rd Party Streaming"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Enabled:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr "Mobile:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Rate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Channels:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Name"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin User"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Password"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount cannot be empty with Icecast server."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr "Push metadata to your station on TuneIn?"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr "Station ID:"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr "Partner Key:"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr "Partner Id:"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Import Folder:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Watched Folders:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Not a valid Directory"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr "Smart Block"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr "Webstream"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr "Upload"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Play"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Set Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Set Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr "%s Password Reset"
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in and cue out are null."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Can't set cue out to be greater than file length."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Can't set cue in to be larger than cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Can't set cue out to be smaller than cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr "Upload Time"
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Rebroadcast of %s from %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr "Powered by %s"
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
+msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3829,12 @@ msgstr "%s is not a valid directory."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s is already set as the current storage dir or in the watched folders list"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s is already set as the current storage dir or in the watched folders list."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3842,18 @@ msgstr "%s is already set as the current storage dir or in the watched folders l
 msgid "%s doesn't exist in the watched list."
 msgstr "%s doesn't exist in the watched list."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
-msgstr "Hi %s, \n\nPlease click this link to reset your password: "
+msgid "Powered by %s"
+msgstr "Powered by %s"
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Select Country"
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Shows can have a max length of 24 hours."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Cannot schedule overlapping shows.\nNote: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr "livestream"
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3868,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "The schedule you're viewing is out of date! (instance mismatch)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "The schedule you're viewing is out of date!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "You are not allowed to schedule show %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "You cannot add files to recording shows."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "The show %s is over and cannot be scheduled."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "The show %s has been previously updated!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr "Cannot schedule a playlist that contains missing files."
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "A selected File does not exist!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
-msgstr "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Shows can have a max length of 24 hours."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Rebroadcast of %s from %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3968,1074 @@ msgstr "Invalid webstream - This appears to be a file download."
 msgid "Unrecognized stream type: %s"
 msgstr "Unrecognised stream type: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Record file doesn't exist"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "View Recorded File Metadata"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr "View"
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr "Schedule Tracks"
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr "Clear Show"
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr "Cancel Show"
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr "Edit Instance"
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edit"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edit Show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr "Delete Instance"
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr "Delete Instance and All Following"
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Permission denied"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Can't drag and drop repeating shows"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Can't move a past show"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Can't move show into past"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Show was deleted because recorded show does not exist!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Must wait 1 hour to rebroadcast."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Track"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Played"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "previous"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "play"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "next"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "mute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "unmute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max volume"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Update Required"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "About"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr "%1$s %2$s, the open radio software for scheduling and remote station management."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr "%1$s %2$s is distributed under the %3$s"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr "Welcome to %s!"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr "Here's how you can get started using %s to automate your broadcasts: "
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr "Upload audio tracks"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr "Click the 'Upload' button in the left corner to upload tracks to your library."
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr "Schedule a show"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr "Add tracks to your show"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr "Now you're good to go!"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "For more detailed help, read the %suser manual%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Share"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Select stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr "An error has occurred."
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr "Bad Request!"
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr "The requested action is not supported!"
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr "Access Denied!"
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr "You do not have permission to access this page!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Page not found!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr "We couldn't find the page you were looking for."
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr "Oops!"
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Looks like the page you were looking for doesn't exist!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Show Source"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Choose Days:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Add"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Repeat Days:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter History"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Choose Show Instance"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Find"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr "Forgot your password?"
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr "TuneIn Settings"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Settings"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr "Dangerous Options"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr "Live Broadcasting"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master Source"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr "Use these settings in your broadcasting software to stream live at any time."
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Choose folder"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Set"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Current Import Folder:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr "Rescan watched directory (This is useful if it is a network mount and may be out of sync with %s)"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Remove watched directory"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "You are not watching any media folders."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Register Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr "Click the box below to promote your station on %s."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Required)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(for verification purposes only, will not be published)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Show me what I am sending "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Terms and Conditions"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Find Shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr "Search Criteria:"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr "New Criteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "or"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "and"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr "New Modifier"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " to "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "files meet the criteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr "file meets the criteria"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Additional Options"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "The following info will be displayed to listeners in their media player:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Your radio station website)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr "Viewing "
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr "Editing "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Track:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Length:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Sample Rate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Number:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "File Path:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamic Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Static Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audio Track"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Playlist Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Static Smart Block Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamic Smart Block Criteria: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limit to "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "File import in progress..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Advanced Search Options"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr "Listeners"
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr "Stream Data Collection Status"
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "New password"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Please enter and confirm your new password in the fields below."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr "Email Sent!"
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr "Password Reset"
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr "Webstreams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Previous:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Next:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Source Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Listen"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Logout"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Your trial expires in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr "Toggle Details"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Empty playlist content"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Clear"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Save playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "No open playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Show Waveform"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Original Length:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr "Remove all content from this smart block"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr "No smart block currently open"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Expand Static Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Expand Dynamic Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr "Choose some search criteria above and click Generate to create this playlist."
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr "A track list will be generated when you schedule this smart block into a show."
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr "Drag tracks here from your library to add them to the playlist"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Log Sheet"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "File Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Show Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr "Playout History Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "New Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "No Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "New File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "No File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Creating File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Creating Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Add more elements"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Add New Field"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Set Default Template"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr "Drop files here or click to browse your computer."
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr "Failed"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr "Pending"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr "Recent Uploads"
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Stream Settings"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr "Global"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr "Output Streams"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Add this show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Update show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "What"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "When"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live Stream Input"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Who"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Style"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Disk Space"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Manage Users"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "New User"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "First Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Last Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "User Type"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Default Length:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "No webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+
+#~ msgid "Remove track"
+#~ msgstr "Remove track"
+
+#~ msgid "Upload track"
+#~ msgstr "Upload track"
+
+#~ msgid ""
+#~ "To configure and use the embeddable player you must:<br><br>\n"
+#~ "            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
+#~ "            2. Enable the Public Airtime API under System -> Preferences"
+#~ msgstr ""
+#~ "To configure and use the embeddable player you must:<br><br>\n"
+#~ "            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
+#~ "            2. Enable the Public Airtime API under System -> Preferences"
+
+#~ msgid ""
+#~ "To use the embeddable weekly schedule widget you must:<br><br>\n"
+#~ "            Enable the Public Airtime API under System -> Preferences"
+#~ msgstr ""
+#~ "To use the embeddable weekly schedule widget you must:<br><br>\n"
+#~ "            Enable the Public Airtime API under System -> Preferences"
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "please put in a time in seconds '00 (.0)'"
+
+#~ msgid "Airtime Pro Streaming"
+#~ msgstr "Airtime Pro Streaming"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"

--- a/airtime_mvc/locale/en_GB/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/en_GB/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/en_US/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Daniel James <daniel@64studio.com>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/sourcefabric/airtime/language/en_US/)\n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "The year %s must be within the range of 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s is not a valid date"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s is not a valid time"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edit"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edit Show"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Delete"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendar"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Users"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout History"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "History Templates"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Listener Stats"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Help"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Getting Started"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "User Manual"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "You are not allowed to access this resource."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "You are not allowed to access this resource. "
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Bad request. no 'mode' parameter passed."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Bad request. 'mode' parameter is invalid"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "You don't have permission to disconnect source."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "There is no source connected to this input."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "You don't have permission to switch source."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s not found"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Something went wrong."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Preview"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Add to Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Add to Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Delete"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplicate Playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "No action available"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "You don't have permission to delete selected items."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Copy of %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Untitled Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream saved."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Invalid form values."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Please make sure admin user/password is correct on System->Streams page."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Recording:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nothing Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Current Show:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Current"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "You are running the latest version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "New version available: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "This version will soon be obsolete."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "This version is no longer supported."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Please upgrade to "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Add to current playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Add to current smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Adding 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Adding %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "You can only add tracks to smart blocks."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Please select a cursor position on timeline."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edit Metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Add to selected show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Select"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Select this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Deselect this page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Deselect all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Are you sure you want to delete the selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Scheduled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Title"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Creator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bit Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Composer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Conductor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded By"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Language"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Last Modified"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Last Played"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Length"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Mood"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Owner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Track Number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Uploaded"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Year"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Loading..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "All"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlists"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blocks"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Unknown type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Are you sure you want to delete the selected item?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Uploading in progress..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "The SoundCloud id for this file is: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "There was an error while uploading to SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Error code: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Error msg: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Input must be a positive number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Input must be a number"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Input must be in the format: yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Input must be in the format: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Open Media Builder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "please put in a time '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Your browser does not support playing this file type: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dynamic block is not previewable"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limit to: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlist shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Listener Count on %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Remind me in 1 week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Remind me never"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Yes, help Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Image must be one of jpg, jpeg, png, or gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block shuffled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block generated and criteria saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block saved"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Processing..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Select modifier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contains"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "does not contain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "is"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "is not"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "starts with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "ends with"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "is greater than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "is less than"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "is in the range"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Choose Storage Folder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Choose Folder to Watch"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Manage Media Folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Are you sure you want to remove the watched folder?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "This path is currently not accessible."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Connected to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "The stream is disabled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Getting information from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Can not connect to the streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "For more details, please read the %sAirtime Manual%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Check this box to automatically switch on Master/Show source upon source connection."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Warning: You cannot change this field while the show is currently playing"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "No result found"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Specify custom authentication which will work only for this show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "The show instance doesn't exist anymore!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Warning: Shows cannot be re-linked"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Show is empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Retrieving data from the server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "This show has no scheduled content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "This show is not completely filled with content."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "January"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "February"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "March"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "May"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "June"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "July"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "August"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "September"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "October"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "December"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Oct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Sunday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Monday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Tuesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Wednesday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Thursday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Friday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Saturday"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Sun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Mon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Tue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Wed"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Thu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Fri"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Shows longer than their scheduled time will be cut off by a following show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Cancel Current Show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Stop recording current show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contents of Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Remove all content?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Delete selected item(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Start"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "End"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duration"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show Empty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Recording From Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Track preview"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Cannot schedule outside a show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Moving 1 Item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Moving %s Items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Save"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Editor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Waveform features are available in a browser supporting the Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Select all"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Select none"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Remove selected scheduled items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Jump to the current playing track"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancel current show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Open library to add or remove content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Add / Remove Content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "in use"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Look in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Open"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Program Manager"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Guest"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Guests can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "View schedule"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "View show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJs can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Manage assigned show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Import media files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Create playlists, smart blocks, and webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Manage their own library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Progam Managers can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "View and manage show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Schedule shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Manage all library content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Admins can do the following:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Manage preferences"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Manage users"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Manage watched folders"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Send support feedback"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "View system status"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Access playout history"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "View listener stats"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Show / hide columns"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "From {from} to {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Su"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Mo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Tu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "We"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Th"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Fr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Close"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hour"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Done"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Select files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Add files to the upload queue and click the start button."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Add Files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Stop Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Start upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Add files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Uploaded %d/%d files"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Drag files here."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "File extension error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "File size error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "File count error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Security error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generic error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO error."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "File: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d files queued"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "File: %f, size: %s, max file size: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload URL might be wrong or doesn't exist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Error: File too large: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Error: Invalid file extension: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Set Default"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Create Entry"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Edit History Record"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "No Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Copied %s row%s to the clipboard"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Wrong username or password provided. Please try again."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "You don't have permission to delete selected %s(s)."
 msgid "You can only add tracks to smart block."
 msgstr "You can only add tracks to smart block."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "You can only add tracks, smart blocks, and webstreams to playlists."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Untitled Playlist"
@@ -384,2627 +2414,88 @@ msgstr "Untitled Playlist"
 msgid "Untitled Smart Block"
 msgstr "Untitled Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Unknown Playlist"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "You are not allowed to access this resource."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preferences updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Support setting updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream Setting Updated."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "path should be specified"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem with Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "You don't have permission to disconnect source."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "There is no source connected to this input."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "You don't have permission to switch source."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Wrong username or password provided. Please try again."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "You are not allowed to access this resource. "
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Bad request. no 'mode' parameter passed."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Bad request. 'mode' parameter is invalid"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Recording:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nothing Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Current Show:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Current"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "You are running the latest version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "New version available: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "This version will soon be obsolete."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "This version is no longer supported."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Please upgrade to "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Add to current playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Add to current smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Adding 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Adding %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "You can only add tracks to smart blocks."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Please select a cursor position on timeline."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Add to selected show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Select"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Select this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Deselect this page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Deselect all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Are you sure you want to delete the selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Scheduled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bit Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded By"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Last Modified"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Last Played"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Owner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Sample Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Track Number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Uploaded"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Loading..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "All"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlists"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blocks"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Unknown type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Are you sure you want to delete the selected item?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Uploading in progress..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "The SoundCloud id for this file is: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "There was an error while uploading to SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Error code: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Error msg: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Input must be a positive number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Input must be a number"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Input must be in the format: yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Input must be in the format: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Open Media Builder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "please put in a time '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "please put in a time in seconds '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Your browser does not support playing this file type: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dynamic block is not previewable"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limit to: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlist shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Listener Count on %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Remind me in 1 week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Remind me never"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Yes, help Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Image must be one of jpg, jpeg, png, or gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block shuffled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block generated and criteria saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block saved"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Processing..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Select modifier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contains"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "does not contain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "is"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "is not"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "starts with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "ends with"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "is greater than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "is less than"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "is in the range"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Choose Storage Folder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Choose Folder to Watch"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Are you sure you want to change the storage folder?\nThis will remove the files from your Airtime library!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Manage Media Folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Are you sure you want to remove the watched folder?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "This path is currently not accessible."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Connected to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "The stream is disabled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Getting information from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Can not connect to the streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "For more details, please read the %sAirtime Manual%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Check this box to automatically switch off Master/Show source upon source disconnection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Check this box to automatically switch on Master/Show source upon source connection."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "If your Icecast server expects a username of 'source', this field can be left blank."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "If your live streaming client does not ask for a username, this field should be 'source'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Warning: You cannot change this field while the show is currently playing"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "No result found"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "This follows the same security pattern for the shows: only users assigned to the show can connect."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Specify custom authentication which will work only for this show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "The show instance doesn't exist anymore!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Warning: Shows cannot be re-linked"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Show is empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Retrieving data from the server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "This show has no scheduled content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "This show is not completely filled with content."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "January"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "February"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "March"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "May"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "June"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "July"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "August"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "September"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "October"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "December"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Oct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Sunday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Monday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Tuesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Wednesday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Thursday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Friday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Saturday"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Sun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Mon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Tue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Wed"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Thu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Fri"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Shows longer than their scheduled time will be cut off by a following show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Cancel Current Show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Stop recording current show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contents of Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Remove all content?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Delete selected item(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Start"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "End"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duration"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show Empty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Recording From Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Track preview"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Cannot schedule outside a show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Moving 1 Item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Moving %s Items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Save"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Editor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Waveform features are available in a browser supporting the Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Select all"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Select none"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Remove selected scheduled items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Jump to the current playing track"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancel current show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Open library to add or remove content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Add / Remove Content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "in use"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Look in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Open"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Program Manager"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Guest"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Guests can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "View schedule"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "View show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJs can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Manage assigned show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Import media files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Create playlists, smart blocks, and webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Manage their own library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Progam Managers can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "View and manage show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Schedule shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Manage all library content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Admins can do the following:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Manage preferences"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Manage users"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Manage watched folders"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Send support feedback"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "View system status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Access playout history"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "View listener stats"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Show / hide columns"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "From {from} to {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Su"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Mo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Tu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "We"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Th"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Fr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Close"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hour"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Done"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Select files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Add files to the upload queue and click the start button."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Add Files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Stop Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Start upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Add files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Uploaded %d/%d files"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Drag files here."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "File extension error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "File size error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "File count error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Security error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generic error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO error."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "File: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d files queued"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "File: %f, size: %s, max file size: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload URL might be wrong or doesn't exist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Error: File too large: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Error: Invalid file extension: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Set Default"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Create Entry"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Edit History Record"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "No Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Copied %s row%s to the clipboard"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Select cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Remove cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "show does not exist"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Rebroadcast of show %s from %s at %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Select cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Remove cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "show does not exist"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "User added successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "User updated successfully!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Settings updated successfully!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Untitled Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream saved."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Invalid form values."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "The year %s must be within the range of 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s is not a valid date"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s is not a valid time"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Play"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Set Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Set Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Share"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Select stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "mute"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "unmute"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "About"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "For more detailed help, read the %suser manual%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout History"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Log Sheet"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "File Summary"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Show Summary"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Expand Static Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Expand Dynamic Block"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Name:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Description:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Duration:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Empty playlist content"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Clear"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Save playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "No open playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Show Waveform"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Original Length:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Stream Settings"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Login"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "New password"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Please enter and confirm your new password in the fields below."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Manage Users"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "New User"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Username"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "First Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Last Name"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "User Type"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Find Shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Choose Show Instance"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Find"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Repeat Days:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Remove"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Add"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Show Source"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Register Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Required)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(for verification purposes only, will not be published)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Note: Anything larger than 600x600 will be resized."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Show me what I am sending "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Terms and Conditions"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Choose Days:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "or"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "and"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " to "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "files meet the criteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter History"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Additional Options"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "The following info will be displayed to listeners in their media player:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Your radio station website)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Choose folder"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Set"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Current Import Folder:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Remove watched directory"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "You are not watching any media folders."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master Source"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Settings"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Add this show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Update show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "What"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "When"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live Stream Input"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Who"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Style"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Disk Space"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "File import in progress..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Advanced Search Options"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Title:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Creator:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Track:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Length:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Sample Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Mood:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Year:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Composer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conductor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Number:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Website:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Language:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "File Path:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamic Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Static Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audio Track"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Playlist Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Static Smart Block Contents: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamic Smart Block Criteria: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limit to "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Your trial expires in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "days"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Previous:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Next:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Source Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Listen"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Logout"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "New Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "No Log Sheet Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "New File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "No File Summary Templates"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Creating File Summary Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Creating Log Sheet Template"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Name"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Add more elements"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Add New Field"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Set Default Template"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Description"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Default Length:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "No webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Help"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Page not found!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Looks like the page you were looking for doesn't exist!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "previous"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "play"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "next"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max volume"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Update Required"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Date Start:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Date Start:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Invalid character entered"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Date End:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "All My Shows:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Search Users:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Station Name"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Phone:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Station Web Site:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Country:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "City:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Station Description:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Station Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "You have to agree to privacy policy."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Record from Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Rebroadcast?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Value is required and can't be empty"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' does not fit the date format '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' is less than %min% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' is more than %max% characters long"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Passwords do not match"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "Time must be specified"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Must wait at least 1 hour to rebroadcast"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Reset password"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Untitled Show"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Number:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Default Crossfade Duration (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Default Fade In (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Default Fade Out (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Disabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Enabled"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Station Timezone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Week Starts On"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Username:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Verify Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Firstname:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Lastname:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobile Phone:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "User Type:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Login name is not unique."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Import Folder:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Watched Folders:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Not a valid Directory"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Default License:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "All rights are reserved"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "The work is in the public domain"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface Timezone:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Now Playing"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Select criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "hours"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutes"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "items"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Static"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamic"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generate playlist content and save criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generate"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Shuffle playlist content"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limit cannot be empty or smaller than 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limit cannot be more than 24 hrs"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "The value should be an integer"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 is the max item limit value you can set"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "You must select Criteria and Modifier"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Length' should be in '00:00:00' format"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "The value has to be numeric"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "The value should be less then 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "The value should be less than %s characters"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Value cannot be empty"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Stream Label:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artist - Title"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Station name - Show name"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Enable Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifier"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirm new password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Password confirmation does not match your password."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Enabled:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Channels:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Only numbers are allowed."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin User"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Password"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port cannot be empty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount cannot be empty with Icecast server."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' does not fit the time format 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Timezone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Repeats?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Cannot create show in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Cannot modify start date/time of the show that is already started"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "End date/time cannot be in the past"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Cannot have duration < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Cannot have duration 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Cannot have duration greater than 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Use Custom Authentication:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Custom Username"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Custom Password"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Username field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Password field cannot be empty."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Background Color:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Text Color:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Type the characters you see in the picture below."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "days"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr "day of the month"
 msgid "day of the week"
 msgstr "day of the week"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Date End:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "No End?"
@@ -3877,115 +2633,1174 @@ msgstr "End date must be after start date"
 msgid "Please select a repeat day"
 msgstr "Please select a repeat day"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Record from Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Rebroadcast?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Background Color:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Text Color:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendar"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Remove"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Users"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Name:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Untitled Show"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Description:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Listener Stats"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' does not fit the time format 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "History Templates"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Duration:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Timezone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Repeats?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Cannot create show in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Cannot modify start date/time of the show that is already started"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "End date/time cannot be in the past"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Cannot have duration < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Cannot have duration 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Cannot have duration greater than 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Cannot schedule overlapping shows"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Search Users:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Username:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Verify Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Firstname:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Lastname:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobile Phone:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "User Type:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Login name is not unique."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Getting Started"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "User Manual"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Value is required and can't be empty"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Date Start:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Title:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Creator:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Year:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Composer:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conductor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Mood:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Number:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Website:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Language:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Start Time"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "End Time"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface Timezone:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Station Name"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Station Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Note: Anything larger than 600x600 will be resized."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Default Crossfade Duration (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Default Fade In (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Default Fade Out (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Disabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Enabled"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Station Timezone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Week Starts On"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' is no valid email address in the basic format local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' does not fit the date format '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' is less than %min% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' is more than %max% characters long"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' is not between '%min%' and '%max%', inclusively"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Only numbers are allowed."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Login"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Type the characters you see in the picture below."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirm new password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Password confirmation does not match your password."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Username"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Reset password"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Now Playing"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Phone:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Station Web Site:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Country:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "City:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Station Description:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "You have to agree to privacy policy."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "All My Shows:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Select criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Description"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "hours"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutes"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "items"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Static"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamic"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generate playlist content and save criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generate"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Shuffle playlist content"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limit cannot be empty or smaller than 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limit cannot be more than 24 hrs"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "The value should be an integer"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 is the max item limit value you can set"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "You must select Criteria and Modifier"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Length' should be in '00:00:00' format"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "The value has to be numeric"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "The value should be less then 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "The value should be less than %s characters"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Value cannot be empty"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Default License:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "All rights are reserved"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "The work is in the public domain"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Stream Label:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artist - Title"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Station name - Show name"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Enable Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifier"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Enabled:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Rate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Channels:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Name"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin User"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Password"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port cannot be empty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount cannot be empty with Icecast server."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Import Folder:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Watched Folders:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Not a valid Directory"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Play"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Set Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Set Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in and cue out are null."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Can't set cue out to be greater than file length."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Can't set cue in to be larger than cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Can't set cue out to be smaller than cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Rebroadcast of %s from %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Select Country"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s is not a valid directory."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s is already set as the current storage dir or in the watched folders list"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s is already set as the current storage dir or in the watched folders list."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s is already set as the current storage dir or in the watched folders l
 msgid "%s doesn't exist in the watched list."
 msgstr "%s doesn't exist in the watched list."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Select Country"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Shows can have a max length of 24 hours."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Cannot schedule overlapping shows.\nNote: Resizing a repeating show affects all of its repeats."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "The schedule you're viewing is out of date! (instance mismatch)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "The schedule you're viewing is out of date!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "You are not allowed to schedule show %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "You cannot add files to recording shows."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "The show %s is over and cannot be scheduled."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "The show %s has been previously updated!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "A selected File does not exist!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Shows can have a max length of 24 hours."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Rebroadcast of %s from %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1049 @@ msgstr "Invalid webstream - This appears to be a file download."
 msgid "Unrecognized stream type: %s"
 msgstr "Unrecognized stream type: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Record file doesn't exist"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "View Recorded File Metadata"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edit"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edit Show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Permission denied"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Can't drag and drop repeating shows"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Can't move a past show"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Can't move show into past"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Can't move a recorded show less than 1 hour before its rebroadcasts."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Show was deleted because recorded show does not exist!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Must wait 1 hour to rebroadcast."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Track"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Played"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "previous"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "play"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "next"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "mute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "unmute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max volume"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Update Required"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "About"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "For more detailed help, read the %suser manual%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Share"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Select stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Page not found!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Looks like the page you were looking for doesn't exist!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Show Source"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Choose Days:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Add"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Repeat Days:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter History"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Choose Show Instance"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Find"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Settings"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master Source"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Choose folder"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Set"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Current Import Folder:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Remove watched directory"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "You are not watching any media folders."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Register Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Required)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(for verification purposes only, will not be published)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Show me what I am sending "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Terms and Conditions"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Find Shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "or"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "and"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " to "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "files meet the criteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Additional Options"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "The following info will be displayed to listeners in their media player:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Your radio station website)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(In order to promote your station, 'Send support feedback' must be enabled)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Track:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Length:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Sample Rate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Number:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "File Path:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamic Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Static Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audio Track"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Playlist Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Static Smart Block Contents: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamic Smart Block Criteria: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limit to "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "File import in progress..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Advanced Search Options"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "New password"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Please enter and confirm your new password in the fields below."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Previous:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Next:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Source Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Listen"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Logout"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Your trial expires in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Empty playlist content"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Clear"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Save playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "No open playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Show Waveform"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Original Length:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Expand Static Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Expand Dynamic Block"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Log Sheet"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "File Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Show Summary"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "New Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "No Log Sheet Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "New File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "No File Summary Templates"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Creating File Summary Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Creating Log Sheet Template"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Add more elements"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Add New Field"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Set Default Template"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Stream Settings"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Add this show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Update show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "What"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "When"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live Stream Input"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Who"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Style"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Disk Space"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Manage Users"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "New User"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "First Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Last Name"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "User Type"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Default Length:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "No webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "please put in a time in seconds '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Content in linked shows must be scheduled before or after any one is broadcasted"

--- a/airtime_mvc/locale/en_US/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/en_US/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/es_ES/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Maria Ituarte <maria.ituarte@sourcefabric.org>, 2015
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -10,266 +10,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-25 13:52+0000\n"
 "Last-Translator: Maria Ituarte <maria.ituarte@sourcefabric.org>\n"
 "Language-Team: Spanish (Spain) (http://www.transifex.com/sourcefabric/airtime/language/es_ES/)\n"
+"Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es_ES\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "No existe el archivo"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "El año %s debe estar dentro del rango de 1753-9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Ver los metadatos del archivo grabado"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s no es una fecha válida"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s no es una hora válida"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Editar"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Editar show"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Eliminar"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "No es posible arrastrar y soltar shows que se repiten"
-
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "No se puede mover un show pasado"
-
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "No se puede mover un show al pasado"
-
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "No se pueden programar shows traslapados"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "No se pueden mover shows grabados a menos de 1 hora antes de su retransmisión."
-
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "El show se eliminó porque el show grabado no existe!"
-
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Debe esperar 1 hora para retransmitir."
-
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Título"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Creador"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Álbum"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Duración"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Género"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Estilo (mood)"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Sello"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Compositor"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
-
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Derechos de autor"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Año"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Director"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Idioma"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Tiempo de Inicio"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Tiempo de Finalización"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Reproducido"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendario"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Usuarios"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Estatus"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Historial de reproducción"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Estadísticas de oyentes"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Ayuda"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Cómo iniciar"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Manual para el usuario"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "No tienes permiso para acceder esta fuente."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "No tienes permiso para acceder a esta fuente."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Solicitud errónea.  Ningún parámetro 'mode' pasó."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Solicitud errónea.  El parámetro 'mode' es inválido"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "No tienes permiso para desconectar la fuente."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "No hay fuente conectada a esta entrada."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "No tienes permiso para prender/apagar la fuente."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "No se encontró %s"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Algo falló."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Previsualizar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Agregar a lista de reproducción."
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Agregar un bloque inteligente"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Editar metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Eliminar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Descargar"
 
@@ -278,81 +892,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Lista de reproducción duplicada"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "No una acción disponible"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "No tienes permiso para eliminar los ítems seleccionados."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Copia de %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Se almacenó el webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Los valores en el formulario son inválidos."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Verifica que la contraseña del usuario admin. esté correcta en Sistema->página de streams."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Se agregó exitosamente el usuario."
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Reproductor de audio"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Se actualizó exitosamente el usuario."
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "¡Configuraciones actualizadas con éxito!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Grabando:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Stream maestro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Stream en vivo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nada programado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Show actual:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Actual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Estás usando la versión más reciente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Ya está disponible una versión nueva:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Pronto esta versión será obsoleta."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Esta versión ya no cuenta con soporte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Por favor actualiza a"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Añadir a la lista de reproducción actual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Añadir al bloque inteligente actual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Añadiendo 1 item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Añadiendo %s  ítems"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Solo puedes añadir pistas a bloques inteligentes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "solo puedes añadir pistas, bloques inteligentes y webstreams a listas de reproducción."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Indica tu selección en la lista de reproducción actual."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Editar metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Añadir al show seleccionado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Seleccionar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Seleccionar esta página"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Deseleccionar esta página"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Deseleccionar todo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "¿De verdad quieres eliminar los ítems seleccionados?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Título"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Creador"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Álbum"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Tasa de bits"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Compositor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Director"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Derechos de autor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Codificado por"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Género"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Sello"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Idioma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Último modificado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Último reproducido"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Duración"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Estilo (mood)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Propietario"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Ganancia en la repetición"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Tasa de muestreo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Número de registro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Cargado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Sitio web"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Año"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Cargando..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Todo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Archivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Listas de reproducción"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Bloques inteligentes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Tipo desconocido:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "¿De verdad deseas eliminar el ítem seleccionado?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Carga en progreso..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Recolectando data desde el servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "El ID de SoundCloud para este archivo es:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Se registró un error mientras se cargaba a SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Código de error:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Msg de error:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "La entrada debe ser un número positivo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "La entrada debe ser un  número"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "La entrada debe estar en el siguiente formato:  yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "La entrada debe estar en el siguiente formato:  hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Actualmente estas subiendo archivos.  %sSi cambias de pantalla el proceso de carga se cancelará.  %s¿De verdad quieres dejar esta página e ir a otra?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "por favor ingresa un tiempo '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Tu navegador no respalda la reproducción de este tipo de archivos:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Los bloques dinámicos no se pueden previsualizar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limitado a:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Se guardó la lista de reproducción"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Se mezclaron las listas de reproducción."
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime no está seguro del estatus de este archivo.  Esto puede ocurrir cuando el archivo está en un disco remoto que no está accesible o el archivo está en un directorio que ya no está 'monitoreado'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "El conteo de los oyentes en  %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Recuérdame en 1 semana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Nunca me recuerdes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Sí, ayudar a Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "La imagen debe ser jpg, jpeg, png, o gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Un bloque inteligente estático almacenará los criterios y generará el contenido del bloque inmediatamente.  Esto te permite editarlo y verlo en la biblioteca antes de agregarlo a un show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Un bloque inteligente dinámico sólo guardará los criterios.  El contenido del bloque será generado al agregarlo a un show.  No podrás ver ni editar el contenido en la Biblioteca."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "La duración deseada para el bloque no se alcanzará si Airtime no puede encontrar suficientes pistas únicas que se ajusten a tus criterios.  Activa esta opción si deseas que se agreguen pistas varias veces al bloque inteligente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Se reprodujo el bloque inteligente de forma aleatoria"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Bloque inteligente generado y criterios guardados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Se guardó el bloque inteligente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Procesando..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Elige un modificador"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contiene"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "no contiene"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "es"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "no es"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "empieza con"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "termina con"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "es mayor que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "es menor que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "está en el rango de"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Elegir carpeta de almacenamiento"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Elegir carpeta para monitorear"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"¿Estás seguro de querer cambiar la carpeta de almacenamiento?\n"
+" ¡Esto eliminará los archivos de tu biblioteca de Airtime!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Administrar las Carpetas de Medios"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "¿Estás seguro de que quieres quitar la carpeta monitoreada?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Esta ruta actualmente está inaccesible."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Conectado al servidor de streaming"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Se desactivó el stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Obteniendo información desde el servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "No es posible conectar el servidor de streaming"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Si Airtime está detrás de un router o firewall, posiblemente tengas que configurar una redirección en el puerto (port forwarding) y esta información de campo será incorrecta.  En este caso necesitarás actualizar manualmente el campo pra que muestre el host/port/mount correcto al que tus DJs necesitan conectarse.  El rango permitido es entre 1024 y 49151. "
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Para más detalles, por favor lee el Manual%s de %sAirtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Elige esta opción para activar los metadatos de los streams OGG (los metadatos del stream incluyen información de la pista como título, artista y nombre del show, los cuales se desplegarán en el reproductor de audio).  VLC y mplayer muestran un bug serio cuando reproducen streams OGG/VORBIS que tienen los metadatos activados:  se desconectarán del stream después de cada pista.  Si eestas usando un stream OGG y tus oyentes no requieren soporte para estos reproductores de audio, entonces activa esta opción."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Elige esta opción para desactivar automáticamente la fuente maestra/del show cuando ocurra una desconexión de la fuente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Elige esta opción para activar automáticamente la fuente maestra/del show cuando ocurra una desconexión de la fuente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Si tu servidor de Icecast te pide un usuario para la 'source' (fuente), puedes dejar este campo en blanco."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Si tu cliente de streaming en vivo no te pide un usuario, este campo debe ser la 'source' (fuente)."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Este es el usuario y contraseña administrativa de Icecast/SHOUTcast para obtener las estadísticas de oyentes."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Sin resultados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Esto sigue el mismo patrón de seguridad de los shows:  solo los usuarios asignados al show se pueden conectar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Especifique una autenticación personalizada que funcione solo para este show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "¡La instancia de este show ya no existe!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "El show está vacío"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Recopilando información desde el servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Este show no cuenta con contenido programado."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "A este show le falta contenido.  "
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "enero"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "febrero"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "marzo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "abril"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "mayo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "junio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "julio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "agosto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "septiembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "octubre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "noviembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "diciembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Ene"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "abr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "ag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "sept"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "oct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "dic"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "domingo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "lunes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "martes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "miércoles"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "jueves"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Viernes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Sábado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Dom"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Lun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Miér"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Jue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Vier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sab"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Los shows que sean más largos que su segmento programado serán cortados por el show que continúe."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "¿Deseas cancelar el show actual?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "¿Deseas detener la grabación del show actual?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contenidos del show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "¿Eliminar todo el contenido?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "¿Eliminar los ítems seleccionados?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Inicio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Final"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duración"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show vacío"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Grabando desde la entrada"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Previsualización de la pista"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "No es posible programar un show externo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Moviendo 1 ítem"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Moviendo %s ítems."
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Guardar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Seleccionar todos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Seleccionar uno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Eliminar los ítems programados seleccionados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Saltar a la pista en reproducción actual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancelar el show actual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Abrir biblioteca para agregar o eliminar contenido"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Agregar / eliminar contenido"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "en uso"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disco"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Buscar en"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Abrir"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Administrador de programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Invitado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Los invitados pueden hacer lo siguiente:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Ver programación"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Ver contenido del show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Los DJ pueden hacer lo siguiente:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Administrar el contenido del show asignado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Importar archivos de medios"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Crear listas de reproducción, bloques inteligentes y webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Administrar su propia biblioteca de contenido"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Los encargados de programa pueden hacer lo siguiente:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Ver y administrar contenido del show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Programar shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Administrar el contenido de toda la biblioteca"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Los administradores pueden:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Administrar preferencias"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Administrar usuarios"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Administrar folders monitoreados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Enviar retroalimentación respecto al soporte técnico"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Ver el estatus del sistema"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Acceder al historial de reproducción"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Ver las estadísticas de los oyentes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Mostrar / ocultar columnas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "De {from} para {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Dom"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Lun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Miér"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Jue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Vier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sáb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Cerrar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hora"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Hecho"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Seleccione los archivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Añade los archivos a la cola de carga y haz clic en el botón de iniciar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Añadir archivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Detener carga"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Iniciar carga"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Añadir archivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Archivos %d/%d cargados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "No disponible"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Arrastra los archivos a esta área."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Error de extensión del archivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Error de tamaño del archivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Error de cuenta del archivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Error de inicialización."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Error de HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Error de seguridad."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Error genérico."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Error IO."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Archivo: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d archivos en cola"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Archivo: %f, tamaño: %s, tamaño máximo del archivo: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Puede que el URL de carga no esté funcionando o no exista"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Error:  el archivo es demasiado grande:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Error:  extensión de archivo inválida:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Se copiaron %s celda%s al portapapeles"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "Vista%s de %simpresión Por favor usa tu navegador para imprimir esta tabla.  Presiona escape cuando termines."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "No fue posible enviar el correo electrónico.  Revisa tu configuración de correo y asegúrate de que sea correcta."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "El usuario o la contraseña son incorrectos.  Por favor intenta de nuevo."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2407,6 @@ msgstr "No tienes permiso para eliminar los %s(s) seleccionados."
 msgid "You can only add tracks to smart block."
 msgstr "Solo puedes añadir pistas a los bloques inteligentes."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "solo puedes añadir pistas, bloques inteligentes y webstreams a listas de reproducción."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Lista de reproducción sin nombre"
@@ -385,2627 +2415,88 @@ msgstr "Lista de reproducción sin nombre"
 msgid "Untitled Smart Block"
 msgstr "Bloque inteligente sin nombre"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Lista de reproducción desconocida"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "No tienes permiso para acceder esta fuente."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Se actualizaron las preferencias."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Se actualizaron las configuraciones de soporte."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Tu estación en nuestro catálogo"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Se actualizaron las configuraciones del stream."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "se debe especificar la ruta"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Hay un problema con Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "No tienes permiso para desconectar la fuente."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "No hay fuente conectada a esta entrada."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "No tienes permiso para prender/apagar la fuente."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "El usuario o la contraseña son incorrectos.  Por favor intenta de nuevo."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "No fue posible enviar el correo electrónico.  Revisa tu configuración de correo y asegúrate de que sea correcta."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "No tienes permiso para acceder a esta fuente."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Solicitud errónea.  Ningún parámetro 'mode' pasó."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Solicitud errónea.  El parámetro 'mode' es inválido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Reproductor de audio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Grabando:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Stream maestro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Stream en vivo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nada programado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Show actual:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Actual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Estás usando la versión más reciente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Ya está disponible una versión nueva:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Pronto esta versión será obsoleta."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Esta versión ya no cuenta con soporte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Por favor actualiza a"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Añadir a la lista de reproducción actual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Añadir al bloque inteligente actual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Añadiendo 1 item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Añadiendo %s  ítems"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Solo puedes añadir pistas a bloques inteligentes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Indica tu selección en la lista de reproducción actual."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Añadir al show seleccionado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Seleccionar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Seleccionar esta página"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Deseleccionar esta página"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Deseleccionar todo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "¿De verdad quieres eliminar los ítems seleccionados?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Tasa de bits"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Codificado por"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Último modificado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Último reproducido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Propietario"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Ganancia en la repetición"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Tasa de muestreo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Número de registro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Cargado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Sitio web"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Cargando..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Todo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Archivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Listas de reproducción"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Bloques inteligentes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Tipo desconocido:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "¿De verdad deseas eliminar el ítem seleccionado?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Carga en progreso..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Recolectando data desde el servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "El ID de SoundCloud para este archivo es:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Se registró un error mientras se cargaba a SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Código de error:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Msg de error:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "La entrada debe ser un número positivo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "La entrada debe ser un  número"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "La entrada debe estar en el siguiente formato:  yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "La entrada debe estar en el siguiente formato:  hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Actualmente estas subiendo archivos.  %sSi cambias de pantalla el proceso de carga se cancelará.  %s¿De verdad quieres dejar esta página e ir a otra?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "por favor ingresa un tiempo '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "por favor ingresa un tiempo '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Tu navegador no respalda la reproducción de este tipo de archivos:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Los bloques dinámicos no se pueden previsualizar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limitado a:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Se guardó la lista de reproducción"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Se mezclaron las listas de reproducción."
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime no está seguro del estatus de este archivo.  Esto puede ocurrir cuando el archivo está en un disco remoto que no está accesible o el archivo está en un directorio que ya no está 'monitoreado'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "El conteo de los oyentes en  %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Recuérdame en 1 semana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Nunca me recuerdes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Sí, ayudar a Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "La imagen debe ser jpg, jpeg, png, o gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Un bloque inteligente estático almacenará los criterios y generará el contenido del bloque inmediatamente.  Esto te permite editarlo y verlo en la biblioteca antes de agregarlo a un show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Un bloque inteligente dinámico sólo guardará los criterios.  El contenido del bloque será generado al agregarlo a un show.  No podrás ver ni editar el contenido en la Biblioteca."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "La duración deseada para el bloque no se alcanzará si Airtime no puede encontrar suficientes pistas únicas que se ajusten a tus criterios.  Activa esta opción si deseas que se agreguen pistas varias veces al bloque inteligente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Se reprodujo el bloque inteligente de forma aleatoria"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Bloque inteligente generado y criterios guardados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Se guardó el bloque inteligente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Procesando..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Elige un modificador"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contiene"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "no contiene"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "es"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "no es"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "empieza con"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "termina con"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "es mayor que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "es menor que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "está en el rango de"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Elegir carpeta de almacenamiento"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Elegir carpeta para monitorear"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "¿Estás seguro de querer cambiar la carpeta de almacenamiento?\n ¡Esto eliminará los archivos de tu biblioteca de Airtime!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Administrar las Carpetas de Medios"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "¿Estás seguro de que quieres quitar la carpeta monitoreada?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Esta ruta actualmente está inaccesible."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Conectado al servidor de streaming"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Se desactivó el stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Obteniendo información desde el servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "No es posible conectar el servidor de streaming"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Si Airtime está detrás de un router o firewall, posiblemente tengas que configurar una redirección en el puerto (port forwarding) y esta información de campo será incorrecta.  En este caso necesitarás actualizar manualmente el campo pra que muestre el host/port/mount correcto al que tus DJs necesitan conectarse.  El rango permitido es entre 1024 y 49151. "
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Para más detalles, por favor lee el Manual%s de %sAirtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Elige esta opción para activar los metadatos de los streams OGG (los metadatos del stream incluyen información de la pista como título, artista y nombre del show, los cuales se desplegarán en el reproductor de audio).  VLC y mplayer muestran un bug serio cuando reproducen streams OGG/VORBIS que tienen los metadatos activados:  se desconectarán del stream después de cada pista.  Si eestas usando un stream OGG y tus oyentes no requieren soporte para estos reproductores de audio, entonces activa esta opción."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Elige esta opción para desactivar automáticamente la fuente maestra/del show cuando ocurra una desconexión de la fuente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Elige esta opción para activar automáticamente la fuente maestra/del show cuando ocurra una desconexión de la fuente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Si tu servidor de Icecast te pide un usuario para la 'source' (fuente), puedes dejar este campo en blanco."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Si tu cliente de streaming en vivo no te pide un usuario, este campo debe ser la 'source' (fuente)."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Este es el usuario y contraseña administrativa de Icecast/SHOUTcast para obtener las estadísticas de oyentes."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Sin resultados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Esto sigue el mismo patrón de seguridad de los shows:  solo los usuarios asignados al show se pueden conectar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Especifique una autenticación personalizada que funcione solo para este show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "¡La instancia de este show ya no existe!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "El show está vacío"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Recopilando información desde el servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Este show no cuenta con contenido programado."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "A este show le falta contenido.  "
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "enero"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "febrero"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "marzo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "abril"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "mayo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "junio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "julio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "agosto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "septiembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "octubre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "noviembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "diciembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Ene"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "abr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "ag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "sept"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "oct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "dic"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "domingo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "lunes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "martes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "miércoles"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "jueves"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Viernes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Sábado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Dom"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Lun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Miér"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Jue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Vier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sab"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Los shows que sean más largos que su segmento programado serán cortados por el show que continúe."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "¿Deseas cancelar el show actual?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "¿Deseas detener la grabación del show actual?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contenidos del show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "¿Eliminar todo el contenido?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "¿Eliminar los ítems seleccionados?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Inicio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Final"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duración"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show vacío"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Grabando desde la entrada"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Previsualización de la pista"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "No es posible programar un show externo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Moviendo 1 ítem"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Moviendo %s ítems."
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Guardar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Seleccionar todos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Seleccionar uno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Eliminar los ítems programados seleccionados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Saltar a la pista en reproducción actual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancelar el show actual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Abrir biblioteca para agregar o eliminar contenido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Agregar / eliminar contenido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "en uso"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disco"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Buscar en"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Abrir"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Administrador de programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Invitado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Los invitados pueden hacer lo siguiente:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Ver programación"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Ver contenido del show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Los DJ pueden hacer lo siguiente:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Administrar el contenido del show asignado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Importar archivos de medios"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Crear listas de reproducción, bloques inteligentes y webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Administrar su propia biblioteca de contenido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Los encargados de programa pueden hacer lo siguiente:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Ver y administrar contenido del show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Programar shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Administrar el contenido de toda la biblioteca"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Los administradores pueden:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Administrar preferencias"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Administrar usuarios"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Administrar folders monitoreados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Enviar retroalimentación respecto al soporte técnico"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Ver el estatus del sistema"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Acceder al historial de reproducción"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Ver las estadísticas de los oyentes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Mostrar / ocultar columnas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "De {from} para {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Dom"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Lun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Miér"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Jue"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Vier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sáb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Cerrar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hora"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Hecho"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Seleccione los archivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Añade los archivos a la cola de carga y haz clic en el botón de iniciar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Estatus"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Añadir archivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Detener carga"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Iniciar carga"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Añadir archivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Archivos %d/%d cargados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "No disponible"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Arrastra los archivos a esta área."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Error de extensión del archivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Error de tamaño del archivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Error de cuenta del archivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Error de inicialización."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Error de HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Error de seguridad."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Error genérico."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Error IO."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Archivo: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d archivos en cola"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Archivo: %f, tamaño: %s, tamaño máximo del archivo: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Puede que el URL de carga no esté funcionando o no exista"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Error:  el archivo es demasiado grande:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Error:  extensión de archivo inválida:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Se copiaron %s celda%s al portapapeles"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "Vista%s de %simpresión Por favor usa tu navegador para imprimir esta tabla.  Presiona escape cuando termines."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Elegir cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Eliminar cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "El show no existe"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Retransmitir el show %s  de %s  a %s "
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "El año %s debe estar dentro del rango de 1753-9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s no es una fecha válida"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s no es una hora válida"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Stream en vivo"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr "Bloque Inteligente"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Compartir"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Seleccionar stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "silenciar"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "desactivar silencio"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Sobre nosotros"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Para una ayuda más detallada, lee el manual%s del %susuario."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Historial de reproducción"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Expandir bloque estático"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Expandir bloque dinámico"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Nombre:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Descripción:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Duración:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Lista de reproducción aleatoria"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Reproducción aleatoria"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Transición (crossfade) de la lista de reproducción"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Almacenar lista de reproducción"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "No hay listas de reproducción abiertas"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue in:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue out:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Duración original:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Configuración de stream"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Ingreso"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nueva contraseña"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Por favor ingrese y confirme una nueva cotnraseña en los campos que aparecen a continuación."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Administrar usuarios"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nuevo usuario"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Usuario"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Nombre"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Apellido"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Tipo de usuario"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Encontrar shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Elegir cursor"
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Días en que se repite:"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Eliminar cursor"
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Elimina"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "El show no existe"
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Añadir"
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Se agregó exitosamente el usuario."
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Fuente del show"
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Se actualizó exitosamente el usuario."
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Registrar Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Requerido)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(únicamente para fines de verificación, no será publicado)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Nota:  cualquier cosa mayor a 600x600 será redimensionada."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Muéstrame lo que estoy enviando"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Términos y condiciones"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Elige los días:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "para"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "los archivos si cumplen con los criterios"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtrar historial"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Para poder promocionar tu estación, 'Send support feedback' (Enviar retroalimentación de soporte) debe estar activado)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Optiones adicionales"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "La siguiente información se desplegará a los oyentes en sus reproductores:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(El sitio web de tu estación)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL del stream:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Elija la carpeta"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Fijar"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Carpeta actual de importación:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Remover el directorio monitoreado"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "No está monitoreando ninguna carpeta de medios."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Fuente maestra "
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Configuración de SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Añadir este show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Actualizar show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Que"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Cuando"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Entrada de stream en vivo"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Quien"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Estilo"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Espacio en disco"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Importación del archivo en progreso..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Opciones de búsqueda avanzada"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Título:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Creador:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Álbum:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Pista:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Duración:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Tasa de muestreo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Tasa de bits:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Estilo (mood):"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Género:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Año:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Sello:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Compositor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conductor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Derechos de autor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Número ISRC"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Sitio web:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Idioma:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Ruta del archivo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Stream web"
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "¡Configuraciones actualizadas con éxito!"
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Bloque inteligente dinámico"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Bloque inteligente estático"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Pista de audio"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Contenido de la lista de reproducción:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Contenido del bloque inteligente estático:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Criterios del bloque inteligente dinámico:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Límite hasta"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Tu prueba expira el"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "días"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Previamente:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Próximamente:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Streams fuente"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "AL AIRE"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Escuchar"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Salir"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Nombre"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Descripción"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL del stream:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Duración por defecto:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "No existe un webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Ayuda"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "¡Página no encontrada!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "¡Parece que la página que buscas no existe!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "previo"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "reproducir"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pausa"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "próximo"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "parar"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "volumen máximo"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Se requiere actualizar"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Para reproducir estas pistas necesitarás actualizar tu navegador a una versión más reciente o atualizar tus plugin%s de %sFlash"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Se almacenó el webstream"
 
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Fecha de Inicio:"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Los valores en el formulario son inválidos."
 
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2506,6 @@ msgstr "Fecha de Inicio:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Se introdujo un caracter inválido"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Fecha de Finalización:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Todos mis shows:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Búsqueda de usuarios:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Nombre de la estación"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Teléfono:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Correo electrónico"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Sitio web de la estación:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "País:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Ciudad:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Descripción de la estación:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo de la estación:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Debes aceptar las políticas de privacidad."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "¿Grabar desde la entrada (line in)?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "¿Reprogramar?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "El valor es necesario y no puede estar vacío"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' no es una dirección de correo electrónico válida en el formato básico local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' no se ajusta al formato de fecha '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' tiene menos de %min% caracteres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' tiene más de %max% caracteres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' no está entre '%min%' y '%max%', inclusive"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Las contraseñas no coinciden"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2522,55 @@ msgstr "Se debe especificar una hora"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Debes esperar al menos 1 hora para reprogramar"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Restablecer contraseña"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Show sin nombre"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Número ISRC:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Desactivado"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Activado"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "La semana empieza el"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Usuario:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Contraseña:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Verificar contraseña:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Nombre:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Apellido:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Celular:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Tipo de usuario:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "El nombre de usuario no es único."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Carpeta de importación:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Carpetas monitoreadas:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "No es un directorio válido"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Licencia por defecto:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Todos los derechos reservados"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "El trabajo es de dominio público"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Atribución Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Atribución-NoComercial Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Atribución-sinDerivadas Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Atribución-CompartirIgual Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Atribución-NoComercial-SinDerivadas Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Atribución-NoComercial-CompartirIgual Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Reproduciéndose ahora"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Seleccionar criterio"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Tasa de bits (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Tasa de muestreo (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "horas"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutos"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "items"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Estático"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinámico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generar contenido para la lista de reproducción y guardar criterios"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generar"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Reproducir de forma aleatoria los contenidos de la lista de reproducción"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "El límite no puede estar vacío o ser menor que 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "El límite no puede ser mayor a 24 horas"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "El valor debe ser un número entero"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 es el valor máximo de ítems que se pueden configurar"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Debes elegir Criterios y Modificador"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Length' (la duración) debe establecerse e un formato de '00:00:00' "
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "El valor debe estar en un formato de tiempo (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "El valor debe ser numérico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "El valor debe ser menor a 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "El valor debe ser menor que los caracteres %s"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "El valor no se puede vaciar"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Metadata Icecast Vorbis"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Sello del stream:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artísta - Título"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artista - Título"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Nombre de la estación - nombre del show"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Metadata fuera del aire"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Activar ajuste del volumen"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Modificar ajuste de volumen"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Contraseña"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirma nueva contraseña"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "La confirmación de la contraseña no concuerda con tu contraseña."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Activado:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Tipo de stream:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Tipo de servicio:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Canales:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Estéreo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Servidor"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Puerto"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Solo se permiten números."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Punto de instalación"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Usuario administrativo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Contraseña administrativa"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "El servidor no puede estar vacío."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "El puerto no puede estar vacío."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "La instalación no puede estar vacía con el servidor Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' no concuerda con el formato de tiempo 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Huso horario:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "¿Se repite?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "No puedes crear un show en el pasado"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "No puedes modificar la hora/fecha de inicio de un show que ya empezó"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "La fecha/hora de finalización no puede estar en el pasado."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "No puede tener una duración < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "No puede tener una duración 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "No puede tener una duración mayor a 24 horas"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Use la autenticación personalizada:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Usuario personalizado"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Contraseña personalizada"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "El campo de usuario no puede estar vacío."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "El campo de contraseña no puede estar vacío."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Color de fondo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Color del texto:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Digita los caracteres que ves en la gráfica que aparece a continuación."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "días"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2616,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Fecha de Finalización:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "¿Sin fin?"
@@ -3878,115 +2634,1174 @@ msgstr "La fecha de finalización debe ser posterior a la inicio"
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "¿Grabar desde la entrada (line in)?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "¿Reprogramar?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Color de fondo:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Color del texto:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendario"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Elimina"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Usuarios"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Nombre:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Show sin nombre"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Género:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Descripción:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Estadísticas de oyentes"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' no concuerda con el formato de tiempo 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Duración:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Huso horario:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "¿Se repite?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "No puedes crear un show en el pasado"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "No puedes modificar la hora/fecha de inicio de un show que ya empezó"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "La fecha/hora de finalización no puede estar en el pasado."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "No puede tener una duración < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "No puede tener una duración 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "No puede tener una duración mayor a 24 horas"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "No se pueden programar shows traslapados"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Búsqueda de usuarios:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Usuario:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Contraseña:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Verificar contraseña:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Nombre:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Apellido:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Correo electrónico"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Celular:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Tipo de usuario:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "El nombre de usuario no es único."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Cómo iniciar"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Manual para el usuario"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "El valor es necesario y no puede estar vacío"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Fecha de Inicio:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Título:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Creador:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Álbum:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Año:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Sello:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Compositor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conductor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Estilo (mood):"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Derechos de autor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Número ISRC:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Sitio web:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Idioma:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Tiempo de Inicio"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Tiempo de Finalización"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Nombre de la estación"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo de la estación:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Nota:  cualquier cosa mayor a 600x600 será redimensionada."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Desactivado"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Activado"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "La semana empieza el"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' no es una dirección de correo electrónico válida en el formato básico local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' no se ajusta al formato de fecha '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' tiene menos de %min% caracteres"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' tiene más de %max% caracteres"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' no está entre '%min%' y '%max%', inclusive"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Las contraseñas no coinciden"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Solo se permiten números."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Ingreso"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Digita los caracteres que ves en la gráfica que aparece a continuación."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Contraseña"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirma nueva contraseña"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "La confirmación de la contraseña no concuerda con tu contraseña."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Usuario"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Restablecer contraseña"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Reproduciéndose ahora"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Teléfono:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Sitio web de la estación:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "País:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Ciudad:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Descripción de la estación:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Debes aceptar las políticas de privacidad."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Todos mis shows:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Seleccionar criterio"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Tasa de bits (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Descripción"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Tasa de muestreo (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "horas"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutos"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "items"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Estático"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinámico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generar contenido para la lista de reproducción y guardar criterios"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generar"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Reproducir de forma aleatoria los contenidos de la lista de reproducción"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Reproducción aleatoria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "El límite no puede estar vacío o ser menor que 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "El límite no puede ser mayor a 24 horas"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "El valor debe ser un número entero"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 es el valor máximo de ítems que se pueden configurar"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Debes elegir Criterios y Modificador"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Length' (la duración) debe establecerse e un formato de '00:00:00' "
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "El valor debe estar en un formato de tiempo (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "El valor debe ser numérico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "El valor debe ser menor a 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "El valor debe ser menor que los caracteres %s"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "El valor no se puede vaciar"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Licencia por defecto:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Todos los derechos reservados"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "El trabajo es de dominio público"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Atribución Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Atribución-NoComercial Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Atribución-sinDerivadas Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Atribución-CompartirIgual Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Atribución-NoComercial-SinDerivadas Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Atribución-NoComercial-CompartirIgual Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Metadata Icecast Vorbis"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Sello del stream:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artísta - Título"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artista - Título"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Nombre de la estación - nombre del show"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Metadata fuera del aire"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Activar ajuste del volumen"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Modificar ajuste de volumen"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Activado:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Tipo de stream:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Tasa de bits:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Tipo de servicio:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Canales:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Estéreo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Servidor"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Puerto"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Nombre"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Punto de instalación"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Usuario administrativo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Contraseña administrativa"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "El servidor no puede estar vacío."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "El puerto no puede estar vacío."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "La instalación no puede estar vacía con el servidor Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Carpeta de importación:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Carpetas monitoreadas:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "No es un directorio válido"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr "Bloque Inteligente"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Stream en vivo"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in y cue out son nulos."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "No se puede asignar un cue out mayor que la duración del archivo."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "No se puede asignar un cue in mayor al cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "No se puede asignar un cue out menor que el cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Retransmisión de %s desde %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Seleccionar país"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3826,12 @@ msgstr "%s no es un directorio válido."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s ya está asignado como el directorio actual de almacenamiento o en la lista de carpetas monitoreadas."
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s ya está asignado como el directorio actual de almacenamiento o en la lista de carpetas monitoreadas."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3839,18 @@ msgstr "%s ya está asignado como el directorio actual de almacenamiento o en la
 msgid "%s doesn't exist in the watched list."
 msgstr "%s no existe en la lista de monitoreo."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Seleccionar país"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Los shows pueden tener una duración máxima de 24 horas."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "No se pueden programar shows traslapados.\nNota: Cambiar el tamaño de un show periódico afecta todas sus repeticiones."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3865,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "¡La programación que estás viendo está desactualizada! (desfase de instancia)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "¡La programación que estás viendo está desactualizada!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "No tienes permiso para programar el show %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "No puedes agregar pistas a shows en grabación."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "El show %s terminó y no puede ser programado."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "¡El show %s ha sido actualizado previamente!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "¡Un Archivo seleccionado no existe!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Los shows pueden tener una duración máxima de 24 horas."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"No se pueden programar shows traslapados.\n"
+"Nota: Cambiar el tamaño de un show periódico afecta todas sus repeticiones."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Retransmisión de %s desde %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3965,1046 @@ msgstr "Webstream inválido - Esto parece ser una descarga de archivo."
 msgid "Unrecognized stream type: %s"
 msgstr "Tipo de stream no reconocido:  %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "No existe el archivo"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Ver los metadatos del archivo grabado"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Editar"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Editar show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "No es posible arrastrar y soltar shows que se repiten"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "No se puede mover un show pasado"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "No se puede mover un show al pasado"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "No se pueden mover shows grabados a menos de 1 hora antes de su retransmisión."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "El show se eliminó porque el show grabado no existe!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Debe esperar 1 hora para retransmitir."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Reproducido"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "previo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "reproducir"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pausa"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "próximo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "parar"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "silenciar"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "desactivar silencio"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "volumen máximo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Se requiere actualizar"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Para reproducir estas pistas necesitarás actualizar tu navegador a una versión más reciente o atualizar tus plugin%s de %sFlash"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Sobre nosotros"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Para una ayuda más detallada, lee el manual%s del %susuario."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Compartir"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Seleccionar stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "¡Página no encontrada!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "¡Parece que la página que buscas no existe!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Fuente del show"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Elige los días:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Añadir"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Días en que se repite:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtrar historial"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Configuración de SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Fuente maestra "
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Elija la carpeta"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Fijar"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Carpeta actual de importación:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Remover el directorio monitoreado"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "No está monitoreando ninguna carpeta de medios."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Registrar Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Requerido)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(únicamente para fines de verificación, no será publicado)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Muéstrame lo que estoy enviando"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Términos y condiciones"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Encontrar shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "para"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "los archivos si cumplen con los criterios"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Optiones adicionales"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "La siguiente información se desplegará a los oyentes en sus reproductores:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(El sitio web de tu estación)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL del stream:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Para poder promocionar tu estación, 'Send support feedback' (Enviar retroalimentación de soporte) debe estar activado)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Pista:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Duración:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Tasa de muestreo:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Número ISRC"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Ruta del archivo:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Stream web"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Bloque inteligente dinámico"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Bloque inteligente estático"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Pista de audio"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Contenido de la lista de reproducción:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Contenido del bloque inteligente estático:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Criterios del bloque inteligente dinámico:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Límite hasta"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Importación del archivo en progreso..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Opciones de búsqueda avanzada"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nueva contraseña"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Por favor ingrese y confirme una nueva cotnraseña en los campos que aparecen a continuación."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Previamente:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Próximamente:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Streams fuente"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "AL AIRE"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Escuchar"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Salir"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Tu prueba expira el"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Lista de reproducción aleatoria"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Transición (crossfade) de la lista de reproducción"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Almacenar lista de reproducción"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "No hay listas de reproducción abiertas"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue in:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue out:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Duración original:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Expandir bloque estático"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Expandir bloque dinámico"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Configuración de stream"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Añadir este show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Actualizar show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Que"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Cuando"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Entrada de stream en vivo"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Quien"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Estilo"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Espacio en disco"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Administrar usuarios"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nuevo usuario"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Nombre"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Apellido"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Tipo de usuario"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL del stream:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Duración por defecto:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "No existe un webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "por favor ingresa un tiempo '00 (.0)'"

--- a/airtime_mvc/locale/es_ES/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/es_ES/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/fr_FR/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # AlbertFR <albert.bruc.ab@gmail.com>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: French (France) (http://www.transifex.com/sourcefabric/airtime/language/fr_FR/)\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr_FR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "L'enregistrement du fichier n'existe pas"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "L'année %s  doit être comprise entre 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Afficher les métadonnées du fichier enregistré"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s n'est pas une date valide"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s n'est pas une durée valide"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edition"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edition de l'Emission"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Effacer"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Permission refusée"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Vous ne pouvez pas faire glisser et déposer des émissions en répétition"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Ne peux pas déplacer une émission diffusée"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Ne peux pas déplacer une émission dans le passé"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Ne peux pas programmer des émissions qui se chevauchent"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Impossible de déplacer une émission enregistrée à moins d'1 heure avant ses rediffusions."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "L'Emission a été éffacée parce que l'enregistrement de l'émission n'existe pas!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Doit attendre 1 heure pour retransmettre."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Titre"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Créateur"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Durée"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Compositeur"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Droit d'Auteur"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Année"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Morceau"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Conducteur"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Langue"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Heure de Début"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Heure de Fin"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Joué"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendrier"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Utilisateurs"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Flux"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Historique de Diffusion"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Modèle d'historique"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Statistiques des Auditeurs"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Aide"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Mise en route"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Manuel Utilisateur"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Vous n'êtes pas autorisé à acceder à cette ressource."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Vous n'êtes pas autorisé à acceder à cette ressource."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr "Le fichier n'existe pas dans %s"
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Mauvaise requête. pas de \"mode\" paramètre passé."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Mauvaise requête.paramètre  'mode'  invalide"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Vous n'avez pas la permission de déconnecter la source."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Il n'y a pas de source connectée à cette entrée."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Vous n'avez pas la permission de changer de source."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s non trouvé"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Quelque chose s'est mal passé."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Pré-Visualisation"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Ajouter une"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Ajouter un bloc Intelligent"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edition des Méta-Données"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Effacer"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Téléchargement"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "dupliquer  la Liste de lecture"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Aucune action disponible"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Vous n'avez pas la permission de supprimer les éléments sélectionnés."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Copie de %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Flux Web sans Titre"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Flux Web sauvegardé"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Valeurs du formulaire non valides."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "S'il vous plaît assurez-vous que l'utilisateur admin a un mot de passe correct sur le système-> page flux."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Utilisateur ajouté avec succès!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Lecteur Audio"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Utilisateur mis à jour avec succès!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Paramètres mis à jour avec succès!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Enregistrement:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Flux Maitre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Flux Direct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Rien de Prévu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Emission en Cours:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "En ce moment"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Vous éxécutez la dernière version"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nouvelle version disponible:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Cette version sera bientôt obsolête."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Cette version n'est plus supportée."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "SVP mettez vous à jour vers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Ajouter à la liste de lecture"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Ajouter au Bloc Intelligent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Ajouter 1 élément"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Ajout de %s Elements"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Vous pouvez seulement ajouter des pistes aux Blocs Intelligents."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Vous pouvez uniquement ajouter des pistes, des blocs intelligents et flux web aux listes de lecture."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "S'il vous plaît sélectionner un curseur sur la timeline."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edition des Méta-Données"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Ajouter à l'émission selectionnée"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Selection"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Selectionner cette page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Dé-selectionner cette page"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Tous déselectioner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Etes-vous sûr de vouloir efacer le(s) élément(s) selectionné(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Programmé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Titre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Créateur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Taux d'echantillonage"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Compositeur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Conducteur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Droit d'Auteur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encodé Par"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Langue"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Dernier Modifié"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Dernier Joué"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Durée"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Mood"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Propriétaire"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Taux d'Echantillonnage"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Numéro de la Piste"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Téléversé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Site Internet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Année"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Chargement..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Tous"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Fichiers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Listes de Lecture"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Blocs Intelligents"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Flux Web"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Type non reconnu:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Êtes-vous sûr de vouloir supprimer l'élément sélectionné?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Téléversement en cours..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Récupération des données du serveur..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "L'Id. SoundCloud pour ce fichier est:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Une erreur s'est produite lors du téléversement vers SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Code d'Erreur:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Message d'Erreur:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "L'entrée doit être un nombre positif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "L'entrée doit être un nombre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "L'entrée doit être au format suivant: aaaa-mm-jj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "L'entrée doit être au format suivant: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Vous êtes en train de téléverser des fichiers. %s Aller vers un autre écran pour annuler le processus de téléversement. %s Êtes-vous sûr de vouloir quitter la page?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Ouvrir le Constructeur de Média"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "s'il vous plaît mettez en durée '00: 00:00 (.0) '"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Votre navigateur ne prend pas en charge la lecture de ce type de fichier:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Le Bloc dynamique n'est pas prévisualisable"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limiter à:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Liste de Lecture sauvegardé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "liste de lecture mélangée"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime n'est pas sûr de l'état de ce fichier. Cela peut arriver lorsque le fichier se trouve sur un lecteur distant qui est inaccessible ou si le fichier est dans un répertoire qui n'est pas plus «sruveillé»."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Nombre d'auditeur sur %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Me le Rappeler dans une semain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Ne jamais me le Rapeller"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Oui, aidez Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "L'Image doit être du type jpg, jpeg, png, ou gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Un bloc statique intelligent permettra d'économiser les critères et générera le contenu du bloc immédiatement. Cela vous permet d'éditer et de le voir dans la médiathèque avant de l'ajouter à une émission."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Un bloc dynamique intelligent enregistre uniquement les critères. Le contenu du bloc que vous obtiendrez sera généré lors de l'ajout à l'émission. Vous ne serez pas en mesure d'afficher et de modifier le contenu de la médiathèque."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "La longueur du bloc souhaité ne sera pas atteint si de temps d'antenne ne peut pas trouver suffisamment de pistes uniques en fonction de vos critères. Activez cette option si vous souhaitez autoriser les pistes à s'ajouter plusieurs fois dans le bloc intelligent."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Bloc intelligent mélangé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Bloc Intelligent généré et critère(s) sauvegardé(s)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Bloc Intelligent sauvegardé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Traitement en cours ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Sélectionnez modification"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contient"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "ne contitent pas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "est"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "n'est pas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "commence par"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "fini par"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "est plus grand que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "est plus petit que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "est dans le champ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Choisir un Répertoire de Stockage"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Choisir un Répertoire à Surveiller"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Etes-vous sûr que vous voulez changer le répertoire de stockage? \n"
+"Cela supprimera les fichiers de votre médiathèque Airtime!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Gérer les Répertoires des Médias"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Êtes-vous sûr de vouloir supprimer le répertoire surveillé?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Ce chemin n'est pas accessible."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Certains types de flux nécessitent une configuration supplémentaire. Les détails sur l'activation de l' %sAAC+ Support%s ou %sOpus Support%s sont prévus."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Connecté au serveur de flux"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Le flux est désactivé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Obtention des informations à partir du serveur ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Impossible de se connecter au serveur de flux"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Si Airtime est derrière un routeur ou un pare-feu, vous devrez peut-être configurer la redirection de port et ce champ d'information sera alors incorrect.Dans ce cas, vous devrez mettre à jour manuellement ce champ de sorte qu'il affiche l'hôte/le port /le point de montage correct  dont le DJ a besoin pour s'y connecter. La plage autorisée est comprise entre 1024 et 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Pour plus de détails, s'il vous plaît lire le %sManuel d'Airtime%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Cochez cette option pour activer les métadonnées pour les flux OGG (les métadonnées du flux est le titre de la piste, l'artiste et le nom de émission qui est affiché dans un lecteur audio). VLC et mplayer ont un sérieux bogue lors de la lecture d'un flux Ogg / Vorbis qui affiche les informations de métadonnées: ils se déconnecteront après chaque chanson. Si vous utilisez un flux OGG et vos auditeurs n'utilisent pas ces lecteurs audio, alors n'hésitez pas à activer cette option."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Cochez cette case arrête automatiquement  la source Maître/Emission lors de la déconnexion."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Cochez cette case démarre automatiquement la source Maître/Emission lors de la connexion."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Si votre serveur Icecast s'attend à ce que le nom d'utilisateur soit «source», ce champ peut être laissé vide."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Si votre client de flux audio ne demande pas un nom d'utilisateur, ce champ doit être «source»."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "C'est le nom d'utilisateur administrateur et mot de passe pour icecast / shoutcast qui permet obtenir les statistiques d'écoute."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Attention: Vous ne pouvez pas modifier ce champ alors que l'émission est en cours de lecture"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "aucun résultat trouvé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Cela suit le même modèle de sécurité que pour les émissions: seuls les utilisateurs affectés à l' émission peuvent se connecter."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Spécifiez l'authentification personnalisée qui ne fonctionnera que pour cette émission."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "L'instance émission n'existe plus!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Attention: Les émissions ne peuvent pas être re-liés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "En liant vos émissions répétées chaques éléments multimédias programmés dans n'importe quelle émission répétitée seront également programmées dans les autres émissions répétées"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Le fuseau horaire est fixé au fuseau horaire de la Station par défaut. les émissions dans le calendrier seront affichés dans votre heure locale définie par le fuseau horaire de l'interface dans vos paramètres utilisateur."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Emission"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "L'Emission est vide"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Récupération des données du serveur..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Cette émission n'a pas de contenu programmée."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Cette émission n'est pas complètement remplie avec ce contenu."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Janvier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Fevrier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Mars"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Avril"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Mai"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Juin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Juillet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Aout"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Septembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Octobre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Novembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Décembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Fev"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Avr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jui"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aou"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Oct"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Dimanche"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Lundi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Mardi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Mercredi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Jeudi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Vendredi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Samedi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Dim"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Lun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Mer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Jeu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Ven"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sam"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Les émissions qui dépassent leur programmation seront coupés par les émissions suivantes."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Annuler l'Emission en Cours?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Arreter l'enregistrement de l'émission en cours"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contenu de l'émission"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Enlever tous les contenus?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Selectionner le(s) élément(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Début"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Fin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Durée"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Point d'Entré"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Point de Sorti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "fondu en Entré"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fondu en Sorti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Emission vide"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Enregistrement à partir de 'Line In'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Pré-écoute de la Piste"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Vous ne pouvez pas programmer en dehors d'une émission."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Déplacer 1 élément"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Déplacer %s éléments"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Sauvegarder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Annuler"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Editeur de Fondu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Editeur de Point d'E/S"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Les caractéristiques de la forme d'onde sont disponibles dans un navigateur supportant l'API Web Audio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Tout Selectionner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Ne Rien Selectionner"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Supprimer les éléments programmés selectionnés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Aller à la piste en cours de lecture"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Annuler l'émission en cours"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Ouvrir la Médiathèque pour ajouter ou supprimer du contenu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Ajouter/Supprimer Contenu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "en utilisation"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disque"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Regarder à l'intérieur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Ouvrir"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrateur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DeaJee"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programmateur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Invité"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Les Invités peuvent effectuer les opérations suivantes:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Voir le calendrier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Voir le contenu des émissions"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Les DJs peuvent effectuer les opérations suivantes:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Gérer le contenu des émissions attribué"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Importer des fichiers multimédias"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Créez des listes de lectures, des blocs intelligents et des flux web"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Gérer le contenu  de leur propre audiotheque"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Les gestionnaires pouvent effectuer les opérations suivantes:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Afficher et gérer le contenu des émissions"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Programmer des émissions"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Gérez tout le contenu de l'audiotheque"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Les Administrateurs peuvent effectuer les opérations suivantes:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Gérer les préférences"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Gérer les utilisateurs"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Gérer les dossiers surveillés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Envoyez vos remarques au support"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Voir l'état du système"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Accédez à l'historique diffusion"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Voir les statistiques des auditeurs"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Montrer / cacher les colonnes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "De {from} à  {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "aaaa-mm-jj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Lu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Ma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Me"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Je"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Ve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Fermer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Heure"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minute"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Fait"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Sélectionnez les fichiers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Ajouter des fichiers à la file d'attente de téléversement, puis cliquez sur le bouton Démarrer."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Ajouter des fichiers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Arreter le Téléversement"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Démarrer le Téléversement"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Ajouter des fichiers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Téléversement de %d/%d fichiers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Faites glisser les fichiers ici."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Erreur d'extension du fichier."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Erreur de la Taille de Fichier."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Erreur de comptage des fichiers."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Erreur d'Initialisation."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Erreur HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Erreur de sécurité."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Erreur générique."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Erreur d'E/S."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Fichier: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d fichiers en file d'attente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Fichier:%f, taille: %s, taille de fichier maximale: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "l'URL de Téléversement est peut être erronée ou inexistante"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Erreur: Fichier trop grand:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Erreur: extension de fichier non valide:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Définir par défaut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "créer une entrée"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Éditer l'enregistrement de l'historique"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Pas d'émission"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Copié %s ligne(s)%s dans le presse papier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sVue Imprimante%s Veuillez utiliser la fonction d'impression de votre navigateur pour imprimer ce tableau. Appuyez sur échapper lorsque vous avez terminé."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Le Courriel n'a pas pu être envoyé. Vérifiez vos paramètres du serveur de messagerie et s'assurez vous qu'il a été correctement configuré."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Mauvais Nom d'utilisateur ou mot de passe fourni. S'il vous plaît essayez de nouveau."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "Vous n'avez pas la permission de supprimer la sélection %s(s)."
 msgid "You can only add tracks to smart block."
 msgstr "Vous pouvez seulement ajouter des pistes au bloc intelligent."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Vous pouvez uniquement ajouter des pistes, des blocs intelligents et flux web aux listes de lecture."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Liste de Lecture Sans Titre"
@@ -384,2627 +2414,88 @@ msgstr "Liste de Lecture Sans Titre"
 msgid "Untitled Smart Block"
 msgstr "Bloc Intelligent Sans Titre"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Liste de Lecture Inconnue"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Vous n'êtes pas autorisé à acceder à cette ressource."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Préférences mises à jour."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Régalges su Support mis à jour."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Remarques au support"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Réglages du Flux mis à jour."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "le chemin doit être spécifié"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problème ave Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Vous n'avez pas la permission de déconnecter la source."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Il n'y a pas de source connectée à cette entrée."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Vous n'avez pas la permission de changer de source."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Mauvais Nom d'utilisateur ou mot de passe fourni. S'il vous plaît essayez de nouveau."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Le Courriel n'a pas pu être envoyé. Vérifiez vos paramètres du serveur de messagerie et s'assurez vous qu'il a été correctement configuré."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Vous n'êtes pas autorisé à acceder à cette ressource."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr "Le fichier n'existe pas dans %s"
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Mauvaise requête. pas de \"mode\" paramètre passé."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Mauvaise requête.paramètre  'mode'  invalide"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Lecteur Audio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Enregistrement:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Flux Maitre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Flux Direct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Rien de Prévu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Emission en Cours:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "En ce moment"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Vous éxécutez la dernière version"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nouvelle version disponible:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Cette version sera bientôt obsolête."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Cette version n'est plus supportée."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "SVP mettez vous à jour vers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Ajouter à la liste de lecture"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Ajouter au Bloc Intelligent"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Ajouter 1 élément"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Ajout de %s Elements"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Vous pouvez seulement ajouter des pistes aux Blocs Intelligents."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "S'il vous plaît sélectionner un curseur sur la timeline."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Ajouter à l'émission selectionnée"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Selection"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Selectionner cette page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Dé-selectionner cette page"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Tous déselectioner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Etes-vous sûr de vouloir efacer le(s) élément(s) selectionné(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Programmé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Taux d'echantillonage"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encodé Par"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Dernier Modifié"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Dernier Joué"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Propriétaire"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Taux d'Echantillonnage"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Numéro de la Piste"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Téléversé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Site Internet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Chargement..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Tous"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Fichiers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Listes de Lecture"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Blocs Intelligents"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Flux Web"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Type non reconnu:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Êtes-vous sûr de vouloir supprimer l'élément sélectionné?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Téléversement en cours..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Récupération des données du serveur..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "L'Id. SoundCloud pour ce fichier est:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Une erreur s'est produite lors du téléversement vers SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Code d'Erreur:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Message d'Erreur:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "L'entrée doit être un nombre positif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "L'entrée doit être un nombre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "L'entrée doit être au format suivant: aaaa-mm-jj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "L'entrée doit être au format suivant: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Vous êtes en train de téléverser des fichiers. %s Aller vers un autre écran pour annuler le processus de téléversement. %s Êtes-vous sûr de vouloir quitter la page?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Ouvrir le Constructeur de Média"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "s'il vous plaît mettez en durée '00: 00:00 (.0) '"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "s'il vous plaît mettez dans une durée en secondes '00 (.0) '"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Votre navigateur ne prend pas en charge la lecture de ce type de fichier:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Le Bloc dynamique n'est pas prévisualisable"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limiter à:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Liste de Lecture sauvegardé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "liste de lecture mélangée"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime n'est pas sûr de l'état de ce fichier. Cela peut arriver lorsque le fichier se trouve sur un lecteur distant qui est inaccessible ou si le fichier est dans un répertoire qui n'est pas plus «sruveillé»."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Nombre d'auditeur sur %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Me le Rappeler dans une semain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Ne jamais me le Rapeller"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Oui, aidez Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "L'Image doit être du type jpg, jpeg, png, ou gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Un bloc statique intelligent permettra d'économiser les critères et générera le contenu du bloc immédiatement. Cela vous permet d'éditer et de le voir dans la médiathèque avant de l'ajouter à une émission."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Un bloc dynamique intelligent enregistre uniquement les critères. Le contenu du bloc que vous obtiendrez sera généré lors de l'ajout à l'émission. Vous ne serez pas en mesure d'afficher et de modifier le contenu de la médiathèque."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "La longueur du bloc souhaité ne sera pas atteint si de temps d'antenne ne peut pas trouver suffisamment de pistes uniques en fonction de vos critères. Activez cette option si vous souhaitez autoriser les pistes à s'ajouter plusieurs fois dans le bloc intelligent."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Bloc intelligent mélangé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Bloc Intelligent généré et critère(s) sauvegardé(s)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Bloc Intelligent sauvegardé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Traitement en cours ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Sélectionnez modification"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contient"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "ne contitent pas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "est"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "n'est pas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "commence par"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "fini par"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "est plus grand que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "est plus petit que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "est dans le champ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Choisir un Répertoire de Stockage"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Choisir un Répertoire à Surveiller"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Etes-vous sûr que vous voulez changer le répertoire de stockage? \nCela supprimera les fichiers de votre médiathèque Airtime!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Gérer les Répertoires des Médias"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Êtes-vous sûr de vouloir supprimer le répertoire surveillé?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Ce chemin n'est pas accessible."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Certains types de flux nécessitent une configuration supplémentaire. Les détails sur l'activation de l' %sAAC+ Support%s ou %sOpus Support%s sont prévus."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Connecté au serveur de flux"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Le flux est désactivé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Obtention des informations à partir du serveur ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Impossible de se connecter au serveur de flux"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Si Airtime est derrière un routeur ou un pare-feu, vous devrez peut-être configurer la redirection de port et ce champ d'information sera alors incorrect.Dans ce cas, vous devrez mettre à jour manuellement ce champ de sorte qu'il affiche l'hôte/le port /le point de montage correct  dont le DJ a besoin pour s'y connecter. La plage autorisée est comprise entre 1024 et 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Pour plus de détails, s'il vous plaît lire le %sManuel d'Airtime%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Cochez cette option pour activer les métadonnées pour les flux OGG (les métadonnées du flux est le titre de la piste, l'artiste et le nom de émission qui est affiché dans un lecteur audio). VLC et mplayer ont un sérieux bogue lors de la lecture d'un flux Ogg / Vorbis qui affiche les informations de métadonnées: ils se déconnecteront après chaque chanson. Si vous utilisez un flux OGG et vos auditeurs n'utilisent pas ces lecteurs audio, alors n'hésitez pas à activer cette option."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Cochez cette case arrête automatiquement  la source Maître/Emission lors de la déconnexion."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Cochez cette case démarre automatiquement la source Maître/Emission lors de la connexion."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Si votre serveur Icecast s'attend à ce que le nom d'utilisateur soit «source», ce champ peut être laissé vide."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Si votre client de flux audio ne demande pas un nom d'utilisateur, ce champ doit être «source»."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "C'est le nom d'utilisateur administrateur et mot de passe pour icecast / shoutcast qui permet obtenir les statistiques d'écoute."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Attention: Vous ne pouvez pas modifier ce champ alors que l'émission est en cours de lecture"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "aucun résultat trouvé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Cela suit le même modèle de sécurité que pour les émissions: seuls les utilisateurs affectés à l' émission peuvent se connecter."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Spécifiez l'authentification personnalisée qui ne fonctionnera que pour cette émission."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "L'instance émission n'existe plus!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Attention: Les émissions ne peuvent pas être re-liés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "En liant vos émissions répétées chaques éléments multimédias programmés dans n'importe quelle émission répétitée seront également programmées dans les autres émissions répétées"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Le fuseau horaire est fixé au fuseau horaire de la Station par défaut. les émissions dans le calendrier seront affichés dans votre heure locale définie par le fuseau horaire de l'interface dans vos paramètres utilisateur."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Emission"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "L'Emission est vide"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Récupération des données du serveur..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Cette émission n'a pas de contenu programmée."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Cette émission n'est pas complètement remplie avec ce contenu."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Janvier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Fevrier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Mars"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Avril"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Mai"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Juin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Juillet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Aout"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Septembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Octobre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Novembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Décembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Fev"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Avr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jui"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aou"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Oct"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Dimanche"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Lundi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Mardi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Mercredi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Jeudi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Vendredi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Samedi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Dim"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Lun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Mer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Jeu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Ven"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sam"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Les émissions qui dépassent leur programmation seront coupés par les émissions suivantes."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Annuler l'Emission en Cours?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Arreter l'enregistrement de l'émission en cours"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contenu de l'émission"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Enlever tous les contenus?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Selectionner le(s) élément(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Début"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Fin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Durée"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Point d'Entré"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Point de Sorti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "fondu en Entré"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fondu en Sorti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Emission vide"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Enregistrement à partir de 'Line In'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Pré-écoute de la Piste"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Vous ne pouvez pas programmer en dehors d'une émission."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Déplacer 1 élément"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Déplacer %s éléments"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Sauvegarder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Annuler"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Editeur de Fondu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Editeur de Point d'E/S"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Les caractéristiques de la forme d'onde sont disponibles dans un navigateur supportant l'API Web Audio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Tout Selectionner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Ne Rien Selectionner"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Supprimer les éléments programmés selectionnés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Aller à la piste en cours de lecture"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Annuler l'émission en cours"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Ouvrir la Médiathèque pour ajouter ou supprimer du contenu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Ajouter/Supprimer Contenu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "en utilisation"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disque"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Regarder à l'intérieur"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Ouvrir"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrateur"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DeaJee"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programmateur"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Invité"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Les Invités peuvent effectuer les opérations suivantes:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Voir le calendrier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Voir le contenu des émissions"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Les DJs peuvent effectuer les opérations suivantes:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Gérer le contenu des émissions attribué"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Importer des fichiers multimédias"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Créez des listes de lectures, des blocs intelligents et des flux web"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Gérer le contenu  de leur propre audiotheque"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Les gestionnaires pouvent effectuer les opérations suivantes:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Afficher et gérer le contenu des émissions"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Programmer des émissions"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Gérez tout le contenu de l'audiotheque"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Les Administrateurs peuvent effectuer les opérations suivantes:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Gérer les préférences"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Gérer les utilisateurs"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Gérer les dossiers surveillés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Envoyez vos remarques au support"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Voir l'état du système"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Accédez à l'historique diffusion"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Voir les statistiques des auditeurs"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Montrer / cacher les colonnes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "De {from} à  {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "aaaa-mm-jj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Lu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Ma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Me"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Je"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Ve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Fermer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Heure"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minute"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Fait"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Sélectionnez les fichiers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Ajouter des fichiers à la file d'attente de téléversement, puis cliquez sur le bouton Démarrer."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Ajouter des fichiers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Arreter le Téléversement"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Démarrer le Téléversement"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Ajouter des fichiers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Téléversement de %d/%d fichiers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Faites glisser les fichiers ici."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Erreur d'extension du fichier."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Erreur de la Taille de Fichier."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Erreur de comptage des fichiers."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Erreur d'Initialisation."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Erreur HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Erreur de sécurité."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Erreur générique."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Erreur d'E/S."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Fichier: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d fichiers en file d'attente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Fichier:%f, taille: %s, taille de fichier maximale: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "l'URL de Téléversement est peut être erronée ou inexistante"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Erreur: Fichier trop grand:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Erreur: extension de fichier non valide:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Définir par défaut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "créer une entrée"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Éditer l'enregistrement de l'historique"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Pas d'émission"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Copié %s ligne(s)%s dans le presse papier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sVue Imprimante%s Veuillez utiliser la fonction d'impression de votre navigateur pour imprimer ce tableau. Appuyez sur échapper lorsque vous avez terminé."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Selectionner le Curseur"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Enlever le Curseur"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "L'Emission n'existe pas"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Rediffusion de l'émission %s de %s à %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Selectionner le Curseur"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Enlever le Curseur"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "L'Emission n'existe pas"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Utilisateur ajouté avec succès!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Utilisateur mis à jour avec succès!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Paramètres mis à jour avec succès!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Flux Web sans Titre"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Flux Web sauvegardé"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Valeurs du formulaire non valides."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "L'année %s  doit être comprise entre 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s n'est pas une date valide"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s n'est pas une durée valide"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Flux Live"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Lecture"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Placer le Point d'Entré"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Placer le Point de Sortie"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Curseur"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Partager"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Selection du Flux:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "sourdine"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "désactiver"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "A propos"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr "%1$s %2$s, le logiciel ouvert de gestion et de programmation pour vos stations distantes."
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr "%1$s %2$s est distribué sous %3$s"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr "Bienvenue à %s !"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr "Voici comment vous pouvez commencer à utiliser %s pour automatiser vos émissions:"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Pour une aide plus détaillée, lisez le %smanuel utilisateur%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Historique de Diffusion"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Fichier de Log"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Résumé du fichier"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Historique Emision"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Ettendre le bloc Statique"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Ettendre le Bloc Dynamique"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Nom:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Description:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Durée:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Liste de Lecture Aléatoire"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Aléatoire"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Fondu enchainé de la Liste de Lecture"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Vider le contenu de la Liste de Lecture"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Vider"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fondu en entrée:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fondu en sortie:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Sauvegarde de la Liste de Lecture"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Pas de Liste de Lecture Ouverte"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Montrer la Forme d'Onde"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Point d'Entrée"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Point de Sortie:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Durée Originale:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Réglages des Flux"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Connexion"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr "Bienvenue à la démo %s ! Vous pouvez vous connecter en utilisant le nom d'utilisateur «admin» et le mot de passe «admin» ."
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nouveau mot de passe"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "S'il vous plaît saisir et confirmer votre nouveau mot de passe dans les champs ci-dessous."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Gérer les Utilisateurs"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nouvel Utilisateur"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Utilisateur"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Prénom"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Nom"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Type d'Utilisateur"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Trouver Emissions"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Choisissez Afficher instance"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Trouver"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Jours de Répétition:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Enlever"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Ajouter"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Source Emission"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Enregistrez Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr "Cliquez sur la case ci-dessous pour promouvoir votre station sur %s ."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Requis)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(à des fins de vérification uniquement, ne sera pas publié)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Remarque: Tout ce qui est plus grand que 600x600 sera redimensionné."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Montrez-moi ce que je vais envoyer"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Termes et Conditions."
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Choix des Jours:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "ou"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "et"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "à"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "fichiers répondent aux critères"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtre de l'Historique"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Pour la promotion de votre station, 'Envoyez vos remarques au support' doit être activé)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Flux"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "options supplémentaires"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Les informations suivantes seront affichées aux auditeurs dans leur lecteur multimédia:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Site Internet de la Station de Radio)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL du Flux:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Choisir le répertoire"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Installer"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Répertoire d'Import en Cours:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr "Rescanner le répertoire surveillé (Ce qui peut être utile si il est sur le réseau et est peut être désynchronisé de %s)"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Supprimer le répertoire surveillé"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Vous ne surveillez pas les dossiers médias."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Source Maitre"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Réglages SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Ajouter cette Emission"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Mettre à jour l'émission"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Quoi"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Quand"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Entrée du Flux Direct"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Qui"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Style"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Espace Disque"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Import du Fichier en cours..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Options Avancées de Recherche"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Titre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Créateur:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Piste:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Durée:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Fréquence d'Echantillonnage"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Débit:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Atmosphère:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Année:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Label:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Compositeur:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conducteur:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Numéro ISRC:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Site Internet:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Langue"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Chemin du fichier:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Flux Web"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Bloc Intelligent Dynamique"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Bloc Intélligent Statique"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Piste Audio"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Contenus de la Liste de Lecture:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Contenus du Bloc Intelligent Statique:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Critère(s) du Bloc Intelligent Dynamique:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limité à"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Votre période d'éssai expire dans"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "jours"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Précédent:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Prochain:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Sources des Flux"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "DIRECT"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Ecouter"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Déconnexion"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Modèles de fichiers de Log"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Nouveau modèle de fichier de Log"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Aucun modèles de fichiers de Log"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Modèle de fichier d'historique"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Nouveau modèle de fichier d'Historique"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "aucun modèle de fichier d'Historique"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Création du fichier Modèle d'Historique"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Création du modèle de fichier de Log"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Nom"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Ajouter plus d'éléments"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Ajouter un nouveau champs"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Definir le modèle par défaut"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Description"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL du Flux:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Durée par Défaut:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Aucun Flux Web"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Aide"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Page non trouvée!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "On dirait que la page que vous cherchez n'existe pas!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "précédent"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "jouer"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "suivant"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "Volume max"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Mise à Jour Requise"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Pour lire le média, vous devrez mettre à jour votre navigateur vers une version récente ou mettre à jour votre %sPlugin Flash%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Date de Début:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Date de Début:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Caractère Invalide saisi"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Date de Fin:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Toutes Mes Emissions:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Recherche d'Utilisateurs:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "v"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Nom de la Station"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Téléphone"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Courriel:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Site Internet de la Station"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Pays:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Ville:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Description de la Station:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo de la Station:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Promouvoir station sur %s"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "En cochant cette case , je accepte la %s's %s de politique de confidentialité %s ."
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Vous devez accepter la politique de confidentialité."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Enregistrer à partir de 'Line In'?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Rediffusion?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Une Valeur est requise, ne peut pas être vide"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%'  n'est pas une adresse de courriel valide dans le format de type partie-locale@nomdedomaine"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' ne correspond pas au format de la date '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' est inférieur à %min% charactères"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' est plus grand de %min% charactères"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' n'est pas entre '%min%' et '%max%', inclusivement"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Les mots de passe ne correspondent pas"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "La durée doit être spécifiée"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Vous devez attendre au moins 1 heure pour retransmettre"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Réinitialisation du Mot de Passe"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Emission sans Titre"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Numéro ISRC:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Durée du fondu enchaîné "
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Fondu en Entrée par défaut (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Fondu en Sorti par défaut (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Désactivé"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Activé"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Fuseau horaire de la Station"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "La Semaine Commence Le"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Utilisateur:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Mot de Passe:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Vérification du Mot de Passe:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Prénom:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Nom:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Numéro de Mobile:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Type d'Utilisateur:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Le Nom de connexion n'est pas unique."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "répertoire d'Import:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Répertoires Suveillés:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "N'est pas un Répertoire valide"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Licence par Défaut:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Tous droits réservés"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Ce travail est dans le domaine public"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Non Commercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution Pas de Travaux Dérivés"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Distribution à l'Identique"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Non Commercial Pas de Travaux Dérivés"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Non Commercial Distribution à l'Identique"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Fuseau horaire de l'Interface:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "En Lecture"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Selectionner le critère"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Taux d'Echantillonage (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Taux d'Echantillonage (Khz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "heures"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutes"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "éléments"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statique"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamique"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Génération de la liste de lecture et sauvegarde des crières"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Générer"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Contenu de la liste de lecture alèatoire"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "La Limite ne peut être vide ou plus petite que 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "La Limite ne peut être supérieure à 24 heures"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "La valeur doit être un entier"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 est la valeur maximale de l'élément que vous pouvez définir"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Vous devez sélectionner Critères et Modification"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "La 'Durée' doit être au format '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "La valeur doit être en format d'horodatage (par exemple 0000-00-00 ou 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "La valeur doit être numérique"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "La valeur doit être inférieure à 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "La valeur doit être inférieure à %s caractères"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "La Valeur ne peut pas être vide"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Metadata Vorbis"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Label du Flux:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artiste - Titre"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Emission - Artiste - Titre"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Nom de la Station - Nom de l'Emission"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Métadonnées Hors Antenne"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Activer"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Modifier le Niveau du Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Mot de Passe"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirmez le nouveau mot de passe"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "La confirmation mot de passe ne correspond pas à votre mot de passe."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Activé:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Type de Flux:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Type de service:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Cannaux:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Serveur"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Seuls les chiffres sont autorisés."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Point de Montage"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Utilisateur Admin"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Mot de Passe Admin"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Le Serveur ne peut être vide."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Le Port ne peut être vide."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Le Point de Montage ne peut être vide avec un serveur Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' ne correspond pas au format de durée 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Fuseau horaire:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Répétitions?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Impossible de créer un émission dans le passé"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Vous ne pouvez pas modifier la date / heure de début de l'émission qui a déjà commencé"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "La date/heure de Fin ne peut être dans le passé"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Ne peut pas avoir une durée <0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Ne peut pas avoir une durée de 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Ne peut pas avoir une durée supérieure à 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "Utilisez l'authentification %s :"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Utiliser l'authentification personnalisée:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Nom d'utilisateur personnalisé"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Mot de Passe personnalisé"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Le Champ Nom d'Utilisateur ne peut pas être vide."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Le Champ Mot de Passe ne peut être vide."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Couleur de Fond:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Couleur du Texte:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Saisissez les caractères que vous voyez dans l'image ci-dessous."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "jours"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr "jour du mois"
 msgid "day of the week"
 msgstr "jour de la semaine"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Date de Fin:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Sans Fin?"
@@ -3877,115 +2633,1174 @@ msgstr "La Date de Fin doit être postérieure à la Date de Début"
 msgid "Please select a repeat day"
 msgstr "SVP, selectionnez un jour de répétition"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Enregistrer à partir de 'Line In'?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Rediffusion?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Couleur de Fond:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Couleur du Texte:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendrier"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Enlever"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Utilisateurs"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Nom:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Flux"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Emission sans Titre"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Description:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Statistiques des Auditeurs"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' ne correspond pas au format de durée 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Modèle d'historique"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Durée:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Fuseau horaire:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Répétitions?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Impossible de créer un émission dans le passé"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Vous ne pouvez pas modifier la date / heure de début de l'émission qui a déjà commencé"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "La date/heure de Fin ne peut être dans le passé"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Ne peut pas avoir une durée <0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Ne peut pas avoir une durée de 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Ne peut pas avoir une durée supérieure à 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Ne peux pas programmer des émissions qui se chevauchent"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Recherche d'Utilisateurs:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "v"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Utilisateur:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Mot de Passe:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Vérification du Mot de Passe:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Prénom:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Nom:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Courriel:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Numéro de Mobile:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Type d'Utilisateur:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Le Nom de connexion n'est pas unique."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Mise en route"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Manuel Utilisateur"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Une Valeur est requise, ne peut pas être vide"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Date de Début:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Titre:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Créateur:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Année:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Label:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Compositeur:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conducteur:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Atmosphère:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Numéro ISRC:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Site Internet:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Langue"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Heure de Début"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Heure de Fin"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Fuseau horaire de l'Interface:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Nom de la Station"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo de la Station:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Remarque: Tout ce qui est plus grand que 600x600 sera redimensionné."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Durée du fondu enchaîné "
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Fondu en Entrée par défaut (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Fondu en Sorti par défaut (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Désactivé"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Activé"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Fuseau horaire de la Station"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "La Semaine Commence Le"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%'  n'est pas une adresse de courriel valide dans le format de type partie-locale@nomdedomaine"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' ne correspond pas au format de la date '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' est inférieur à %min% charactères"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' est plus grand de %min% charactères"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' n'est pas entre '%min%' et '%max%', inclusivement"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Les mots de passe ne correspondent pas"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Seuls les chiffres sont autorisés."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Connexion"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Saisissez les caractères que vous voyez dans l'image ci-dessous."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Mot de Passe"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirmez le nouveau mot de passe"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "La confirmation mot de passe ne correspond pas à votre mot de passe."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Utilisateur"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Réinitialisation du Mot de Passe"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "En Lecture"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Téléphone"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Site Internet de la Station"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Pays:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Ville:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Description de la Station:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Promouvoir station sur %s"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "En cochant cette case , je accepte la %s's %s de politique de confidentialité %s ."
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Vous devez accepter la politique de confidentialité."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Toutes Mes Emissions:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Selectionner le critère"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Taux d'Echantillonage (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Description"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Taux d'Echantillonage (Khz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "heures"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutes"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "éléments"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statique"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamique"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Génération de la liste de lecture et sauvegarde des crières"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Générer"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Contenu de la liste de lecture alèatoire"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Aléatoire"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "La Limite ne peut être vide ou plus petite que 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "La Limite ne peut être supérieure à 24 heures"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "La valeur doit être un entier"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 est la valeur maximale de l'élément que vous pouvez définir"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Vous devez sélectionner Critères et Modification"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "La 'Durée' doit être au format '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "La valeur doit être en format d'horodatage (par exemple 0000-00-00 ou 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "La valeur doit être numérique"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "La valeur doit être inférieure à 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "La valeur doit être inférieure à %s caractères"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "La Valeur ne peut pas être vide"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Licence par Défaut:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Tous droits réservés"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Ce travail est dans le domaine public"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Non Commercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution Pas de Travaux Dérivés"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Distribution à l'Identique"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Non Commercial Pas de Travaux Dérivés"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Non Commercial Distribution à l'Identique"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Metadata Vorbis"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Label du Flux:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artiste - Titre"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Emission - Artiste - Titre"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Nom de la Station - Nom de l'Emission"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Métadonnées Hors Antenne"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Activer"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Modifier le Niveau du Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Activé:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Type de Flux:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Débit:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Type de service:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Cannaux:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Serveur"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Nom"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Point de Montage"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Utilisateur Admin"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Mot de Passe Admin"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Le Serveur ne peut être vide."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Le Port ne peut être vide."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Le Point de Montage ne peut être vide avec un serveur Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "répertoire d'Import:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Répertoires Suveillés:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "N'est pas un Répertoire valide"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Lecture"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Placer le Point d'Entré"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Placer le Point de Sortie"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Curseur"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Flux Live"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr "%s Réinitialisation du mot de passe"
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Le Point d'entré et le point de sortie sont nul."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Ne peut pas fixer un point de sortie plus grand que la durée du fichier."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Impossible de définir un point d'entrée plus grand que le point de sortie."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Ne peux pas fixer un point de sortie plus petit que le point d'entrée."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Rediffusion de %s à %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Selectionner le Pays"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s n'est pas un répertoire valide."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s est déjà défini comme le répertoire de stockage courant ou dans la liste des dossiers surveillés"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s est déjà défini comme espace de stockage courant ou dans la liste des répertoires surveillés."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s est déjà défini comme espace de stockage courant ou dans la liste 
 msgid "%s doesn't exist in the watched list."
 msgstr "%s n'existe pas dans la liste surveillée"
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr "%s Réinitialisation du mot de passe"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Selectionner le Pays"
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Les Emissions peuvent avoir une durée maximale de 24 heures."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Ne peux pas programmer des émissions qui se chevauchent. \nRemarque: Le redimensionnement d'une émission répétée affecte l'ensemble de ses répétitions."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "La programmation que vous consultez n'est pas à jour! (décalage d'instance)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Le calendrier que vous consultez n'est pas à jour!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Vous n'êtes pas autorisé à programme l'émission %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Vous ne pouvez pas ajouter des fichiers à des emissions enregistrées."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "L émission %s est terminé et ne peut pas être programmé."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "L'émission %s a été précédement mise à jour!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Le contenu des émissions liés doit être programmé avant ou après sa diffusion"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr "Vous ne pouvez pas programmer une liste de lecture qui contient des fichiers manquants "
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Un fichier séléctionné n'existe pas!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Les Emissions peuvent avoir une durée maximale de 24 heures."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Ne peux pas programmer des émissions qui se chevauchent. \n"
+"Remarque: Le redimensionnement d'une émission répétée affecte l'ensemble de ses répétitions."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Rediffusion de %s à %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1049 @@ msgstr "Flux Web Invalide - Ceci semble être un fichier téléchargeable."
 msgid "Unrecognized stream type: %s"
 msgstr "Type de flux non reconnu: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "L'enregistrement du fichier n'existe pas"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Afficher les métadonnées du fichier enregistré"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edition"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edition de l'Emission"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Permission refusée"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Vous ne pouvez pas faire glisser et déposer des émissions en répétition"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Ne peux pas déplacer une émission diffusée"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Ne peux pas déplacer une émission dans le passé"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Impossible de déplacer une émission enregistrée à moins d'1 heure avant ses rediffusions."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "L'Emission a été éffacée parce que l'enregistrement de l'émission n'existe pas!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Doit attendre 1 heure pour retransmettre."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Morceau"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Joué"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "précédent"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "jouer"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "suivant"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "sourdine"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "désactiver"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "Volume max"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Mise à Jour Requise"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Pour lire le média, vous devrez mettre à jour votre navigateur vers une version récente ou mettre à jour votre %sPlugin Flash%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "A propos"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr "%1$s %2$s, le logiciel ouvert de gestion et de programmation pour vos stations distantes."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr "%1$s %2$s est distribué sous %3$s"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr "Bienvenue à %s !"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr "Voici comment vous pouvez commencer à utiliser %s pour automatiser vos émissions:"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Pour une aide plus détaillée, lisez le %smanuel utilisateur%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Partager"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Selection du Flux:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Page non trouvée!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "On dirait que la page que vous cherchez n'existe pas!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Source Emission"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Choix des Jours:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Ajouter"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Jours de Répétition:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtre de l'Historique"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Choisissez Afficher instance"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Trouver"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Réglages SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Source Maitre"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Choisir le répertoire"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Installer"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Répertoire d'Import en Cours:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr "Rescanner le répertoire surveillé (Ce qui peut être utile si il est sur le réseau et est peut être désynchronisé de %s)"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Supprimer le répertoire surveillé"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Vous ne surveillez pas les dossiers médias."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Enregistrez Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr "Cliquez sur la case ci-dessous pour promouvoir votre station sur %s ."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Requis)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(à des fins de vérification uniquement, ne sera pas publié)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Montrez-moi ce que je vais envoyer"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Termes et Conditions."
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Trouver Emissions"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "ou"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "et"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "à"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "fichiers répondent aux critères"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Flux"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "options supplémentaires"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Les informations suivantes seront affichées aux auditeurs dans leur lecteur multimédia:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Site Internet de la Station de Radio)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL du Flux:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Pour la promotion de votre station, 'Envoyez vos remarques au support' doit être activé)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Piste:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Durée:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Fréquence d'Echantillonnage"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Numéro ISRC:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Chemin du fichier:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Flux Web"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Bloc Intelligent Dynamique"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Bloc Intélligent Statique"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Piste Audio"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Contenus de la Liste de Lecture:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Contenus du Bloc Intelligent Statique:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Critère(s) du Bloc Intelligent Dynamique:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limité à"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Import du Fichier en cours..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Options Avancées de Recherche"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr "Bienvenue à la démo %s ! Vous pouvez vous connecter en utilisant le nom d'utilisateur «admin» et le mot de passe «admin» ."
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nouveau mot de passe"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "S'il vous plaît saisir et confirmer votre nouveau mot de passe dans les champs ci-dessous."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Précédent:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Prochain:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Sources des Flux"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "DIRECT"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Ecouter"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Déconnexion"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Votre période d'éssai expire dans"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Liste de Lecture Aléatoire"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Fondu enchainé de la Liste de Lecture"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Vider le contenu de la Liste de Lecture"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Vider"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fondu en sortie:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Sauvegarde de la Liste de Lecture"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Pas de Liste de Lecture Ouverte"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Montrer la Forme d'Onde"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Point d'Entrée"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Point de Sortie:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Durée Originale:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fondu en entrée:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Ettendre le bloc Statique"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Ettendre le Bloc Dynamique"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Fichier de Log"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Résumé du fichier"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Historique Emision"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Modèles de fichiers de Log"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Nouveau modèle de fichier de Log"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Aucun modèles de fichiers de Log"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Modèle de fichier d'historique"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Nouveau modèle de fichier d'Historique"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "aucun modèle de fichier d'Historique"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Création du fichier Modèle d'Historique"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Création du modèle de fichier de Log"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Ajouter plus d'éléments"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Ajouter un nouveau champs"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Definir le modèle par défaut"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Réglages des Flux"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Ajouter cette Emission"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Mettre à jour l'émission"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Quoi"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Quand"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Entrée du Flux Direct"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Qui"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Style"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Espace Disque"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Gérer les Utilisateurs"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nouvel Utilisateur"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Prénom"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Nom"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Type d'Utilisateur"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL du Flux:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Durée par Défaut:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Aucun Flux Web"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "s'il vous plaît mettez dans une durée en secondes '00 (.0) '"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Le contenu des émissions liés doit être programmé avant ou après sa diffusion"

--- a/airtime_mvc/locale/fr_FR/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/fr_FR/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hr_HR/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Sourcefabric <contact@sourcefabric.org>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Croatian (Croatia) (http://www.transifex.com/sourcefabric/airtime/language/hr_HR/)\n"
+"Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr_HR\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Snimljena datoteka ne postoji"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Godine %s moraju biti u rasponu od 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Metapodaci Snimljenog Fajla"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s nije ispravan datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s nije ispravan datum"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Uredi"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Uredi Programa"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Izbriši"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Dozvola odbijena"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Ne možeš povući i ispustiti ponavljajuće emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Ne možeš premjestiti događane emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Ne možeš premjestiti emisiju u prošlosti"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Ne možeš zakazati preklapajuće emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Ne možeš premjestiti snimljene emisije ranije od 1 sat vremena prije njenih reemitiranja."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Emisija je izbrisana jer je snimljena emisija ne postoji!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Moraš pričekati 1 sat za re-emitiranje."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Naziv"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Tvorac"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Dužina"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Žanr"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Raspoloženje"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Naljepnica"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Kompozitor"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Autorsko pravo"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Godina"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Pjesma"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Jezik"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Vrijeme Početka"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Vrijeme Završetka"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Pušteno"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalendar"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Korisnici"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Prijenosi"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Stanje"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Povijest puštenih pjesama"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Povijesni Predlošci"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Slušateljska Statistika"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Pomoć"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Početak Korištenja"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Priručnik"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Ne smiješ pristupiti ovog izvora."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Ne smiješ pristupiti ovog izvora."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Neispravan zahtjev."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Neispravan zahtjev"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Nemaš dopuštenje isključiti izvor."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Nema spojenog izvora na ovaj ulaz."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Nemaš dozvolu za promjenu izvora."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nije pronađen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Nešto je pošlo po krivu."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Pregled"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Dodaj na Popis Pjesama"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Dodaj u Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Uredi Metapodatke"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Izbriši"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Preuzimanje"
 
@@ -276,81 +890,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Udvostručavanje"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Nema dostupnih akcija"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Nemaš dopuštenje za brisanje odabrane stavke."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopiranje od %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Neimenovani Prijenos"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Prijenos je spremljen."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Nevažeći vrijednosti obrasca."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Molimo, provjeri da li je ispravan/na admin korisnik/lozinka na stranici Sustav->Prijenosi."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Korisnik je uspješno dodan!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Uređaj"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Korisnik je uspješno ažuriran!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Postavke su uspješno ažurirane!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Snimanje:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Majstorski Prijenos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Prijenos Uživo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Ništa po rasporedu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Trenutna Emisija:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Trenutna"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Ti imaš instaliranu najnoviju verziju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nova verzija je dostupna:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Ova verzija uskoro će biti zastario."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Ova verzija više nije podržana."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Molimo nadogradi na"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Dodaj u trenutni popis pjesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Dodaj u trenutni smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Dodavanje 1 Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Dodavanje %s Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Možeš dodavati samo pjesme kod pametnih blokova."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Možeš samo dodati pjesme, pametne blokova, i prijenose kod popise pjesama."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Molimo odaberi mjesto pokazivača na vremenskoj crti."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Uredi Metapodatke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Dodaj u odabranoj emisiji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Odaberi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Odaberi ovu stranicu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Odznači ovu stranicu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Odznači sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Jesi li siguran da želiš izbrisati odabranu (e) stavku (e)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Zakazana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Naziv"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Tvorac"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Prijenos Bita"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Kompozitor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Autorsko pravo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Kodirano je po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Žanr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Naljepnica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Jezik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Zadnja Izmjena"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Zadnji Put Odigrano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Dužina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mimika"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Raspoloženje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Vlasnik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Uzorak Stopa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Broj Pjesma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Dodano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Web stranica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Godina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Učitavanje..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Popisi pjesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Block-ovi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Prijenosi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Nepoznati tip:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Jesi li siguran da želiš obrisati odabranu stavku?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Prijenos je u tijeku..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Preuzimanje podataka s poslužitelja..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "SoundCloud id za ovu datoteku je:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Došlo je do pogreške prilikom prijenosa na SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Šifra pogreške:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Poruka o pogrešci:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Mora biti pozitivan broj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Mora biti broj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Mora biti u obliku: gggg-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Mora biti u obliku: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Trenutno je prijenos datoteke. %sOdlazak na drugom ekranu će otkazati proces slanja. %sJesi li siguran da želiš napustiti stranicu?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Otvori Medijskog Graditelja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "molimo stavi u vrijeme '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Tvoj preglednik ne podržava ovu vrstu audio datoteku:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dinamički blok nije dostupan za pregled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Ograničiti se na:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Popis pjesama je spremljena"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Popis pjesama je izmiješan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime je nesiguran o statusu ove datoteke. To se također može dogoditi kada je datoteka na udaljenom disku ili je datoteka u nekoj direktoriji, koja se više nije 'praćena tj. nadzirana'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Broj Slušalaca %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Podsjeti me za 1 tjedan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Nikad me više ne podsjeti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Da, pomažem Airtime-u"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Slika mora biti jpg, jpeg, png, ili gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Statički pametni blokovi spremaju kriterije i odmah generiraju blok sadržaja. To ti omogućuje da urediš i vidiš ga u knjižnici prije nego što ga dodaš na emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Dinamički pametni blokovi samo kriterije spremaju. Blok sadržaja će se generira nakon što ga dodate na emisiju. Nećeš moći pregledavati i uređivati sadržaj u knjižnici."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Željena duljina bloka neće biti postignut jer Airtime ne mogu naći dovoljno jedinstvene pjesme koje odgovaraju tvojim kriterijima. Omogući ovu opciju ako želiš dopustiti da neke pjesme mogu se više puta ponavljati."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block je izmiješan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block je generiran i kriterije su spremne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block je spremljen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Obrada..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Odaberi modifikator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "sadrži"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "ne sadrži"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "je"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "nije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "počinje sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "završava sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "je veći od"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "je manji od"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "je u rasponu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Odaberi Mapu za Skladištenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Odaberi Mapu za Praćenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Jesi li siguran da želiš promijeniti mapu za pohranu?\n"
+"To će ukloniti datoteke iz tvoje knjižnice!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Upravljanje Medijske Mape"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Jesi li siguran da želiš ukloniti nadzorsku mapu?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Ovaj put nije trenutno dostupan."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Neke vrste emitiranje zahtijevaju dodatnu konfiguraciju. Detalji oko omogućavanja %sAAC+ Podrške%s ili %sOpus Podrške%s su ovdje dostupni."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Priključen je na poslužitelju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Prijenos je onemogućen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Dobivanje informacija sa poslužitelja..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Ne može se povezati na poslužitelju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Ako je iza Airtime-a usmjerivač ili vatrozid, možda ćeš morati konfigurirati polje porta prosljeđivanje i ovo informacijsko polje će biti netočan. U tom slučaju morat ćeš ručno ažurirati ovo polje, da bi pokazao točno host/port/mount da se mogu povezati tvoji Disk Džokeji. Dopušteni raspon je između 1024 i 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Za više detalja, pročitaj %sPriručniku za korisnike%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Provjeri ovu opciju kako bi se omogućilo metapodataka za OGG potoke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Provjeri ovu kućicu za automatsko isključenje Majstor/Emisija izvora, nakon prestanka rada izvora."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Provjeri ovu kućicu za automatsko prebacivanje na Majstor/Emisija izvora, nakon što je spojen izvor."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Ako tvoj Icecast poslužitelj očekuje korisničko ime iz 'izvora', ovo polje može ostati prazno."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Ako tvoj 'live streaming' klijent ne pita za korisničko ime, ovo polje trebalo biti 'izvor'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Ovo je admin korisničko ime i lozinka za Icecast/SHOUTcast da bi dobio slušateljsku statistiku."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Upozorenje: Ne možeš promijeniti sadržaj polja, dok se sadašnja emisija ne završava"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nema pronađenih rezultata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "To slijedi isti uzorak sigurnosti za emisije: samo dodijeljeni korisnici se mogu povezati na emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Odredi prilagođene autentikacije koje će se uvažiti samo za ovu emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Emisija u ovom slučaju više ne postoji!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Upozorenje: Emisije ne može ponovno se povezati"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Povezivanjem svoje ponavljajuće emisije svaka zakazana medijska stavka u svakoj ponavljajućim emisijama dobit će isti raspored također i u drugim ponavljajućim emisijama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Vremenska zona je postavljena po staničnu zonu prema zadanim. Emisije u kalendaru će se prikazati po tvojim lokalnom vremenu koja je definirana u sučelji vremenske zone u tvojim korisničkim postavcima."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Program"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Emisija je prazna"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Dobivanje podataka s poslužitelja..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Ova emisija nema zakazanog sadržaja."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Ova emisija nije u potpunosti ispunjena sa sadržajem."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Siječanj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Veljača"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Ožujak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Travanj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Svibanj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Lipanj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Srpanj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Kolovoz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Rujan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Listopad"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Studeni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Prosinac"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Sij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Vel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Ožu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Tra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Lip"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Srp"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Kol"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Ruj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Lis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Stu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Pro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Nedjelja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Ponedjeljak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Utorak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Srijeda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Četvrtak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Petak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Subota"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Ned"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Pon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Uto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Sri"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Čet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Pet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sub"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Emisija dulje od predviđenog vremena će biti odsječen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Otkaži Trenutnog Programa?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Zaustavljanje snimanje emisije?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Sadržaj Emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Ukloniš sve sadržaje?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Obrišeš li odabranu(e) stavku(e)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Početak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Završetak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Trajanje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Odtamnjenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Zatamnjenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Prazna Emisija"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Snimanje sa Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Pregled pjesma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Ne može se zakazivati izvan emisije."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Premještanje 1 Stavka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Premještanje %s Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Spremi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Uređivač za (Od-/Za-)tamnjivanje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Uređivač"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Valni oblik značajke su dostupne u sporednu Web Audio API pregledniku"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Odaberi sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Ne odaberi ništa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Ukloni odabrane zakazane stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Skoči na trenutnu sviranu pjesmu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Poništi trenutnu emisiju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Otvori knjižnicu za dodavanje ili uklanjanje sadržaja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Dodaj / Ukloni Sadržaj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "u upotrebi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Pogledaj unutra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Otvori"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "Disk-džokej"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Voditelj Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Gost"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Gosti mogu učiniti sljedeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Pregled rasporeda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Pregled sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Disk-džokeji mogu učiniti sljedeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Upravljanje dodijeljen sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Uvoz medijske datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Izradi popise naslova, smart block-ove, i prijenose"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Upravljanje svoje knjižničnog sadržaja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Menadžer programa mogu učiniti sljedeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Prikaz i upravljanje sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Rasporedne emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Upravljanje sve sadržaje knjižnica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Administratori mogu učiniti sljedeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Upravljanje postavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Upravljanje korisnike"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Upravljanje nadziranih datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Pošalji povratne informacije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Pregled stanja sustava"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Pristup za povijest puštenih pjesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Pogledaj statistiku slušatelje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Pokaži/sakrij stupce"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Od {from} do {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "gggg-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Ne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Ut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Sr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Če"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Pe"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Su"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Zatvori"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Sat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Gotovo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Odaberi datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Dodaj datoteke i klikni na 'Pokreni Upload' dugme."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Dodaj Datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Zaustavi Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Pokreni upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Dodaj datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Poslana %d/%d datoteka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Povuci datoteke ovdje."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Pogreška (datotečni nastavak)."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Pogreška veličine datoteke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Pogreška broj datoteke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init pogreška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP pogreška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Sigurnosna pogreška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generička pogreška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO pogreška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Datoteka: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d datoteka na čekanju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Datoteka: %f, veličina: %s, maks veličina datoteke: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Prijenosni URL može biti u krivu ili ne postoji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Pogreška: Datoteka je prevelika:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Pogreška: Nevažeći datotečni nastavak:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Postavi Zadano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Stvaranje Unosa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Uredi Povijest Zapisa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Nema Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s red%s je kopiran u međumemoriju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sIspis pogled%sMolimo, koristi preglednika ispis funkciju za ispis ovu tablicu. Kad završiš, pritisni Escape."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-mail nije mogao biti poslan. Provjeri svoje postavke poslužitelja pošte i uvjeri se da je ispravno podešen."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Pogrešno korisničko ime ili lozinka. Molimo pokušaj ponovno."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -370,11 +2405,6 @@ msgstr "Nemaš dopuštenje za brisanje odabranog (e) %s."
 msgid "You can only add tracks to smart block."
 msgstr "Možeš samo pjesme dodavati za pametnog bloka."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Možeš samo dodati pjesme, pametne blokova, i prijenose kod popise pjesama."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Neimenovani Popis Pjesama"
@@ -383,2627 +2413,88 @@ msgstr "Neimenovani Popis Pjesama"
 msgid "Untitled Smart Block"
 msgstr "Neimenovani Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Nepoznati Popis Pjesama"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Ne smiješ pristupiti ovog izvora."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Postavke su ažurirane."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Podrška postavka je ažurirana."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Povratne Informacije"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Prijenos Podešavanje je Ažurirano."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "put bi trebao biti specificiran"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem sa Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Nemaš dopuštenje isključiti izvor."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Nema spojenog izvora na ovaj ulaz."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Nemaš dozvolu za promjenu izvora."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Pogrešno korisničko ime ili lozinka. Molimo pokušaj ponovno."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-mail nije mogao biti poslan. Provjeri svoje postavke poslužitelja pošte i uvjeri se da je ispravno podešen."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Ne smiješ pristupiti ovog izvora."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Neispravan zahtjev."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Neispravan zahtjev"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Uređaj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Snimanje:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Majstorski Prijenos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Prijenos Uživo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Ništa po rasporedu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Trenutna Emisija:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Trenutna"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Ti imaš instaliranu najnoviju verziju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nova verzija je dostupna:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Ova verzija uskoro će biti zastario."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Ova verzija više nije podržana."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Molimo nadogradi na"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Dodaj u trenutni popis pjesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Dodaj u trenutni smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Dodavanje 1 Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Dodavanje %s Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Možeš dodavati samo pjesme kod pametnih blokova."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Molimo odaberi mjesto pokazivača na vremenskoj crti."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Dodaj u odabranoj emisiji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Odaberi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Odaberi ovu stranicu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Odznači ovu stranicu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Odznači sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Jesi li siguran da želiš izbrisati odabranu (e) stavku (e)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Zakazana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Prijenos Bita"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Kodirano je po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Zadnja Izmjena"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Zadnji Put Odigrano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mimika"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Vlasnik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Uzorak Stopa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Broj Pjesma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Dodano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Web stranica"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Učitavanje..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Popisi pjesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Block-ovi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Prijenosi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Nepoznati tip:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Jesi li siguran da želiš obrisati odabranu stavku?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Prijenos je u tijeku..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Preuzimanje podataka s poslužitelja..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "SoundCloud id za ovu datoteku je:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Došlo je do pogreške prilikom prijenosa na SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Šifra pogreške:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Poruka o pogrešci:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Mora biti pozitivan broj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Mora biti broj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Mora biti u obliku: gggg-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Mora biti u obliku: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Trenutno je prijenos datoteke. %sOdlazak na drugom ekranu će otkazati proces slanja. %sJesi li siguran da želiš napustiti stranicu?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Otvori Medijskog Graditelja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "molimo stavi u vrijeme '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "molimo stavi u vrijeme u sekundama '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Tvoj preglednik ne podržava ovu vrstu audio datoteku:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dinamički blok nije dostupan za pregled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Ograničiti se na:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Popis pjesama je spremljena"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Popis pjesama je izmiješan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime je nesiguran o statusu ove datoteke. To se također može dogoditi kada je datoteka na udaljenom disku ili je datoteka u nekoj direktoriji, koja se više nije 'praćena tj. nadzirana'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Broj Slušalaca %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Podsjeti me za 1 tjedan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Nikad me više ne podsjeti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Da, pomažem Airtime-u"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Slika mora biti jpg, jpeg, png, ili gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Statički pametni blokovi spremaju kriterije i odmah generiraju blok sadržaja. To ti omogućuje da urediš i vidiš ga u knjižnici prije nego što ga dodaš na emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Dinamički pametni blokovi samo kriterije spremaju. Blok sadržaja će se generira nakon što ga dodate na emisiju. Nećeš moći pregledavati i uređivati sadržaj u knjižnici."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Željena duljina bloka neće biti postignut jer Airtime ne mogu naći dovoljno jedinstvene pjesme koje odgovaraju tvojim kriterijima. Omogući ovu opciju ako želiš dopustiti da neke pjesme mogu se više puta ponavljati."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block je izmiješan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block je generiran i kriterije su spremne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block je spremljen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Obrada..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Odaberi modifikator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "sadrži"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "ne sadrži"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "je"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "nije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "počinje sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "završava sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "je veći od"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "je manji od"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "je u rasponu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Odaberi Mapu za Skladištenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Odaberi Mapu za Praćenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Jesi li siguran da želiš promijeniti mapu za pohranu?\nTo će ukloniti datoteke iz tvoje knjižnice!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Upravljanje Medijske Mape"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Jesi li siguran da želiš ukloniti nadzorsku mapu?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Ovaj put nije trenutno dostupan."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Neke vrste emitiranje zahtijevaju dodatnu konfiguraciju. Detalji oko omogućavanja %sAAC+ Podrške%s ili %sOpus Podrške%s su ovdje dostupni."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Priključen je na poslužitelju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Prijenos je onemogućen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Dobivanje informacija sa poslužitelja..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Ne može se povezati na poslužitelju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Ako je iza Airtime-a usmjerivač ili vatrozid, možda ćeš morati konfigurirati polje porta prosljeđivanje i ovo informacijsko polje će biti netočan. U tom slučaju morat ćeš ručno ažurirati ovo polje, da bi pokazao točno host/port/mount da se mogu povezati tvoji Disk Džokeji. Dopušteni raspon je između 1024 i 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Za više detalja, pročitaj %sPriručniku za korisnike%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Provjeri ovu opciju kako bi se omogućilo metapodataka za OGG potoke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Provjeri ovu kućicu za automatsko isključenje Majstor/Emisija izvora, nakon prestanka rada izvora."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Provjeri ovu kućicu za automatsko prebacivanje na Majstor/Emisija izvora, nakon što je spojen izvor."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Ako tvoj Icecast poslužitelj očekuje korisničko ime iz 'izvora', ovo polje može ostati prazno."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Ako tvoj 'live streaming' klijent ne pita za korisničko ime, ovo polje trebalo biti 'izvor'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Ovo je admin korisničko ime i lozinka za Icecast/SHOUTcast da bi dobio slušateljsku statistiku."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Upozorenje: Ne možeš promijeniti sadržaj polja, dok se sadašnja emisija ne završava"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nema pronađenih rezultata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "To slijedi isti uzorak sigurnosti za emisije: samo dodijeljeni korisnici se mogu povezati na emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Odredi prilagođene autentikacije koje će se uvažiti samo za ovu emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Emisija u ovom slučaju više ne postoji!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Upozorenje: Emisije ne može ponovno se povezati"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Povezivanjem svoje ponavljajuće emisije svaka zakazana medijska stavka u svakoj ponavljajućim emisijama dobit će isti raspored također i u drugim ponavljajućim emisijama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Vremenska zona je postavljena po staničnu zonu prema zadanim. Emisije u kalendaru će se prikazati po tvojim lokalnom vremenu koja je definirana u sučelji vremenske zone u tvojim korisničkim postavcima."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Program"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Emisija je prazna"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Dobivanje podataka s poslužitelja..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Ova emisija nema zakazanog sadržaja."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Ova emisija nije u potpunosti ispunjena sa sadržajem."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Siječanj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Veljača"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Ožujak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Travanj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Svibanj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Lipanj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Srpanj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Kolovoz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Rujan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Listopad"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Studeni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Prosinac"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Sij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Vel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Ožu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Tra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Lip"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Srp"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Kol"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Ruj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Lis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Stu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Pro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Nedjelja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Ponedjeljak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Utorak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Srijeda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Četvrtak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Petak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Subota"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Ned"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Pon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Uto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Sri"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Čet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Pet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sub"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Emisija dulje od predviđenog vremena će biti odsječen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Otkaži Trenutnog Programa?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Zaustavljanje snimanje emisije?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Sadržaj Emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Ukloniš sve sadržaje?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Obrišeš li odabranu(e) stavku(e)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Početak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Završetak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Trajanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Odtamnjenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Zatamnjenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Prazna Emisija"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Snimanje sa Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Pregled pjesma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Ne može se zakazivati izvan emisije."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Premještanje 1 Stavka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Premještanje %s Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Spremi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Otkaži"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Uređivač za (Od-/Za-)tamnjivanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Uređivač"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Valni oblik značajke su dostupne u sporednu Web Audio API pregledniku"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Odaberi sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Ne odaberi ništa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Ukloni odabrane zakazane stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Skoči na trenutnu sviranu pjesmu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Poništi trenutnu emisiju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Otvori knjižnicu za dodavanje ili uklanjanje sadržaja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Dodaj / Ukloni Sadržaj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "u upotrebi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Pogledaj unutra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Otvori"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "Disk-džokej"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Voditelj Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Gost"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Gosti mogu učiniti sljedeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Pregled rasporeda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Pregled sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Disk-džokeji mogu učiniti sljedeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Upravljanje dodijeljen sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Uvoz medijske datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Izradi popise naslova, smart block-ove, i prijenose"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Upravljanje svoje knjižničnog sadržaja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Menadžer programa mogu učiniti sljedeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Prikaz i upravljanje sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Rasporedne emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Upravljanje sve sadržaje knjižnica"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Administratori mogu učiniti sljedeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Upravljanje postavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Upravljanje korisnike"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Upravljanje nadziranih datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Pošalji povratne informacije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Pregled stanja sustava"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Pristup za povijest puštenih pjesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Pogledaj statistiku slušatelje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Pokaži/sakrij stupce"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Od {from} do {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "gggg-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Ne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Ut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Sr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Če"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Pe"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Su"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Zatvori"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Sat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Gotovo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Odaberi datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Dodaj datoteke i klikni na 'Pokreni Upload' dugme."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Stanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Dodaj Datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Zaustavi Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Pokreni upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Dodaj datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Poslana %d/%d datoteka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Povuci datoteke ovdje."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Pogreška (datotečni nastavak)."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Pogreška veličine datoteke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Pogreška broj datoteke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init pogreška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP pogreška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Sigurnosna pogreška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generička pogreška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO pogreška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Datoteka: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d datoteka na čekanju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Datoteka: %f, veličina: %s, maks veličina datoteke: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Prijenosni URL može biti u krivu ili ne postoji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Pogreška: Datoteka je prevelika:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Pogreška: Nevažeći datotečni nastavak:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Postavi Zadano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Stvaranje Unosa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Uredi Povijest Zapisa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Nema Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s red%s je kopiran u međumemoriju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sIspis pogled%sMolimo, koristi preglednika ispis funkciju za ispis ovu tablicu. Kad završiš, pritisni Escape."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Odaberi pokazivač"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Ukloni pokazivač"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "emisija ne postoji"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Reemitiranje emisija %s od %s na %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Odaberi pokazivač"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Ukloni pokazivač"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "emisija ne postoji"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Korisnik je uspješno dodan!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Korisnik je uspješno ažuriran!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Postavke su uspješno ažurirane!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Neimenovani Prijenos"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Prijenos je spremljen."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Nevažeći vrijednosti obrasca."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Godine %s moraju biti u rasponu od 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s nije ispravan datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s nije ispravan datum"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Prijenos uživo"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Pokreni"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Zaustavi"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Podesi Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Podesi Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Pokazivač"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Podijeli"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Prijenosi:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "nijemi"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "uključi"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "O projektu"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Za detaljnu pomoć, pročitaj %skorisnički priručnik%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Povijest puštenih pjesama"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Popis Prijava"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Datotečni Sažetak"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Programski Sažetak"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Proširenje Statičkog Bloka"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Proširenje Dinamičkog Bloka"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Naziv:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Opis:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Trajanje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Slučajni izbor popis pjesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Miješanje"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Križno utišavanje popis pjesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Prazan sadržaj popis pjesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Očisti"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Odtamnjenje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Zatamnjenje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Spremi popis pjesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Nema otvorenih popis pjesama"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Emisijski zvučni talasni oblik"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Izvorna Dužina:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Prijenosne Postavke"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Prijava"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nova lozinka"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Unesi i potvrdi svoju novu lozinku u polja dolje."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Upravljanje Korisnike"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Novi Korisnik"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Korisničko ime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Ime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Prezime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Tip Korisnika"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Nađi Emisije"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Odaberi Emisijsku Stupnju"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Nađi"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Ponovljeni Dani:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Ukloni"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Dodaj"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Emisijski Izvor"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime Registar"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Obavezno)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(služi samo za provjeru, neće biti objavljena)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Napomena: Sve veća od 600x600 će se mijenjati."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Pokaži mi što šaljem"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Uvjeti i Odredbe"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Odaberi Dane:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "ili"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "i"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "do"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "datoteke zadovoljavaju kriterije"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtriraj Povijesti"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Kako bi se promovirao svoju stanicu, 'Pošalji povratne informacije' mora biti omogućena)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Prijenos"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Dodatne Opcije"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Sljedeće informacije će biti prikazane slušateljima u medijskom plejerima:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Tvoja radijska postaja web stranice)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL Prijenosa:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Odaberi mapu"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Podesi"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktualna Uvozna Mapa:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Ukloni nadzoranu direktoriju"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Ne pratiš nijedne medijske mape."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Majstorski Izvor"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Postavke"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Dodaj ovu emisiju"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Ažuriranje emisije"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Što"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Kada"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Ulaz Uživnog Prijenosa"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Tko"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stil"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Diskovni Prostor"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Uvoz datoteke je u tijeku..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Napredne Opcije Pretraživanja"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Naziv:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Tvorac:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Pjesma:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Dužina:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Uzorak Stopa:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Brzina u Bitovima:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Raspoloženje:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Žanr:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Godina:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Naljepnica:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Kompozitor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dirigent:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Autorsko pravo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Broj:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Web stranica:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Jezik:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Staža Datoteka:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Prijenos"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dinamički Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statički Smart Block"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Zvučni Zapis"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Sadržaji Popis Pjesama:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statički Smart Block Sadržaji:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dinamički Smart Block Kriteriji:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Ograničeno za"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Vaš račun istječe u"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dani"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Prethodna:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Sljedeća:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Prijenosni Izvori"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "PRIJENOS"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Slušaj"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Odjava"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Predlošci Popis Prijave"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Novi Popis Predložaka"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Nema Popis Predložaka"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Predlošci za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Novi Predložak za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Nema Predložaka za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Stvaranje Predložaka za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Stvaranje Popis Predložaka"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Naziv"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Dodaj više elemenata"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Dodaj Novo Polje"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Postavi Zadano Predlošku"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Opis"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL Prijenosa:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Zadana Dužina:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Nema prijenosa"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Pomoć"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Stranica nije pronađena!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Izgleda stranica koju si tražio ne postoji!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "prethodna"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "pokreni"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pauza"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "sljedeća"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "zaustavi"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max glasnoća"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Potrebno Ažuriranje"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Medija je potrebna za reprodukciju, i moraš ažurirati svoj preglednik na noviju verziju, ili ažurirati svoj %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Datum Početka:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2504,6 @@ msgstr "Datum Početka:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Uneseni su nevažeći znakovi"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Datum Završetka:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Sve Moje Emisije:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Traži Korisnike:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Disk-Džokeji:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Naziv Postaje"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Web Stranica:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Država:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Grad:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Opis:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Moraš pristati na pravila o privatnosti."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Snimanje sa Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Ponovno emitirati?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Vrijednost je potrebna i ne može biti prazan"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' nije valjana e-mail adresa u osnovnom obliku local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' ne odgovara po obliku datuma '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' je manji od %min% dugačko znakova"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' je više od %max% dugačko znakova"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' nije između '%min%' i '%max%', uključivo"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Lozinke se ne podudaraju"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2520,55 @@ msgstr "Vrijeme mora biti navedeno"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Moraš čekati najmanje 1 sat za re-emitiranje"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Resetuj lozinku"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Neimenovan Program"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Broj:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "Ok"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Zadano Trajanje Križno Stišavanje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Zadano Odtamnjenje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Zadano Zatamnjenje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Onemogućeno"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Omogućeno"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Stanična Vremenska Zona"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Prvi Dan u Tjednu"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Korisničko ime:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Lozinka:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Potvrdi Lozinku:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Ime:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Prezime:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobitel:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Vrsta Korisnika:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Ime prijave nije jedinstveno."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Uvozna Mapa:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Mape Pod Nadzorom:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Ne valjana Direktorija"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Zadana Dozvola:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Sva prava pridržana"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Rad je u javnoj domeni"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Imenovanje"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Imenovanje Nekomercijalno"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Imenovanje Bez Izvedenih Djela"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Imenovanje Dijeli Pod Istim Uvjetima"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Imenovanje Nekomercijalno Bez Izvedenih Djela"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Imenovanje Nekomercijalno Dijeli Pod Istim Uvjetima"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Vremenska Zona Sučelja:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Trenutno Izvođena"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Odaberi kriterije"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Brzina u Bitovima (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Uzorak Stopa (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "sati"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minuti"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "elementi"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statički"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinamički"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generiranje popisa pjesama i spremanje sadržaja kriterije"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generiraj"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Sadržaj slučajni izbor popis pjesama"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Ograničenje ne može biti prazan ili manji od 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Ograničenje ne može biti više od 24 sati"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Vrijednost mora biti cijeli broj"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 je max stavku graničnu vrijednost moguće je podesiti"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Moraš odabrati Kriteriju i Modifikaciju"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Dužina' trebala biti u '00:00:00' obliku"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Vrijednost mora biti u obliku vremenske oznake (npr. 0000-00-00 ili 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Vrijednost mora biti numerička"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Vrijednost bi trebala biti manja od 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Vrijednost mora biti manja od %s znakova"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Vrijednost ne može biti prazna"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metapodaci"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Vidljivi Podaci:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Autor - Naziv"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Program - Autor - Naziv"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Naziv postaje - Naziv programa"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metapodaci"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Omogući Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifikator"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Lozinka"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Potvrdi novu lozinku"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Lozinke koje ste unijeli ne podudaraju se."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Omogućeno:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Prijenos Tipa:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Tip Usluge:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanali:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Poslužitelj"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Dopušteni su samo brojevi."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Točka Montiranja"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin Korisnik"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Lozinka"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Poslužitelj ne može biti prazan."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port ne može biti prazan."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Montiranje ne može biti prazna s Icecast poslužiteljem."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' se ne uklapa u vremenskom formatu 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Vremenska Zona:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Ponavljanje?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Ne može se stvoriti emisije u prošlosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Ne možeš mijenjati datum/vrijeme početak emisije, ako je već počela"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Datum završetka i vrijeme ne može biti u prošlosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Ne može trajati < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Ne može trajati 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Ne može trajati više od 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Koristi Prilagođeno provjeru autentičnosti:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Prilagođeno Korisničko Ime"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Prilagođena Lozinka"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "'Korisničko Ime' polja ne smije ostati prazno."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "'Lozinka' polja ne smije ostati prazno."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Boja Pozadine:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Boja Teksta:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Upiši znakove koje vidiš na slici u nastavku."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dani"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2614,12 @@ msgstr "dan u mjesecu"
 msgid "day of the week"
 msgstr "dan u tjednu"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Datum Završetka:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Nema Kraja?"
@@ -3876,115 +2632,1174 @@ msgstr "Datum završetka mora biti nakon datuma početka"
 msgid "Please select a repeat day"
 msgstr "Molimo, odaberi kojeg dana"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Snimanje sa Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Ponovno emitirati?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Boja Pozadine:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Boja Teksta:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalendar"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Ukloni"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Korisnici"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Naziv:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Prijenosi"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Neimenovan Program"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Žanr:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Opis:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Slušateljska Statistika"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' se ne uklapa u vremenskom formatu 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Povijesni Predlošci"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Trajanje:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Vremenska Zona:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Ponavljanje?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Ne može se stvoriti emisije u prošlosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Ne možeš mijenjati datum/vrijeme početak emisije, ako je već počela"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Datum završetka i vrijeme ne može biti u prošlosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Ne može trajati < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Ne može trajati 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Ne može trajati više od 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Ne možeš zakazati preklapajuće emisije"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Traži Korisnike:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Disk-Džokeji:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Korisničko ime:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Lozinka:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Potvrdi Lozinku:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Ime:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Prezime:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobitel:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Vrsta Korisnika:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Ime prijave nije jedinstveno."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Početak Korištenja"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Priručnik"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Vrijednost je potrebna i ne može biti prazan"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Datum Početka:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Naziv:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Tvorac:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Godina:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Naljepnica:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Kompozitor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dirigent:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Raspoloženje:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Autorsko pravo:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Broj:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Web stranica:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Jezik:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Vrijeme Početka"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Vrijeme Završetka"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Vremenska Zona Sučelja:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Naziv Postaje"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Napomena: Sve veća od 600x600 će se mijenjati."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Zadano Trajanje Križno Stišavanje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Zadano Odtamnjenje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Zadano Zatamnjenje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Stanična Vremenska Zona"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Prvi Dan u Tjednu"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' nije valjana e-mail adresa u osnovnom obliku local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' ne odgovara po obliku datuma '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' je manji od %min% dugačko znakova"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' je više od %max% dugačko znakova"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' nije između '%min%' i '%max%', uključivo"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Lozinke se ne podudaraju"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Dopušteni su samo brojevi."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Prijava"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Upiši znakove koje vidiš na slici u nastavku."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Lozinka"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Potvrdi novu lozinku"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Lozinke koje ste unijeli ne podudaraju se."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Resetuj lozinku"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Trenutno Izvođena"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Web Stranica:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Država:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Grad:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Opis:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Moraš pristati na pravila o privatnosti."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Sve Moje Emisije:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Odaberi kriterije"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Brzina u Bitovima (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Opis"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Uzorak Stopa (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "sati"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minuti"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "elementi"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statički"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinamički"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generiranje popisa pjesama i spremanje sadržaja kriterije"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generiraj"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Sadržaj slučajni izbor popis pjesama"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Miješanje"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Ograničenje ne može biti prazan ili manji od 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Ograničenje ne može biti više od 24 sati"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Vrijednost mora biti cijeli broj"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 je max stavku graničnu vrijednost moguće je podesiti"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Moraš odabrati Kriteriju i Modifikaciju"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Dužina' trebala biti u '00:00:00' obliku"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Vrijednost mora biti u obliku vremenske oznake (npr. 0000-00-00 ili 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Vrijednost mora biti numerička"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Vrijednost bi trebala biti manja od 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Vrijednost mora biti manja od %s znakova"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Vrijednost ne može biti prazna"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Zadana Dozvola:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Sva prava pridržana"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Rad je u javnoj domeni"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Imenovanje"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Imenovanje Nekomercijalno"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Imenovanje Bez Izvedenih Djela"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Imenovanje Dijeli Pod Istim Uvjetima"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Imenovanje Nekomercijalno Bez Izvedenih Djela"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Imenovanje Nekomercijalno Dijeli Pod Istim Uvjetima"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metapodaci"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Vidljivi Podaci:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Autor - Naziv"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Program - Autor - Naziv"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Naziv postaje - Naziv programa"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metapodaci"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Omogući Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifikator"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Omogućeno:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Prijenos Tipa:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Brzina u Bitovima:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Tip Usluge:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanali:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Poslužitelj"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Naziv"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Točka Montiranja"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin Korisnik"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Lozinka"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Poslužitelj ne može biti prazan."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port ne može biti prazan."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Montiranje ne može biti prazna s Icecast poslužiteljem."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Uvozna Mapa:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Mape Pod Nadzorom:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Ne valjana Direktorija"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Pokreni"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Zaustavi"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Podesi Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Podesi Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Pokazivač"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Prijenos uživo"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in i cue out su nule."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Ne možeš postaviti da će 'cue out' biti veće od duljine datoteke."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Ne možeš postaviti da će 'cue in' biti veće od 'cue out'."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Ne mogu se postaviti da će 'cue out' biti manje od 'cue in'."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Reemitiranje od %s od %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Odaberi Državu"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4009,14 +3824,12 @@ msgstr "%s nije valjana direktorija."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s je već postavljena kao mapa za pohranu ili je između popisa praćene mape"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s je već postavljena kao mapa za pohranu ili je između popisa praćene mape."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,28 +3837,18 @@ msgstr "%s je već postavljena kao mapa za pohranu ili je između popisa praćen
 msgid "%s doesn't exist in the watched list."
 msgstr "%s ne postoji u popisu nadziranih lokacija."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Odaberi Državu"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Emisija može imati najveću duljinu od 24 sata."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Ne može se zakazati preklapajuće emisije.\nNapomena: Promjena veličine ponovljene emisije utječe na sve njene ponavljanje"
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4060,48 +3863,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Zastario se pregledan raspored! (primjer neusklađenost)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Zastario se pregledan raspored!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Ne smijes zakazati rasporednu emisiju %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Ne možeš dodavati datoteke za snimljene emisije."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Emisija %s je gotova i ne mogu biti zakazana."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Ranije je %s emisija već bila ažurirana!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Sadržaj u povezanim emisijama mora biti zakazan prije ili poslije bilo koje emisije"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Odabrana Datoteka ne postoji!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Emisija može imati najveću duljinu od 24 sata."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Ne može se zakazati preklapajuće emisije.\n"
+"Napomena: Promjena veličine ponovljene emisije utječe na sve njene ponavljanje"
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Reemitiranje od %s od %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4148,8 +3963,1049 @@ msgstr "Nevažeći prijenos - Čini se da je ovo preuzimanje datoteka."
 msgid "Unrecognized stream type: %s"
 msgstr "Nepoznati prijenosni tip: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Snimljena datoteka ne postoji"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Metapodaci Snimljenog Fajla"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Uredi"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Uredi Programa"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Dozvola odbijena"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Ne možeš povući i ispustiti ponavljajuće emisije"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Ne možeš premjestiti događane emisije"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Ne možeš premjestiti emisiju u prošlosti"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Ne možeš premjestiti snimljene emisije ranije od 1 sat vremena prije njenih reemitiranja."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Emisija je izbrisana jer je snimljena emisija ne postoji!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Moraš pričekati 1 sat za re-emitiranje."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Pjesma"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Pušteno"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "prethodna"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "pokreni"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pauza"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "sljedeća"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "zaustavi"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "nijemi"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "uključi"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max glasnoća"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Potrebno Ažuriranje"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Medija je potrebna za reprodukciju, i moraš ažurirati svoj preglednik na noviju verziju, ili ažurirati svoj %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "O projektu"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Za detaljnu pomoć, pročitaj %skorisnički priručnik%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Podijeli"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Prijenosi:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Stranica nije pronađena!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Izgleda stranica koju si tražio ne postoji!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Emisijski Izvor"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Odaberi Dane:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Dodaj"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Ponovljeni Dani:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtriraj Povijesti"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Odaberi Emisijsku Stupnju"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Nađi"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Postavke"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Majstorski Izvor"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "Ok"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Odaberi mapu"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Podesi"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktualna Uvozna Mapa:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Ukloni nadzoranu direktoriju"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Ne pratiš nijedne medijske mape."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime Registar"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Obavezno)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(služi samo za provjeru, neće biti objavljena)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Pokaži mi što šaljem"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Uvjeti i Odredbe"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Nađi Emisije"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "ili"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "i"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "do"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "datoteke zadovoljavaju kriterije"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Prijenos"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Dodatne Opcije"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Sljedeće informacije će biti prikazane slušateljima u medijskom plejerima:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Tvoja radijska postaja web stranice)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL Prijenosa:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Kako bi se promovirao svoju stanicu, 'Pošalji povratne informacije' mora biti omogućena)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Pjesma:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Dužina:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Uzorak Stopa:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Broj:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Staža Datoteka:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Prijenos"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dinamički Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statički Smart Block"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Zvučni Zapis"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Sadržaji Popis Pjesama:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statički Smart Block Sadržaji:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dinamički Smart Block Kriteriji:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Ograničeno za"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Uvoz datoteke je u tijeku..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Napredne Opcije Pretraživanja"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nova lozinka"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Unesi i potvrdi svoju novu lozinku u polja dolje."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Prethodna:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Sljedeća:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Prijenosni Izvori"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "PRIJENOS"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Slušaj"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Odjava"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Vaš račun istječe u"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Slučajni izbor popis pjesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Križno utišavanje popis pjesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Prazan sadržaj popis pjesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Očisti"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Zatamnjenje:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Spremi popis pjesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Nema otvorenih popis pjesama"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Emisijski zvučni talasni oblik"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Izvorna Dužina:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Odtamnjenje:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Proširenje Statičkog Bloka"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Proširenje Dinamičkog Bloka"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Popis Prijava"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Datotečni Sažetak"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Programski Sažetak"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Predlošci Popis Prijave"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Novi Popis Predložaka"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Nema Popis Predložaka"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Predlošci za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Novi Predložak za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Nema Predložaka za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Stvaranje Predložaka za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Stvaranje Popis Predložaka"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Dodaj više elemenata"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Dodaj Novo Polje"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Postavi Zadano Predlošku"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Prijenosne Postavke"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Dodaj ovu emisiju"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Ažuriranje emisije"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Što"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Kada"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Ulaz Uživnog Prijenosa"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Tko"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stil"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Diskovni Prostor"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Upravljanje Korisnike"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Novi Korisnik"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Ime"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Prezime"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Tip Korisnika"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL Prijenosa:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Zadana Dužina:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Nema prijenosa"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "molimo stavi u vrijeme u sekundama '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Sadržaj u povezanim emisijama mora biti zakazan prije ili poslije bilo koje emisije"

--- a/airtime_mvc/locale/hr_HR/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/hr_HR/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hu_HU/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Zsolt Magyar <picizse@gmail.com>, 2014
 # Zsolt Magyar <picizse@gmail.com>, 2014
@@ -11,266 +11,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-10-07 18:13+0000\n"
 "Last-Translator: Zsolt Magyar <picizse@gmail.com>\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/sourcefabric/airtime/language/hu_HU/)\n"
+"Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu_HU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Rögzített fájl nem létezik"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Az évnek %s 1753 - 9999 közötti tartományban kell lennie"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "A Rögzített Fájl Metaadatai"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s érvénytelen dátum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s érvénytelen időpont"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Szerkeszt"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Műsor Szerkesztése"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Törlés"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Engedély megtagadva"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Nem lehet megismételni a fogd és vidd típusú műsorokat"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Az elhangzott műsort nem lehet áthelyezni"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "A műsort nem lehet a múltba áthelyezni"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Nem fedhetik egymást a műsorok"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "A rögzített műsort, 1 óránál korábban nem lehet újra közvetíteni."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "A műsor törlésre került, mert a rögzített műsor nem létezik!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Az adás újbóli közvetítésére 1 órát kell várni."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Cím"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Előadó/Szerző"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Hossz"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Műfaj"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Hangulat"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Címke"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Zeneszerző"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Szerzői jog"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Év"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Dalszám"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Karmester"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Nyelv"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Kezdési Idő"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Fejezési Idő"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Lejátszva"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Naptár"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr "Lejátszó"
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr "Profilom"
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Felhasználók"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Adásfolyamok"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Állapot"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Lejátszási Előzmények"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Naplózási Sablonok"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Hallgatói Statisztikák"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Segítség"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Első Lépések"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr "GYIK"
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Felhasználói Kézikönyv"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Az Ön számára nem érhető el az alábbi erőforrás."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Az Ön számára nem érhető el az alábbi erőforrás."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr "A fájl nem elérhető itt: %s"
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Helytelen kérés. nincs 'mód' paraméter lett átadva."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Helytelen kérés. 'mód' paraméter érvénytelen."
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Nincs jogosúltsága a forrás bontásához."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Nem csatlakozik forrás az alábbi bemenethez."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Nincs jogosúltsága a forrás megváltoztatásához."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nem található"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Valami hiba történt."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Előnézet"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Hozzáadás a Lejátszási listához"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Hozzáadás az Okos Táblához"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Metaadatok Szerkesztése"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Törlés"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Letöltés"
 
@@ -279,81 +893,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Lejátszási lista másolatának elkészítése"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Nincs elérhető művelet"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Nincs engedélye, hogy törölje a kiválasztott elemeket."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Másolás %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Névtelen Adásfolyam"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Adásfolyam mentve."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Érvénytelen érték forma."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Kérjük, győződjön meg arról, hogy az admin felhasználónév/jelszó helyes-e a Rendszer-> Adásfolyamok oldalon."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Felhasználó sikeresen hozzáadva!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audió Lejátszó"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Felhasználó sikeresen módosítva!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Beállítások sikeresen módosítva!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Felvétel:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Mester Adás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Élő Adás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nincs semmi ütemezve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Jelenlegi Műsor:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Jelenleg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Ön a legújabb verziót futtatja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Új verzió érhető el:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Ez a verzió hamarosan elavul."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Ez a verzió már nem támogatott."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Kérjük, frissítsen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Hozzáadás a jelenlegi lejátszási listához"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Hozzáadás a jelenlegi okos táblához"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "1 Elem Hozzáadása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "%s Elem Hozzáadása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Csak dalszámokat adhat hozzá az okos táblákhoz."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Csak dalszámokat, okos táblákat és adásfolyamokat adhatunk a lejátszási listákhoz."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Kérjük, válasszon kurzor pozíciót az idővonalon."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Metaadatok Szerkesztése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Adja hozzá a kiválasztott műsort"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Kijelölés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Jelölje ki ezt az oldalt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Az oldal kijelölésének megszüntetése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Minden kijelölés törlése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Biztos benne, hogy törli a kijelölt eleme(ke)t?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Ütemezett"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr "Zeneszámok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Cím"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Előadó/Szerző"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bitráta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Zeneszerző"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Karmester"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Szerzői jog"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Kódolva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Műfaj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Címke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Nyelv"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Utoljára Módosítva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Utoljára Játszott"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Hossz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mimika"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Hangulat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Tulajdonos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Mintavétel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Dalsorszám"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Feltöltve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Honlap"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Év"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Betöltés..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Összes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Fájlok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Lejátszási listák"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Okos Táblák"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Adásfolyamok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Ismeretlen típus:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Biztos benne, hogy törli a kijelölt elemet?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Feltöltés folyamatban..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Adatok lekérdezése a kiszolgálóról..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "A soundcloud azonosító erre a fájlra:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "A soundcloud-ra feltöltés közben hiba jelentkezett."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Hibakód:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Hibaüzenet:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "A bemenetnek pozitív számnak kell lennie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "A bemenetnek számnak kell lennie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "A bemenet formája lehet: éééé-hh-nn"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "A bemenet formája lehet: óó:pp:mm.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Ön jelenleg fájlokat tölt fel. %sHa másik ablakot nyit meg, akkor a feltöltési folyamat megszakad. %sBiztos benne, hogy elhagyja az oldalt?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Média Építő Megnyitása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "kérjük, tegye időbe '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "A böngészője nem támogatja az ilyen típusú fájlok lejátszását:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "A dinamikus tábla nem érhető el előnézetben"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Korlátozva:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Lejátszási lista mentve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Lejátszási lista megkeverve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Az Airtime bizonytalan a fájl állapotával kapcsolatban. Lehetséges, hogy a tárhely már nem elérhető, vagy a 'figyelt' mappa útvonala megváltozott."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Hallgatók Száma %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Emlékeztessen 1 hét múlva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Soha ne emlékeztessen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Igen, segítek az Airtime-nak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "A képek lehetnek: jpg, jpeg, png, vagy gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "A statikus okos tábla elmenti a kritériumokat és azonnal létre is hozza a tábla tartalmát is. Ez lehetővé teszi, hogy módosítsuk és lássuk a könyvtár tartalmát még a műsor közvetítése előtt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "A dinamikus okos tábla csak elmenti a kritériumokat. A táblát szerkesztés után lehet hozzáadni a műsorhoz. Később a tartalmát sem megtekinteni, sem módosítani nem lehet."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "A kívánt táblahosszúság nem elérhető, mert az Airtime nem talál elég egyedi dalszámot, ami megfelelne a kritériumoknak. Engedélyezze ezt az opciót, ha azt szeretné, hogy egyes dalszámok ismétlődjenek."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Okos tábla megkeverve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Okos tábla létrehozva és kritériumok mentve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Okos tábla elmentve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Feldolgozás..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Módosítás választása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "tartalmaz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "nem tartalmaz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "az"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "nem az"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "vele kezdődik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "vele végződik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "több, mint"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "kevesebb, mint"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "közötti tartományban"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Válasszon Tároló Mappát"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Válasszon Figyelt Mappát"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Biztos benne, hogy meg akarja változtatni a tároló mappát?\n"
+"Ezzel eltávolítja a fájlokat az Airtime médiatárából!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Média Mappák Kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Biztos benne, hogy el akarja távolítani a figyelt mappát?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Ez az útvonal jelenleg nem elérhető."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Egyes patak típusokhoz extra beállítások szükségesek. További részletek: a %sAAC+ Támogatással%s vagy a %sOpus Támogatással%s kapcsolatban."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Csatlakozva az adás kiszolgálóhoz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Az adásfolyam ki van kapcsolva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Információk lekérdezése a kiszolgálóról..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Nem lehet kapcsolódni az adásfolyam kiszolgálójához"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Ha az Airtime mögött van egy router vagy egy tűzfal, akkor be kell állítani a továbbító porot, mert ezen a területen az információ helytelen lesz. Ebben az esetben manuálisan kell frissíteni ezen a területen, hogy mutassa a hosztot / portot / csatolási pontot, amelyre a DJ-k csatlakozhatnak. A megengedett tartomány 1024 és 49151 között van."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "A további részletekért, kérjük, olvassa el az %sAirtime Kézikönyvét%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Jelölje be és ellenőrizze ezt az opciót: metaadatok engedélyezése OGG-os adásfolyamra (adatfolyam metaadatok: dalcím, előadó, műsornév, amely megjelenik egy audió lejátszóban). A VLC és mplayer lejátszóknál súlyos hibák előfordulhatnak, OGG/Vorbis adatfolyam játszásakor, amelynél a metaadatok küldése engedélyezett: ilyenkor akadozik az adatfolyam. Ha az OGG-os adatfolyam és a hallgatói nem igényelnek támogatást az ilyen jellegű audió lejátszókhoz, akkor nyugodtan engedélyezze ezt az opciót."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Jelölje be ezt a négyzetet, hogy automatikusan kikapcsol a Mester/Műsor a forrás megszakítása után."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Jelölje be ezt a négyzetet, hogy automatikusan bekapcsol a Mester/Műsor a forrás csatlakozását követően."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Lehet, hogy az Ön Icecast kiszolgálója nem igényli a 'forrás' felhasználónevét, ez a mező üresen maradhat."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Ha az Ön élő adásfolyam kliense nem igényel felhasználónevet, akkor meg kell adnia a 'forrást'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Ez az admin felhasználónév és jelszó az Icecast/SHOUTcast hallgató statisztikához szükségesek."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Figyelmeztetés: Nem lehet megváltoztatni a mező tartalmát, míg a jelenlegi műsor tart"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nem volt találat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Ezt követi ugyanolyan biztonsági műsor-minta: csak a hozzárendelt felhasználók csatlakozhatnak a műsorhoz."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Adjon meg egy egyéni hitelesítést, amely csak ennél a műsornál működik."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "A műsor ez esetben nem létezik többé!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Figyelem: a Műsorokat nem lehet újra-linkelni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Az ismétlődő műsorok összekötésével, minden ütemezett médiai elem, az összes ismétlődő műsorban, ugyanazt a sorrendet kapja, mint a többi ismétlődő műsorban"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Az időzóna az Állomási Időzóna szerint van alapértelmezetten beállítva. A naptárban megjelenő helyi időt a Felületi Időzóna menüpontban módosíthatja, a felhasználói beállításoknál."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Műsor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "A műsor üres"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60p"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Az adatok lekérdezése a szolgálóról..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Ez a műsor nem tartalmaz ütemezett tartalmat."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Ez a műsor nincs teljesen kitöltve tartalommal."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Január"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Február"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Március"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Április"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Május"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Június"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Július"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Augusztus"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Szeptember"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Október"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "November"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "December"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Már"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Ápr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jún"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Júl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sze"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Okt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr "Ma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr "Nap"
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr "Hét"
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr "Hónap"
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Vasárnap"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Hétfő"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Kedd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Szerda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Csütörtök"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Péntek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Szombat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Va"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Hé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Ke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Sz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Cs"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Pé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Ha egy műsor hosszabb az ütemezett időnél, meg lesz vágva és követi azt a következő műsor."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "A Jelenlegi Műsor Megszakítása?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "A jelenlegi műsor rögzítésének félbeszakítása?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "A Műsor Tartalmai"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Az összes tartalom eltávolítása?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Törli a kiválasztott elem(ek)et?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Kezdése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Vége"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Időtartam"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Felkeverés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Lekeverés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Felúsztatás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Leúsztatás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Üres Műsor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Rögzítés a Hangbemenetről"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Belehallgatás a számba"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Nem lehet ütemezni a műsoron kívül."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "1 Elem Áthelyezése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "%s Elemek Áthelyezése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Mentés"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Mégse"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Úsztatási Szerkesztő"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Keverési Szerkesztő"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Hullámalak funkciók állnak rendelkezésre a böngészőben, támogatja a Web Audio API-t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Az összes kijelölése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Egyet sem jelöl ki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "A kijelölt ütemezett elemek eltávolítása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Ugrás a jelenleg hallható számra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "A jelenlegi műsor megszakítása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "A médiatár megnyitása az elemek hozzáadásához vagy eltávolításához"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Elemek Hozzáadása / Eltávolítása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "használatban van"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Lemez"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Nézze meg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Megnyitás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programkezelő"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Vendég"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "A vendégek a kővetkezőket tehetik:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Az ütemezés megtekintése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "A műsor tartalmának megtekintése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "A DJ-k a következőket tehetik:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Minden kijelölt műsor tartalom kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Médiafájlok hozzáadása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Lejátszási listák, okos táblák és adatfolyamok létrehozása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Saját médiatár tartalmának kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "A Program Vezetők a következőket tehetik:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Minden tartalom megtekintése és kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "A műsorok ütemzései"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "A teljes médiatár tartalmának kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Az Adminok a következőket tehetik:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Beállítások kezelései"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "A felhasználók kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "A figyelt mappák kezelése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Támogatási Visszajelzés Küldése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "A rendszer állapot megtekitnése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Hozzáférés lejátszási előzményekhez"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "A hallgatói statisztikák megtekintése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Az oszlopok megjelenítése/elrejtése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "{from} -tól/-től {to} -ig"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "éééé-hh-nn"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "óó:pp:mm.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Va"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Hé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Ke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Sze"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Cs"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Pé"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Szo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Bezárás"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Óra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Perc"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Kész"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Fájlok kiválasztása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Adja meg a fájlokat feltöltési sorrendben, majd kattintson a \"Feltöltés indítása\" gombra."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Fájlok Hozzáadása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Feltöltés Megszakítása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Feltöltés indítása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Fájlok hozzáadása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Feltöltve %d/%d fájl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Húzza a fájlokat ide."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Fájlkiterjesztési hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Fájlméreti hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Fájl számi hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Biztonsági hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Általános hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO hiba."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Fájl: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d várakozó fájl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Fájl: %f,méret: %s, max fájl méret: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "URL feltöltése esetén, felléphet hiba, esetleg nem létezik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Hiba: A fájl túl nagy:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Hiba: Érvénytelen fájl kiterjesztés:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Alapértelmezett"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Napló Létrehozása"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Előzmények Szerkesztése"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Nincs Műsor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s sor%s van másolva a vágólapra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sNyomtatási előnézet%sKérjük, használja böngészője nyomtatási beállításait. Nyomja meg az Esc-t ha végzett."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr "Új Műsor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr "Kérjük, adja meg felhasználónevét és jelszavát."
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Az e-mailt nem lehetett elküldeni. Ellenőrizze a levelező kiszolgáló beállításait."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Hibás felhasználónév vagy jelszó. Kérjük, próbálja meg újra."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -373,11 +2408,6 @@ msgstr "Nincs engedélye, hogy törölje a kiválasztott %s."
 msgid "You can only add tracks to smart block."
 msgstr "Csak dalszámokat lehet hozzáadni okos táblához."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Csak dalszámokat, okos táblákat és adásfolyamokat adhatunk a lejátszási listákhoz."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Névtelen Lejátszási Lista"
@@ -386,2627 +2416,88 @@ msgstr "Névtelen Lejátszási Lista"
 msgid "Untitled Smart Block"
 msgstr "Névtelen Okos Tábla"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Ismeretlen Lejátszási Lista"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Az Ön számára nem érhető el az alábbi erőforrás."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Beállítások frissítve."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Támogatási beállítások frissítve."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Támogatási Visszajelzés"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Adásfolyam Beállítások Frissítve."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "az útvonalat meg kell határozni"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Probléma lépett fel a Liquidsoap-al..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Nincs jogosúltsága a forrás bontásához."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Nem csatlakozik forrás az alábbi bemenethez."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Nincs jogosúltsága a forrás megváltoztatásához."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr "Kérjük, adja meg felhasználónevét és jelszavát."
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Hibás felhasználónév vagy jelszó. Kérjük, próbálja meg újra."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Az e-mailt nem lehetett elküldeni. Ellenőrizze a levelező kiszolgáló beállításait."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Az Ön számára nem érhető el az alábbi erőforrás."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr "A fájl nem elérhető itt: %s"
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Helytelen kérés. nincs 'mód' paraméter lett átadva."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Helytelen kérés. 'mód' paraméter érvénytelen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audió Lejátszó"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Felvétel:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Mester Adás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Élő Adás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nincs semmi ütemezve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Jelenlegi Műsor:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Jelenleg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Ön a legújabb verziót futtatja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Új verzió érhető el:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Ez a verzió hamarosan elavul."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Ez a verzió már nem támogatott."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Kérjük, frissítsen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Hozzáadás a jelenlegi lejátszási listához"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Hozzáadás a jelenlegi okos táblához"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "1 Elem Hozzáadása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "%s Elem Hozzáadása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Csak dalszámokat adhat hozzá az okos táblákhoz."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Kérjük, válasszon kurzor pozíciót az idővonalon."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Adja hozzá a kiválasztott műsort"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Kijelölés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Jelölje ki ezt az oldalt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Az oldal kijelölésének megszüntetése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Minden kijelölés törlése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Biztos benne, hogy törli a kijelölt eleme(ke)t?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Ütemezett"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr "Zeneszámok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bitráta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Kódolva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Utoljára Módosítva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Utoljára Játszott"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mimika"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Tulajdonos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Mintavétel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Dalsorszám"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Feltöltve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Honlap"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Betöltés..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Összes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Fájlok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Lejátszási listák"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Okos Táblák"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Adásfolyamok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Ismeretlen típus:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Biztos benne, hogy törli a kijelölt elemet?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Feltöltés folyamatban..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Adatok lekérdezése a kiszolgálóról..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "A soundcloud azonosító erre a fájlra:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "A soundcloud-ra feltöltés közben hiba jelentkezett."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Hibakód:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Hibaüzenet:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "A bemenetnek pozitív számnak kell lennie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "A bemenetnek számnak kell lennie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "A bemenet formája lehet: éééé-hh-nn"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "A bemenet formája lehet: óó:pp:mm.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Ön jelenleg fájlokat tölt fel. %sHa másik ablakot nyit meg, akkor a feltöltési folyamat megszakad. %sBiztos benne, hogy elhagyja az oldalt?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Média Építő Megnyitása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "kérjük, tegye időbe '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "kérjük, tegye másodpercekbe '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "A böngészője nem támogatja az ilyen típusú fájlok lejátszását:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "A dinamikus tábla nem érhető el előnézetben"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Korlátozva:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Lejátszási lista mentve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Lejátszási lista megkeverve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Az Airtime bizonytalan a fájl állapotával kapcsolatban. Lehetséges, hogy a tárhely már nem elérhető, vagy a 'figyelt' mappa útvonala megváltozott."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Hallgatók Száma %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Emlékeztessen 1 hét múlva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Soha ne emlékeztessen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Igen, segítek az Airtime-nak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "A képek lehetnek: jpg, jpeg, png, vagy gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "A statikus okos tábla elmenti a kritériumokat és azonnal létre is hozza a tábla tartalmát is. Ez lehetővé teszi, hogy módosítsuk és lássuk a könyvtár tartalmát még a műsor közvetítése előtt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "A dinamikus okos tábla csak elmenti a kritériumokat. A táblát szerkesztés után lehet hozzáadni a műsorhoz. Később a tartalmát sem megtekinteni, sem módosítani nem lehet."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "A kívánt táblahosszúság nem elérhető, mert az Airtime nem talál elég egyedi dalszámot, ami megfelelne a kritériumoknak. Engedélyezze ezt az opciót, ha azt szeretné, hogy egyes dalszámok ismétlődjenek."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Okos tábla megkeverve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Okos tábla létrehozva és kritériumok mentve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Okos tábla elmentve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Feldolgozás..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Módosítás választása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "tartalmaz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "nem tartalmaz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "az"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "nem az"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "vele kezdődik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "vele végződik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "több, mint"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "kevesebb, mint"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "közötti tartományban"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Válasszon Tároló Mappát"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Válasszon Figyelt Mappát"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Biztos benne, hogy meg akarja változtatni a tároló mappát?\nEzzel eltávolítja a fájlokat az Airtime médiatárából!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Média Mappák Kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Biztos benne, hogy el akarja távolítani a figyelt mappát?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Ez az útvonal jelenleg nem elérhető."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Egyes patak típusokhoz extra beállítások szükségesek. További részletek: a %sAAC+ Támogatással%s vagy a %sOpus Támogatással%s kapcsolatban."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Csatlakozva az adás kiszolgálóhoz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Az adásfolyam ki van kapcsolva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Információk lekérdezése a kiszolgálóról..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Nem lehet kapcsolódni az adásfolyam kiszolgálójához"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Ha az Airtime mögött van egy router vagy egy tűzfal, akkor be kell állítani a továbbító porot, mert ezen a területen az információ helytelen lesz. Ebben az esetben manuálisan kell frissíteni ezen a területen, hogy mutassa a hosztot / portot / csatolási pontot, amelyre a DJ-k csatlakozhatnak. A megengedett tartomány 1024 és 49151 között van."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "A további részletekért, kérjük, olvassa el az %sAirtime Kézikönyvét%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Jelölje be és ellenőrizze ezt az opciót: metaadatok engedélyezése OGG-os adásfolyamra (adatfolyam metaadatok: dalcím, előadó, műsornév, amely megjelenik egy audió lejátszóban). A VLC és mplayer lejátszóknál súlyos hibák előfordulhatnak, OGG/Vorbis adatfolyam játszásakor, amelynél a metaadatok küldése engedélyezett: ilyenkor akadozik az adatfolyam. Ha az OGG-os adatfolyam és a hallgatói nem igényelnek támogatást az ilyen jellegű audió lejátszókhoz, akkor nyugodtan engedélyezze ezt az opciót."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Jelölje be ezt a négyzetet, hogy automatikusan kikapcsol a Mester/Műsor a forrás megszakítása után."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Jelölje be ezt a négyzetet, hogy automatikusan bekapcsol a Mester/Műsor a forrás csatlakozását követően."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Lehet, hogy az Ön Icecast kiszolgálója nem igényli a 'forrás' felhasználónevét, ez a mező üresen maradhat."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Ha az Ön élő adásfolyam kliense nem igényel felhasználónevet, akkor meg kell adnia a 'forrást'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Ez az admin felhasználónév és jelszó az Icecast/SHOUTcast hallgató statisztikához szükségesek."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Figyelmeztetés: Nem lehet megváltoztatni a mező tartalmát, míg a jelenlegi műsor tart"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nem volt találat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Ezt követi ugyanolyan biztonsági műsor-minta: csak a hozzárendelt felhasználók csatlakozhatnak a műsorhoz."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Adjon meg egy egyéni hitelesítést, amely csak ennél a műsornál működik."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "A műsor ez esetben nem létezik többé!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Figyelem: a Műsorokat nem lehet újra-linkelni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Az ismétlődő műsorok összekötésével, minden ütemezett médiai elem, az összes ismétlődő műsorban, ugyanazt a sorrendet kapja, mint a többi ismétlődő műsorban"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Az időzóna az Állomási Időzóna szerint van alapértelmezetten beállítva. A naptárban megjelenő helyi időt a Felületi Időzóna menüpontban módosíthatja, a felhasználói beállításoknál."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Műsor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "A műsor üres"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60p"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Az adatok lekérdezése a szolgálóról..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Ez a műsor nem tartalmaz ütemezett tartalmat."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Ez a műsor nincs teljesen kitöltve tartalommal."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Január"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Február"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Március"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Április"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Május"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Június"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Július"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Augusztus"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Szeptember"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Október"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "November"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "December"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Már"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Ápr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jún"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Júl"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sze"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Okt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr "Ma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr "Nap"
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr "Hét"
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr "Hónap"
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Vasárnap"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Hétfő"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Kedd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Szerda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Csütörtök"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Péntek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Szombat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Va"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Hé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Ke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Sz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Cs"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Pé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Ha egy műsor hosszabb az ütemezett időnél, meg lesz vágva és követi azt a következő műsor."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "A Jelenlegi Műsor Megszakítása?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "A jelenlegi műsor rögzítésének félbeszakítása?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "A Műsor Tartalmai"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Az összes tartalom eltávolítása?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Törli a kiválasztott elem(ek)et?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Kezdése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Vége"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Időtartam"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Felkeverés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Lekeverés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Felúsztatás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Leúsztatás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Üres Műsor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Rögzítés a Hangbemenetről"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Belehallgatás a számba"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Nem lehet ütemezni a műsoron kívül."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "1 Elem Áthelyezése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "%s Elemek Áthelyezése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Mentés"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Mégse"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Úsztatási Szerkesztő"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Keverési Szerkesztő"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Hullámalak funkciók állnak rendelkezésre a böngészőben, támogatja a Web Audio API-t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Az összes kijelölése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Egyet sem jelöl ki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "A kijelölt ütemezett elemek eltávolítása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Ugrás a jelenleg hallható számra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "A jelenlegi műsor megszakítása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "A médiatár megnyitása az elemek hozzáadásához vagy eltávolításához"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Elemek Hozzáadása / Eltávolítása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "használatban van"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Lemez"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Nézze meg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Megnyitás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programkezelő"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Vendég"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "A vendégek a kővetkezőket tehetik:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Az ütemezés megtekintése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "A műsor tartalmának megtekintése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "A DJ-k a következőket tehetik:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Minden kijelölt műsor tartalom kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Médiafájlok hozzáadása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Lejátszási listák, okos táblák és adatfolyamok létrehozása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Saját médiatár tartalmának kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "A Program Vezetők a következőket tehetik:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Minden tartalom megtekintése és kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "A műsorok ütemzései"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "A teljes médiatár tartalmának kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Az Adminok a következőket tehetik:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Beállítások kezelései"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "A felhasználók kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "A figyelt mappák kezelése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Támogatási Visszajelzés Küldése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "A rendszer állapot megtekitnése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Hozzáférés lejátszási előzményekhez"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "A hallgatói statisztikák megtekintése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Az oszlopok megjelenítése/elrejtése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "{from} -tól/-től {to} -ig"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "éééé-hh-nn"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "óó:pp:mm.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Va"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Hé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Ke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Sze"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Cs"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Pé"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Szo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Bezárás"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Óra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Perc"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Kész"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Fájlok kiválasztása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Adja meg a fájlokat feltöltési sorrendben, majd kattintson a \"Feltöltés indítása\" gombra."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Állapot"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Fájlok Hozzáadása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Feltöltés Megszakítása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Feltöltés indítása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Fájlok hozzáadása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Feltöltve %d/%d fájl"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Húzza a fájlokat ide."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Fájlkiterjesztési hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Fájlméreti hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Fájl számi hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Biztonsági hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Általános hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO hiba."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Fájl: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d várakozó fájl"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Fájl: %f,méret: %s, max fájl méret: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "URL feltöltése esetén, felléphet hiba, esetleg nem létezik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Hiba: A fájl túl nagy:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Hiba: Érvénytelen fájl kiterjesztés:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Alapértelmezett"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Napló Létrehozása"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Előzmények Szerkesztése"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Nincs Műsor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s sor%s van másolva a vágólapra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sNyomtatási előnézet%sKérjük, használja böngészője nyomtatási beállításait. Nyomja meg az Esc-t ha végzett."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr "Új Műsor"
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Kurzor kiválasztása"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Kurzor eltávolítása"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "a műsor nem található"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "A műsor újraközvetítése %s -tól/-től %s a %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Kurzor kiválasztása"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Kurzor eltávolítása"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "a műsor nem található"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Felhasználó sikeresen hozzáadva!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Felhasználó sikeresen módosítva!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Beállítások sikeresen módosítva!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Névtelen Adásfolyam"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Adásfolyam mentve."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Érvénytelen érték forma."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Az évnek %s 1753 - 9999 közötti tartományban kell lennie"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s érvénytelen dátum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s érvénytelen időpont"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Élő adásfolyam"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr "Okos Tábla"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr "Adásfolyam"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr "Feltöltés"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr "Adásfolyamok"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Lejátszás"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Leállítás"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Felkeverés Beállítása"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Lekeverés Beállítása"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Kurzor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Megosztás"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Adásfolyam:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "elnémítás"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "elnémítás megszüntetése"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Rólunk"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr "%1$s %2$s, a nyitott rádiós szoftver, az ütemezett és távoli állomás menedzsment."
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr "%1$s %2$s-ot %3$s mellett terjesztik"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr "Üdvözöljük az %s-nál!"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr "Itt van, hogyan tudod elindítani adásaid automatizálását használva az %s-t:"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "További segítségért, olvassa el a %shasználati útmutatót%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr "Lejátszó"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Lejátszási Előzmények"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Napló"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Fájl Összegző"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Műsor Összegző"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Statikus Tábla Kibővítése"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Dinamikus Tábla Kibővítése"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Név:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Leírás:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Időtartam:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Véletlenszerű lejátszási lista"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Véletlenszerű"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Lejátszási lista átúsztatása"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Üres lejátszási lista tartalom"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Törlés"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Felúsztatás:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Leúsztatás:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Lejátszási lista mentése"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Nincs megnyitott lejátszási lista"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Mutasd a Hullámalakot"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(mm.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Felkeverés:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(óó:pp:mm.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Lekeverés:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Eredeti Hossz:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Adásfolyam/Patak Beállítások"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Bejelentkezés"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr "Üdvözöljük az %s demó változatában! Jelentkezzen be 'admin' felhasználónévvel és 'admin' jelszóval."
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr "Vissza"
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Új jelszó"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Kérjük, adja meg és erősítse meg az új jelszavát az alábbi mezőkben."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "A Felhasználók Kezelése"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Új Felhasználó"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Felhasználónév"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Vezetéknév"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Keresztnév"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Felhasználói Típus"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Műsorok Keresése"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Adjon hozzá több elemet"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Találat"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr "Profilom"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Ismétlések Napjai:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Eltávolítás"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Hozzáadás"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Műsor Forrás"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime Regisztráció"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr "Jelöld be a mezőt az állomásod közzétételéhez a %s-on."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Kötelező)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(csupán ellenőrzés céljából, nem kerül közzétételre)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Megjegyzés: Bármi, ami kisebb nagyobb, mint 600x600, átméretezésre kerül."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Mutasd meg, hogy mit küldök"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Felhasználási Feltételek"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Válasszon Napot:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "vagy"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "és"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "-ig"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "fájl megfelel a kritériumoknak"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Előzmények Szűrése"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr "Elfelejtett jelszó?"
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Annak érdekében, hogy hírdetni tudja az állomását, a 'Támogatási Visszajelzés Küldését' engedélyeznie kell.)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Adásfolyam"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "További Lehetőségek"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "A következő információk megjelennek a hallgatók számára, a saját média lejátszóikban:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(A rádióállomás honlapja)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Adásfolyam URL:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Válasszon mappát"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Beállítás"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Jelenlegi Tároló Mappa:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr "A figyelt mappa újraellenőrzése (Ez akkor hasznos, ha a hálózati csatolás nincs szinkronban az %s-al)"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "A figyelt mappa eltávolítása"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Ön nem figyel minden média mappát."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr "Élő Közvetítés"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Mester Forrás"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Beállítások"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Adja hozzá ezt a műsort"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "A műsor frissítése"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Mi"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Mikor"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Élő Adásfolyam Bemenet"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Kicsoda"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stílus"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Lemezterület"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Fájl importálása folyamatban..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Speciális Keresési Beállítások"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Cím:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Előadó/Szerző:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Dalszám:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Hossz:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Mintavételi Ráta:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bitráta:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Hangulat:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Műfaj:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Év:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Kiadó:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Zeneszerző:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Vezénylő:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Szerzői jog:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Szám:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Honlap:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Nyelv:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Fájl Elérési Útvonal:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Adásfolyam"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dinamikus Okos Tábla"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statikus Okos Tábla"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audió Sáv"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Lejátszási Lista Tartalmak:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statikus Okos Tábla Tartalmak:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dinamikus Okos Tábla Kritériumok:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Korlátozva"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr "Hallgatók"
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Az Ön próba ideje lejár"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "napok"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Előző:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Következő:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Az Adásfolyam Forrásai"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ADÁSBAN"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Hallgat"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Kijelentkezés"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Naplózási Sablonok"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Új Naplózási Sablon"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Nincsenek Naplózási Sablonok"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Összegzési Sablon Fájlok"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Új Összegzési Sablon Fájl"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Nincsenek Összegzési Sablon Fájlok"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Összegzési Sablon Fájl Létrehozása"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Naplózási Sablon Létrehozása"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Név"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Adjon hozzá több elemet"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Új Mező Hozzáadása"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Alapértelmezett Sablon"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Leírás"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Adásfolyam URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Alapértelmezett Hossz:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Nincs adásfolyam"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Segítség"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr "Hoppá!"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Az oldal nem található!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Úgy néz ki, az oldal, amit keresett nem létezik!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "előző"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "lejátszás"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "szünet"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "következő"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "leállítás"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "max hangerő"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Frissítés Szükséges"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "A lejátszáshoz média szükséges, és frissítenie kell a böngészőjét egy újabb verzióra, vagy frissítse a %sFlash bővítményt%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Kezdés Ideje:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3016,127 +2507,6 @@ msgstr "Kezdés Ideje:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Érvénytelen bevitt karakterek"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Végzés Ideje:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Összes Műsorom:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Felhasználók Keresése:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJ-k:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Állomás Név"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Az Állomás Honlapja:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Ország:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Város:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Állomás Leírás: (lehetőség szerint angolul)"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Állomás Logó:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Az állomásom közzététele a %s-on"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "A mező bejelölésével, elfogadom a %s %sadatvédelmi irányelveit%s."
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "El kell fogadnia az adatvédelmi irányelveket."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Felvétel a vonalbemenetről?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Újraközvetítés?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Adjon meg egy értéket, nem lehet üres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' érvénytelen formátum (név@hosztnév)"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' nem illeszkedik a dátum formához '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' rövidebb, mint %min% karakter"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'% value%' több mint, a %max% karakter"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' nem szerepel '%min%' és '%max%', értékek között"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "A jelszavak nem egyeznek meg"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3153,675 +2523,55 @@ msgstr "Az időt meg kell határoznia"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Az újraközvetítésre legalább 1 órát kell várni"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
-msgstr "E-mail"
-
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "A jelszó visszaállítása"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Névtelen Műsor"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Szám:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Alapértelmezett Áttünési Időtartam (mp):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Alapértelmezett Felúsztatás (mp)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Alapértelmezett Leúsztatás (mp)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Letiltva"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Engedélyezve"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Állomási Időzóna:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "A Hét Indul"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Felhasználónév:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Jelszó:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Jelszó Ellenőrzés:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Vezetéknév:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Keresztnév:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobiltelefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Felhasználói Típus:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "A login név nem egyedi."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Tároló Mappa:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Figyelt Mappák:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Érvénytelen Könyvtár"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Alapértelmezett Liszensz:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Minden jog fenntartva"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "A munka a nyilvános felületen folyik"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Nem Kereskedelmi Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Nem Feldolgozható Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Eredményeket Megosztó Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Nem Kereskedelmi Nem Feldolgozható Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Nem Kereskedelmi Megosztó Tulajdonjog"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Felületi Időzóna:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Most Játszott"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr "Adásfolyam Kiválasztása:"
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr "Egy adásfolyam kiválasztása:"
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "A feltételek megadása"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bitráta (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Mintavételi Ráta (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "órák"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "percek"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "elemek"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr "Véletlenszerűen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr "Újabb"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr "Régebbi"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr "Típus:"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statikus"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinamikus"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Lejátszási lista tartalom létrehozása és kritériumok mentése"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Létrehozás"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Véletlenszerű lejátszási lista tartalom"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "A határérték nem lehet üres vagy kisebb, mint 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "A határérték nem lehet hosszabb, mint 24 óra"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Az érték csak egész szám lehet"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Maximum 500 elem állítható be"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Ki kell választania a Kritériumot és a Módosítót"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Hosszúság' '00:00:00' formában lehet"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Az értéknek az alábbi időbélyeg formátumban kell lennie (pl. 0000-00-00 vagy 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Az értéknek numerikusnak kell lennie"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Az érték lehet kevesebb, mint 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Az értéknek rövidebb kell lennie, mint %s karakter"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Az érték nem lehet üres"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metaadatok"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Adás Címke:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Előadó - Cím"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Műsor - Előadó - Cím"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Állomásnév - Műsornév"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Adáson Kívüli - Metaadat"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Replay Gain Engedélyezése"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Módosító"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Jelszó"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Új jelszó megerősítése"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "A megadott jelszavak nem egyeznek meg."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Engedélyezett:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Adatfolyam Típus:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Kiszolgálói Típus:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Csatornák:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Monó"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Sztereó"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Szerver"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Csak számok adhatók meg."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Csatolási Pont"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin Felhasználó"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Admin Jelszó"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "A szerver nem lehet üres."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "A port nem lehet üres."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "A csatolási pont nem lehet üres Icecast szerver esetében."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' az időformátum nem illeszkedik 'ÓÓ:pp'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Időzóna:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Ismétlések?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Műsort nem lehet a múltban létrehozni"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Nem lehet módosítani a műsor kezdési időpontját, ha a műsor már elindult"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "A befejezési dátum/idő nem lehet a múltban"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Nem lehet <0p időtartam"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Nem lehet 00ó 00p időtartam"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Nem tarthat tovább, mint 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "%s Hitelesítés Használata:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Egyéni Hitelesítés Használata:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Egyéni Felhasználónév"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Egyéni Jelszó"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "A felhasználónév nem lehet üres."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "A jelszó nem lehet üres."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Háttérszín:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Szövegszín:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr "Jelenlegi Logó:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Gépelje be a képen látható karaktereket."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "napok"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3867,6 +2617,12 @@ msgstr "a hónap napja"
 msgid "day of the week"
 msgstr "a hét napja"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Végzés Ideje:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Nincs Vége?"
@@ -3879,115 +2635,1174 @@ msgstr "A befejezési idő után kell, hogy legyen kezdési idő is."
 msgid "Please select a repeat day"
 msgstr "Kérjük, válasszon egy ismétlési napot"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Felvétel a vonalbemenetről?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Újraközvetítés?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Háttérszín:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Szövegszín:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
+msgstr "Jelenlegi Logó:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Naptár"
-
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Név:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Névtelen Műsor"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Műfaj:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Leírás:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Felhasználók"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' az időformátum nem illeszkedik 'ÓÓ:pp'"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Adásfolyamok"
-
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Hallgatói Statisztikák"
-
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Naplózási Sablonok"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Időtartam:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Időzóna:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Ismétlések?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Műsort nem lehet a múltban létrehozni"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Nem lehet módosítani a műsor kezdési időpontját, ha a műsor már elindult"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "A befejezési dátum/idő nem lehet a múltban"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Nem lehet <0p időtartam"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Nem lehet 00ó 00p időtartam"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Nem tarthat tovább, mint 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Nem fedhetik egymást a műsorok"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Felhasználók Keresése:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJ-k:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Felhasználónév:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Jelszó:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Jelszó Ellenőrzés:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Vezetéknév:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Keresztnév:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobiltelefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Felhasználói Típus:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "A login név nem egyedi."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Első Lépések"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
-msgstr "GYIK"
-
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Felhasználói Kézikönyv"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Adjon meg egy értéket, nem lehet üres"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Kezdés Ideje:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Cím:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Előadó/Szerző:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Év:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Kiadó:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Zeneszerző:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Vezénylő:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Hangulat:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Szerzői jog:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Szám:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Honlap:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Nyelv:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Kezdési Idő"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Fejezési Idő"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Felületi Időzóna:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Állomás Név"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Állomás Logó:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Megjegyzés: Bármi, ami kisebb nagyobb, mint 600x600, átméretezésre kerül."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Alapértelmezett Áttünési Időtartam (mp):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Alapértelmezett Felúsztatás (mp)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Alapértelmezett Leúsztatás (mp)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Letiltva"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Engedélyezve"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Állomási Időzóna:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "A Hét Indul"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' érvénytelen formátum (név@hosztnév)"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' nem illeszkedik a dátum formához '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' rövidebb, mint %min% karakter"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'% value%' több mint, a %max% karakter"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' nem szerepel '%min%' és '%max%', értékek között"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "A jelszavak nem egyeznek meg"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Csak számok adhatók meg."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Bejelentkezés"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Gépelje be a képen látható karaktereket."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Jelszó"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Új jelszó megerősítése"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "A megadott jelszavak nem egyeznek meg."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr "E-mail"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Felhasználónév"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "A jelszó visszaállítása"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr "Vissza"
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Most Játszott"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr "Adásfolyam Kiválasztása:"
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr "Egy adásfolyam kiválasztása:"
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Az Állomás Honlapja:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Ország:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Város:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Állomás Leírás: (lehetőség szerint angolul)"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Az állomásom közzététele a %s-on"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "A mező bejelölésével, elfogadom a %s %sadatvédelmi irányelveit%s."
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "El kell fogadnia az adatvédelmi irányelveket."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Összes Műsorom:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "A feltételek megadása"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bitráta (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Leírás"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Mintavételi Ráta (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "órák"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "percek"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "elemek"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr "Véletlenszerűen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr "Újabb"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr "Régebbi"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr "Típus:"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statikus"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinamikus"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Lejátszási lista tartalom létrehozása és kritériumok mentése"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Létrehozás"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Véletlenszerű lejátszási lista tartalom"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Véletlenszerű"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "A határérték nem lehet üres vagy kisebb, mint 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "A határérték nem lehet hosszabb, mint 24 óra"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Az érték csak egész szám lehet"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Maximum 500 elem állítható be"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Ki kell választania a Kritériumot és a Módosítót"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Hosszúság' '00:00:00' formában lehet"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Az értéknek az alábbi időbélyeg formátumban kell lennie (pl. 0000-00-00 vagy 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Az értéknek numerikusnak kell lennie"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Az érték lehet kevesebb, mint 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Az értéknek rövidebb kell lennie, mint %s karakter"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Az érték nem lehet üres"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Alapértelmezett Liszensz:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Minden jog fenntartva"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "A munka a nyilvános felületen folyik"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Nem Kereskedelmi Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Nem Feldolgozható Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Eredményeket Megosztó Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Nem Kereskedelmi Nem Feldolgozható Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Nem Kereskedelmi Megosztó Tulajdonjog"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metaadatok"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Adás Címke:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Előadó - Cím"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Műsor - Előadó - Cím"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Állomásnév - Műsornév"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Adáson Kívüli - Metaadat"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Replay Gain Engedélyezése"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Módosító"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Engedélyezett:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Adatfolyam Típus:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bitráta:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Kiszolgálói Típus:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Csatornák:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Monó"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Sztereó"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Szerver"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Név"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Csatolási Pont"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin Felhasználó"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Admin Jelszó"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "A szerver nem lehet üres."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "A port nem lehet üres."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "A csatolási pont nem lehet üres Icecast szerver esetében."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Tároló Mappa:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Figyelt Mappák:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Érvénytelen Könyvtár"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr "Okos Tábla"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr "Adásfolyam"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr "Feltöltés"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Lejátszás"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Leállítás"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Felkeverés Beállítása"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Lekeverés Beállítása"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Kurzor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Élő adásfolyam"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr "%s Jelszó Visszaállítás"
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "A fel- és a lekeverés értékei nullák."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Nem lehet beállítani, mert a lekeverési idő nem lehet nagyobb a fájl hosszánál."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Nem lehet beállítani, hogy a felkeverés hosszabb legyen, mint a lekeverés."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Nem lehet a lekeverés rövidebb, mint a felkeverés."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Úrjaközvetítés %s -tól/-től %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Ország Kiválasztása"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4012,14 +3827,12 @@ msgstr "%s nem létező könyvtár."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s már be van állítva, mint a jelenlegi tároló elérési útvonala vagy a figyelt mappák listája"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s már be van állítva, mint jelenlegi tároló elérési útvonala vagy, a figyelt mappák listájában."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4027,28 +3840,18 @@ msgstr "%s már be van állítva, mint jelenlegi tároló elérési útvonala va
 msgid "%s doesn't exist in the watched list."
 msgstr "%s nem szerepel a figyeltek listáján."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr "%s Jelszó Visszaállítás"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Ország Kiválasztása"
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "A műsorok maximum 24 óra hosszúságúak lehetnek."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Az ütemzés nem fedheti át a műsorokat.\nMegjegyzés: Az ismételt műsorok átméretezése kavarodást okozhat."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4063,48 +3866,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "A megtekintett ütemterv elavult! (például eltérés)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "A megtekintett ütemterv időpontja elavult!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Nincs jogosultsága az ütemezett műsorhoz %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Nem adhat hozzá fájlokat a rögzített műsorokhoz."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "A műsor %s véget ért és nem lehet ütemezni."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "A műsor %s már korábban frissítve lett!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "A kapcsolódó műsorok tartalmait bármelyik adás előtt vagy után kell ütemezni"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr "Nem lehet ütemezni olyan lejátszási listát, amely tartalmaz hiányzó fájlokat."
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "A kiválasztott fájl nem létezik!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "A műsorok maximum 24 óra hosszúságúak lehetnek."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Az ütemzés nem fedheti át a műsorokat.\n"
+"Megjegyzés: Az ismételt műsorok átméretezése kavarodást okozhat."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Úrjaközvetítés %s -tól/-től %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4151,8 +3966,1049 @@ msgstr "Érvénytelen adásfolyam - Úgy néz ki, hogy ez egy fájl letöltés."
 msgid "Unrecognized stream type: %s"
 msgstr "Ismeretlen típusú adásfolyam: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Rögzített fájl nem létezik"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "A Rögzített Fájl Metaadatai"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Szerkeszt"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Műsor Szerkesztése"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Engedély megtagadva"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Nem lehet megismételni a fogd és vidd típusú műsorokat"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Az elhangzott műsort nem lehet áthelyezni"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "A műsort nem lehet a múltba áthelyezni"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "A rögzített műsort, 1 óránál korábban nem lehet újra közvetíteni."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "A műsor törlésre került, mert a rögzített műsor nem létezik!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Az adás újbóli közvetítésére 1 órát kell várni."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Dalszám"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Lejátszva"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "előző"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "lejátszás"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "szünet"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "következő"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "leállítás"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "elnémítás"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "elnémítás megszüntetése"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "max hangerő"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Frissítés Szükséges"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "A lejátszáshoz média szükséges, és frissítenie kell a böngészőjét egy újabb verzióra, vagy frissítse a %sFlash bővítményt%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Rólunk"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr "%1$s %2$s, a nyitott rádiós szoftver, az ütemezett és távoli állomás menedzsment."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr "%1$s %2$s-ot %3$s mellett terjesztik"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr "Üdvözöljük az %s-nál!"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr "Itt van, hogyan tudod elindítani adásaid automatizálását használva az %s-t:"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "További segítségért, olvassa el a %shasználati útmutatót%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Megosztás"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Adásfolyam:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Az oldal nem található!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr "Hoppá!"
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Úgy néz ki, az oldal, amit keresett nem létezik!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Műsor Forrás"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Válasszon Napot:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Hozzáadás"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Ismétlések Napjai:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Előzmények Szűrése"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Adjon hozzá több elemet"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Találat"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr "Elfelejtett jelszó?"
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Beállítások"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr "Élő Közvetítés"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Mester Forrás"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Válasszon mappát"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Beállítás"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Jelenlegi Tároló Mappa:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr "A figyelt mappa újraellenőrzése (Ez akkor hasznos, ha a hálózati csatolás nincs szinkronban az %s-al)"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "A figyelt mappa eltávolítása"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Ön nem figyel minden média mappát."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime Regisztráció"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr "Jelöld be a mezőt az állomásod közzétételéhez a %s-on."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Kötelező)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(csupán ellenőrzés céljából, nem kerül közzétételre)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Mutasd meg, hogy mit küldök"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Felhasználási Feltételek"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Műsorok Keresése"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "vagy"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "és"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "-ig"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "fájl megfelel a kritériumoknak"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Adásfolyam"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "További Lehetőségek"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "A következő információk megjelennek a hallgatók számára, a saját média lejátszóikban:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(A rádióállomás honlapja)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Adásfolyam URL:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Annak érdekében, hogy hírdetni tudja az állomását, a 'Támogatási Visszajelzés Küldését' engedélyeznie kell.)"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Dalszám:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Hossz:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Mintavételi Ráta:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Szám:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Fájl Elérési Útvonal:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Adásfolyam"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dinamikus Okos Tábla"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statikus Okos Tábla"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audió Sáv"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Lejátszási Lista Tartalmak:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statikus Okos Tábla Tartalmak:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dinamikus Okos Tábla Kritériumok:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Korlátozva"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Fájl importálása folyamatban..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Speciális Keresési Beállítások"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr "Hallgatók"
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr "Üdvözöljük az %s demó változatában! Jelentkezzen be 'admin' felhasználónévvel és 'admin' jelszóval."
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Új jelszó"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Kérjük, adja meg és erősítse meg az új jelszavát az alábbi mezőkben."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr "Adásfolyamok"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Előző:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Következő:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Az Adásfolyam Forrásai"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ADÁSBAN"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Hallgat"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Kijelentkezés"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Az Ön próba ideje lejár"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Véletlenszerű lejátszási lista"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Lejátszási lista átúsztatása"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Üres lejátszási lista tartalom"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Törlés"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Leúsztatás:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Lejátszási lista mentése"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Nincs megnyitott lejátszási lista"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Mutasd a Hullámalakot"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Felkeverés:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(óó:pp:mm.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Lekeverés:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Eredeti Hossz:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(mm.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Felúsztatás:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Statikus Tábla Kibővítése"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Dinamikus Tábla Kibővítése"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Napló"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Fájl Összegző"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Műsor Összegző"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Naplózási Sablonok"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Új Naplózási Sablon"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Nincsenek Naplózási Sablonok"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Összegzési Sablon Fájlok"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Új Összegzési Sablon Fájl"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Nincsenek Összegzési Sablon Fájlok"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Összegzési Sablon Fájl Létrehozása"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Naplózási Sablon Létrehozása"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Adjon hozzá több elemet"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Új Mező Hozzáadása"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Alapértelmezett Sablon"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Adásfolyam/Patak Beállítások"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Adja hozzá ezt a műsort"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "A műsor frissítése"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Mi"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Mikor"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Élő Adásfolyam Bemenet"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Kicsoda"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stílus"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Lemezterület"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "A Felhasználók Kezelése"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Új Felhasználó"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Vezetéknév"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Keresztnév"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Felhasználói Típus"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Adásfolyam URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Alapértelmezett Hossz:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Nincs adásfolyam"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "kérjük, tegye másodpercekbe '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "A kapcsolódó műsorok tartalmait bármelyik adás előtt vagy után kell ütemezni"

--- a/airtime_mvc/locale/hu_HU/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/hu_HU/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy/LC_MESSAGES/airtime.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2014-07-28 11:49+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Armenian (http://www.transifex.com/projects/p/airtime/language/hy/)\n"
@@ -13,6 +13,3947 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
+#: airtime_mvc/application/controllers/PlaylistController.php:147
+#, php-format
+msgid "%s not found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:37
+#: airtime_mvc/application/controllers/PlaylistController.php:168
+msgid "Something went wrong."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
+msgid "Preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
+msgid "Add to Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:114
+msgid "Add to Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
+msgid "Download"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:147
+msgid "View track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:148
+msgid "Update track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:155
+msgid "Duplicate Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:199
+msgid "No action available"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:219
+msgid "You don't have permission to delete selected items."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:265
+msgid "Could not delete file because it is scheduled in the future."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:268
+msgid "Could not delete file(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:308
+#, php-format
+msgid "Copy of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:53
+#, php-format
+msgid "You are viewing an older version of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:140
+msgid "You cannot add tracks to dynamic blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:161
+#, php-format
+msgid "You don't have permission to delete selected %s(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:174
+msgid "You can only add tracks to smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:192
+msgid "Untitled Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:194
+msgid "Untitled Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:521
+msgid "Unknown Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:76
+msgid "Preferences updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:141
+msgid "Support setting updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:149
+msgid "Support Feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:351
+msgid "Stream Setting Updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:399
+msgid "path should be specified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:494
+msgid "Problem with Liquidsoap..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:556
+msgid "Request method not accepted"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ScheduleController.php:380
+#, php-format
+msgid "Rebroadcast of show %s from %s at %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
+msgid "Invalid character entered"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
+msgid "Day must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
+msgid "Time must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
+msgid "Must wait at least 1 hour to rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
+#, php-format
+msgid "Use %s Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
+msgid "Use Custom Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
+msgid "Custom Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
+msgid "Custom Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
+msgid "Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
+msgid "Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
+msgid "Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
+msgid "Username field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
+msgid "Password field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:10
+msgid "Link:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:16
+msgid "Repeat Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:19
+msgid "weekly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:20
+msgid "every 2 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:21
+msgid "every 3 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:22
+msgid "every 4 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:23
+msgid "monthly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:32
+msgid "Select Days:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:47
+msgid "Repeat By:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the month"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the week"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:69
+msgid "No End?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:106
+msgid "End date must be after start date"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:113
+msgid "Please select a repeat day"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
+msgid "Cue in and cue out are null."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
+msgid "Can't set cue out to be greater than file length."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
+msgid "Can't set cue in to be larger than cue out."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
+msgid "Can't set cue out to be smaller than cue in."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:1372
+msgid "Upload Time"
+msgstr ""
+
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:160
+#, php-format
+msgid "%s is already watched."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:164
+#, php-format
+msgid "%s contains nested watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:168
+#, php-format
+msgid "%s is nested within existing watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:189
+#: airtime_mvc/application/models/MusicDir.php:370
+#, php-format
+msgid "%s is not a valid directory."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:232
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:388
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:431
+#, php-format
+msgid "%s doesn't exist in the watched list."
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:470
+#, php-format
+msgid "Powered by %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr ""
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:73
+msgid "Cannot move items out of linked shows"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:119
+msgid "The schedule you're viewing is out of date! (sched mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:124
+msgid "The schedule you're viewing is out of date! (instance mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:132
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
+msgid "The schedule you're viewing is out of date!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:143
+#, php-format
+msgid "You are not allowed to schedule show %s."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:147
+msgid "You cannot add files to recording shows."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:153
+#, php-format
+msgid "The show %s is over and cannot be scheduled."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:160
+#, php-format
+msgid "The show %s has been previously updated!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:196
+msgid "Cannot schedule a playlist that contains missing files."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
+msgid "A selected File does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:166
+msgid "Length needs to be greater than 0 minutes"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:171
+msgid "Length should be of form \"00h 00m\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:184
+msgid "URL should be of form \"http://domain\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:187
+msgid "URL should be 512 characters or less"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:193
+msgid "No MIME type found for webstream."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:209
+msgid "Webstream name cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:278
+msgid "Could not parse XSPF playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:298
+msgid "Could not parse PLS playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:318
+msgid "Could not parse M3U playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:332
+msgid "Invalid webstream - This appears to be a file download."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:336
+#, php-format
+msgid "Unrecognized stream type: %s"
+msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:50
 msgid "Record file doesn't exist"
@@ -46,24 +3987,12 @@ msgid "Edit Instance"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
 msgid "Edit"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:158
 #: airtime_mvc/application/services/CalendarService.php:172
 msgid "Edit Show"
-msgstr ""
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:194
@@ -90,13 +4019,6 @@ msgstr ""
 msgid "Can't move show into past"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr ""
-
 #: airtime_mvc/application/services/CalendarService.php:322
 msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
 msgstr ""
@@ -109,1848 +4031,55 @@ msgstr ""
 msgid "Must wait 1 hour to rebroadcast."
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr ""
-
 #: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1128
 msgid "Track"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1176
+#: airtime_mvc/application/services/HistoryService.php:1174
 msgid "Played"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
-#: airtime_mvc/application/controllers/PlaylistController.php:147
-#, php-format
-msgid "%s not found"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
-#: airtime_mvc/application/controllers/PlaylistController.php:168
-msgid "Something went wrong."
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
-msgid "Preview"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
-msgid "Add to Playlist"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
-msgid "Add to Smart Block"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
-msgid "Download"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:147
-msgid "View track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
-msgid "Duplicate Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:213
-msgid "No action available"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:233
-msgid "You don't have permission to delete selected items."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:279
-msgid "Could not delete file because it is scheduled in the future."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:282
-msgid "Could not delete file(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:322
-#, php-format
-msgid "Copy of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid "Please make sure admin user/password is correct on System->Streams page."
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:53
-#, php-format
-msgid "You are viewing an older version of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:140
-msgid "You cannot add tracks to dynamic blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:161
-#, php-format
-msgid "You don't have permission to delete selected %s(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:174
-msgid "You can only add tracks to smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:192
-msgid "Untitled Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:194
-msgid "Untitled Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:522
-msgid "Unknown Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
-msgid "Preferences updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:115
-msgid "Support setting updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:123
-msgid "Support Feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:251
-msgid "Stream Setting Updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:342
-msgid "path should be specified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:437
-msgid "Problem with Liquidsoap..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:493
-msgid "Request method not accepted"
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid "Check this box to automatically switch on Master/Show source upon source connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid "If your Icecast server expects a username of 'source', this field can be left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid "If your live streaming client does not ask for a username, this field should be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid "Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid "Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid "Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
-#, php-format
-msgid "Rebroadcast of show %s from %s at %s"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 msgid "mute"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
@@ -2011,266 +4140,94 @@ msgstr ""
 msgid "For more detailed help, read the %suser manual%s."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid "Choose some search criteria above and click Generate to create this playlist."
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid "A track list will be generated when you schedule this smart block into a show."
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
@@ -2281,42 +4238,89 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
 #, php-format
 msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
@@ -2336,9 +4340,9 @@ msgid "Click the box below to promote your station on %s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 msgid "(Required)"
 msgstr ""
 
@@ -2349,11 +4353,6 @@ msgstr ""
 msgid "(for verification purposes only, will not be published)"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
 msgid "Show me what I am sending "
 msgstr ""
@@ -2362,8 +4361,12 @@ msgstr ""
 msgid "Terms and Conditions"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
@@ -2399,19 +4402,6 @@ msgstr ""
 msgid "file meets the criteria"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
 msgid "Stream "
 msgstr ""
@@ -2432,120 +4422,24 @@ msgstr ""
 msgid "Stream URL: "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid "Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
@@ -2563,66 +4457,8 @@ msgstr ""
 msgid "Sample Rate:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
 msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
@@ -2661,13 +4497,54 @@ msgstr ""
 msgid "Limit to "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
@@ -2678,13 +4555,37 @@ msgstr ""
 msgid "Stream Data Collection Status"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
@@ -2709,6 +4610,123 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
 msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
@@ -2747,11 +4765,6 @@ msgstr ""
 msgid "Creating Log Sheet Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
 msgid "Add more elements"
 msgstr ""
@@ -2764,9 +4777,207 @@ msgstr ""
 msgid "Set Default Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
@@ -2781,1256 +4992,6 @@ msgstr ""
 msgid "No webstream"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
-msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid "'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
-msgid "Day must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
-msgid "Time must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
-msgid "Must wait at least 1 hour to rebroadcast"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
-#, php-format
-msgid "Use %s Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
-msgid "Use Custom Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
-msgid "Custom Username"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
-msgid "Custom Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
-msgid "Host:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
-msgid "Port:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
-msgid "Mount:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
-msgid "Username field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
-msgid "Password field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:10
-msgid "Link:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:16
-msgid "Repeat Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:19
-msgid "weekly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:20
-msgid "every 2 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:21
-msgid "every 3 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:22
-msgid "every 4 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:23
-msgid "monthly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:32
-msgid "Select Days:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:47
-msgid "Repeat By:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the month"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the week"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:69
-msgid "No End?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:106
-msgid "End date must be after start date"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:113
-msgid "Please select a repeat day"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
-msgid "Cue in and cue out are null."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
-msgid "Can't set cue out to be greater than file length."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
-msgid "Can't set cue in to be larger than cue out."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
-msgid "Can't set cue out to be smaller than cue in."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:1366
-msgid "Upload Time"
-msgstr ""
-
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:160
-#, php-format
-msgid "%s is already watched."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:164
-#, php-format
-msgid "%s contains nested watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:168
-#, php-format
-msgid "%s is nested within existing watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:189
-#: airtime_mvc/application/models/MusicDir.php:370
-#, php-format
-msgid "%s is not a valid directory."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:232
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:388
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:431
-#, php-format
-msgid "%s doesn't exist in the watched list."
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:33
-#, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:73
-msgid "Cannot move items out of linked shows"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:119
-msgid "The schedule you're viewing is out of date! (sched mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:124
-msgid "The schedule you're viewing is out of date! (instance mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
-msgid "The schedule you're viewing is out of date!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:142
-#, php-format
-msgid "You are not allowed to schedule show %s."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:146
-msgid "You cannot add files to recording shows."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:152
-#, php-format
-msgid "The show %s is over and cannot be scheduled."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:159
-#, php-format
-msgid "The show %s has been previously updated!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:195
-msgid "Cannot schedule a playlist that contains missing files."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
-msgid "A selected File does not exist!"
-msgstr ""
-
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:166
-msgid "Length needs to be greater than 0 minutes"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:171
-msgid "Length should be of form \"00h 00m\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:184
-msgid "URL should be of form \"http://domain\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:187
-msgid "URL should be 512 characters or less"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:193
-msgid "No MIME type found for webstream."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:209
-msgid "Webstream name cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:278
-msgid "Could not parse XSPF playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:298
-msgid "Could not parse PLS playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:318
-msgid "Could not parse M3U playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:332
-msgid "Invalid webstream - This appears to be a file download."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:336
-#, php-format
-msgid "Unrecognized stream type: %s"
-msgstr ""
-
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
 msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/hy/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/hy/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/hy_AM/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Armenian (Armenia) (http://www.transifex.com/sourcefabric/airtime/language/hy_AM/)\n"
+"Language: hy_AM\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hy_AM\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/hy_AM/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/hy_AM/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/id_ID/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Indonesian (Indonesia) (http://www.transifex.com/sourcefabric/airtime/language/id_ID/)\n"
+"Language: id_ID\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id_ID\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/it_IT/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # danse <francesco.occhipinti@sourcefabric.org>, 2014
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -10,266 +10,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Italian (Italy) (http://www.transifex.com/sourcefabric/airtime/language/it_IT/)\n"
+"Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it_IT\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "L'anno %s deve essere compreso nella serie 1753 - 9999"
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s non Ã¨ una data valida"
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s non Ã¨ un ora valida"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Vedi file registrati Metadata"
-
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edita"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edita show"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Cancella"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Non puoi spostare show ripetuti"
-
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Non puoi spostare uno show passato"
-
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Non puoi spostare uno show nel passato"
-
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Non puoi sovrascrivere gli show"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Non puoi spostare uno show registrato meno di un'ora prima che sia ritrasmesso."
-
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Lo show Ã¨ stato cancellato perchÃ© lo show registrato non esiste!"
-
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Devi aspettare un'ora prima di ritrasmettere."
-
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Titolo"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Creatore"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Lunghezza"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genere"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Genere (Mood)"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Etichetta"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Compositore"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
-
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Anno"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Conduttore"
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Lingua"
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Riprodotti"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendario"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Utenti"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Stato"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Storico playlist"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Statistiche ascolto"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Aiuto"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Iniziare"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Manuale utente"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Non Ã¨ permesso l'accesso  alla risorsa."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Non Ã¨ permesso l'accesso alla risorsa."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Richiesta errata.  'modalitÃ ' parametro non riuscito."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Richiesta errata. 'modalitÃ ' parametro non valido"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Non Ã¨ consentito disconnettersi dalla fonte."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Nessuna fonte connessa a questo ingresso."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Non ha il permesso per cambiare fonte."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s non trovato"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Qualcosa Ã¨ andato storto."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Anteprima"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Aggiungi a playlist"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Aggiungi al blocco intelligente"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edita Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Cancella"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Scarica"
 
@@ -278,81 +892,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Nessuna azione disponibile"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Non ha il permesso per cancellare gli elementi selezionati."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Webstream senza titolo"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream salvate."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Valori non validi."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Registra:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Stream Principale"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Niente programmato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Show attuale:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Attuale"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Sta gestendo l'ultima versione"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nuova versione disponibile:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Questa versione sarÃ  presto aggiornata."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Questa versione non Ã¨ piÃ¹ sopportata."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Per favore aggiorni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Aggiungi all'attuale playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Aggiungi all' attuale blocco intelligente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Sto aggiungendo un elemento"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Aggiunte %s voci"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Puoi solo aggiungere tracce ai blocchi intelligenti."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Puoi solo aggiungere tracce, blocchi intelligenti, e webstreams alle playlist."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edita Metadata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Aggiungi agli show selezionati"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Seleziona"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Seleziona pagina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Deseleziona pagina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Deseleziona tutto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "E' sicuro di voler eliminare la/e voce/i selezionata/e?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Titolo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Creatore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "VelocitÃ  di trasmissione"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Compositore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Conduttore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Codificato da"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genere"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Etichetta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Lingua"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Ultima modifica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Ultima esecuzione"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Lunghezza"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Formato (Mime)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Genere (Mood)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Proprietario"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Ripeti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "VelocitÃ  campione"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Numero traccia"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Caricato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Sito web"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Anno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Caricamento..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Tutto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "File"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Blocchi intelligenti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Tipologia sconosciuta:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Sei sicuro di voler eliminare gli elementi selezionati?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Caricamento in corso..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Dati recuperati dal server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "L'ID soundcloud per questo file Ã¨:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Si Ã¨ presentato un errore durante il caricamento a suondcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Errore codice:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Errore messaggio:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "L'ingresso deve essere un numero positivo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "L'ingresso deve essere un numero"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "L'ingresso deve essere nel formato : yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "L'ingresso deve essere nel formato : hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Stai attualmente scaricando file. %sCambiando schermata cancellerÃ  il processo di caricamento. %sSei sicuro di voler abbandonare la pagina?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "inserisca per favore il tempo '00:00:00(.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Il suo browser non sopporta la riproduzione di questa tipologia di file:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Il blocco dinamico non c'Ã¨ in anteprima"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limitato a:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist salvata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime Ã¨ insicuro sullo stato del file. Â°Questo puÃ² accadere quando il file Ã¨ su un drive remoto che non Ã¨ accessibile o il file Ã¨ su un elenco che non viene piÃ¹ visionato."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Programma in ascolto su %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Ricordamelo tra 1 settimana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Non ricordarmelo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Si, aiuta Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "L'immagine deve essere in  formato jpg, jpeg, png, oppure gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Uno statico blocco intelligente salverÃ  i criteri e genererÃ  il blocco del contenuto immediatamente. Questo permette di modificare e vedere la biblioteca prima di aggiungerla allo show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Un dinamico blocco intelligente salverÃ  i criteri. Il contenuto del blocco sarÃ  generato per aggiungerlo ad un show. Non riuscirÃ  a vedere e modificare il contenuto della Biblioteca."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Alla lunghezza di blocco desiderata non si arriverÃ  se Airtime non puÃ² trovare abbastanza tracce uniche per accoppiare i suoi criteri.Abiliti questa scelta se desidera permettere alle tracce di essere aggiunte molteplici volte al blocco intelligente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Blocco intelligente casuale"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Blocco Intelligente generato ed criteri salvati"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Blocco intelligente salvato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Elaborazione in corso..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Seleziona modificatore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contiene"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "non contiene"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "Ã¨ "
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "non Ã¨"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "inizia con"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "finisce con"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "Ã¨ piÃ¹ di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "Ã¨ meno di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "nella seguenza"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Scelga l'archivio delle cartelle"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Scelga le cartelle da guardare"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"E' sicuro di voler cambiare l'archivio delle cartelle?\n"
+" Questo rimuoverÃ  i file dal suo archivio Airtime!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Gestisci cartelle media"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "E' sicuro di voler rimuovere le cartelle guardate?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Questo percorso non Ã¨ accessibile attualmente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "User aggiunto con successo!"
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Connesso al server di streaming."
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "User aggiornato con successo!"
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Stream  disattivato"
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Ottenere informazioni dal server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Non puÃ² connettersi al server di streaming"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Se Airtime Ã¨ dietro un router o firewall, puÃ² avere bisogno di configurare il trasferimento e queste informazioni di campo saranno incorrette. In questo caso avrÃ² bisogno di aggiornare  manualmente questo campo per mostrare ospite/trasferimento/installa di cui il suo Dj ha bisogno per connettersi. La serie permessa Ã¨ tra 1024 e 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Per maggiori informazioni, legga per favore il %sManuale Airtime%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Controllo questa opzione per abilitare metadata per  le stream OGG (lo stream metadata Ã¨ il titolo della traccia,artista, e nome dello show esposto in un audio player). VLC e mplayer riscontrano un grave errore nel eseguire le stream OGG/VORBIS che ha abilitata l'informazione metadata:si disconnetterÃ  lo stream dopo ogni canzone. Se sta usando uno stream OGG ed i suoi ascoltatori non richiedono supporto nelle eseguzionu audio, puÃ² scegliere di abilitare questa opzione."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Controlli questo spazio per uscire automaticamente dalla fonte Master/Show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Controlli questo spazio per accendere automaticamente alla fonte di Master / Show su collegamento di fonte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Se il suo server Icecast si aspetta un nome utente di 'fonte', questo spazio puÃ² essere lasciato in bianco."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Se la live stream non risponde al nome utente, questo campo dovrebbe essere 'fonte'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
 msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nessun risultato trovato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Questo segue lo stesso modello di sicurezza per gli show: solo gli utenti assegnati allo show possono connettersi."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Imposta autenticazione personalizzata  che funzionerÃ  solo per questo show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "L'istanza dello show non esiste piÃ¹!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Lo show Ã¨ vuoto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Recupera data dal server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Lo show non ha un contenuto programmato."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Gennaio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Febbraio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Marzo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Aprile"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Maggio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Giugno"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Luglio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Agosto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Settembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Ottobre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Novembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Dicembre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Gen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Giu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Lug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Ago"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Set"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Ott"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dic"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Domenica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "LunedÃ¬"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "MartedÃ¬"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "MercoledÃ¬"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "GiovedÃ¬"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "VenerdÃ¬"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Sabato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Dom"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Lun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Mer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Gio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Ven"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sab"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Gli show piÃ¹ lunghi del tempo programmato saranno tagliati dallo show successivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Cancellare lo show attuale?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Fermare registrazione dello show attuale?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "OK"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Contenuti dello Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Rimuovere tutto il contenuto?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Cancellare la/e voce/i selezionata/e?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Start"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Fine"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Durata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Dissolvenza in entrata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Dissolvenza in uscita"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show vuoto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Registrando da Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Anteprima traccia"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Non puÃ² programmare fuori show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Spostamento di un elemento in corso"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Spostamento degli elementi %s in corso"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Salva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancella"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Seleziona tutto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Nessuna selezione"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Rimuovi la voce selezionata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Salta alla traccia dell'attuale playlist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancella show attuale"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Apri biblioteca per aggiungere o rimuovere contenuto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Aggiungi/Rimuovi contenuto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "in uso"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disco"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Cerca in"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Apri"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Amministratore "
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programma direttore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Ospite"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Invia supporto feedback:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Mostra/nascondi colonne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Da {da} a {a}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Dom"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Lun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Mer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Gio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Ven"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sab"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Chiudi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Ore"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Completato"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "L' e-mail non puÃ² essere inviata. Controlli le impostazioni della sua mail e si accerti che Ã¨ stata configurata correttamente."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Nome utente o  password forniti errati. Per favore riprovi."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2407,6 @@ msgstr "Non ha i permessi per cancellare la selezione %s(s)."
 msgid "You can only add tracks to smart block."
 msgstr "PuÃ² solo aggiungere tracce al blocco intelligente."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Puoi solo aggiungere tracce, blocchi intelligenti, e webstreams alle playlist."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Playlist senza nome"
@@ -385,2627 +2415,88 @@ msgstr "Playlist senza nome"
 msgid "Untitled Smart Block"
 msgstr "Blocco intelligente senza nome"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Playlist sconosciuta"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Non Ã¨ permesso l'accesso  alla risorsa."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preferenze aggiornate."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Aggiornamento impostazioni assistenza."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Support Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Aggiornamento impostazioni Stream."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "il percorso deve essere specificato"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problemi con Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Non Ã¨ consentito disconnettersi dalla fonte."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Nessuna fonte connessa a questo ingresso."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Non ha il permesso per cambiare fonte."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Nome utente o  password forniti errati. Per favore riprovi."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "L' e-mail non puÃ² essere inviata. Controlli le impostazioni della sua mail e si accerti che Ã¨ stata configurata correttamente."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Non Ã¨ permesso l'accesso alla risorsa."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Richiesta errata.  'modalitÃ ' parametro non riuscito."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Richiesta errata. 'modalitÃ ' parametro non valido"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Registra:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Stream Principale"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Niente programmato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Show attuale:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Attuale"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Sta gestendo l'ultima versione"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nuova versione disponibile:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Questa versione sarÃ  presto aggiornata."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Questa versione non Ã¨ piÃ¹ sopportata."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Per favore aggiorni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Aggiungi all'attuale playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Aggiungi all' attuale blocco intelligente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Sto aggiungendo un elemento"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Aggiunte %s voci"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Puoi solo aggiungere tracce ai blocchi intelligenti."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Aggiungi agli show selezionati"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Seleziona"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Seleziona pagina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Deseleziona pagina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Deseleziona tutto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "E' sicuro di voler eliminare la/e voce/i selezionata/e?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "VelocitÃ  di trasmissione"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Codificato da"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Ultima modifica"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Ultima esecuzione"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Formato (Mime)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Proprietario"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Ripeti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "VelocitÃ  campione"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Numero traccia"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Caricato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Sito web"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Caricamento..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Tutto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "File"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Blocchi intelligenti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Tipologia sconosciuta:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Sei sicuro di voler eliminare gli elementi selezionati?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Caricamento in corso..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Dati recuperati dal server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "L'ID soundcloud per questo file Ã¨:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Si Ã¨ presentato un errore durante il caricamento a suondcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Errore codice:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Errore messaggio:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "L'ingresso deve essere un numero positivo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "L'ingresso deve essere un numero"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "L'ingresso deve essere nel formato : yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "L'ingresso deve essere nel formato : hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Stai attualmente scaricando file. %sCambiando schermata cancellerÃ  il processo di caricamento. %sSei sicuro di voler abbandonare la pagina?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "inserisca per favore il tempo '00:00:00(.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "inserisca per favore il tempo in secondi '00(.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Il suo browser non sopporta la riproduzione di questa tipologia di file:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Il blocco dinamico non c'Ã¨ in anteprima"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limitato a:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist salvata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime Ã¨ insicuro sullo stato del file. Â°Questo puÃ² accadere quando il file Ã¨ su un drive remoto che non Ã¨ accessibile o il file Ã¨ su un elenco che non viene piÃ¹ visionato."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Programma in ascolto su %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Ricordamelo tra 1 settimana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Non ricordarmelo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Si, aiuta Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "L'immagine deve essere in  formato jpg, jpeg, png, oppure gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Uno statico blocco intelligente salverÃ  i criteri e genererÃ  il blocco del contenuto immediatamente. Questo permette di modificare e vedere la biblioteca prima di aggiungerla allo show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Un dinamico blocco intelligente salverÃ  i criteri. Il contenuto del blocco sarÃ  generato per aggiungerlo ad un show. Non riuscirÃ  a vedere e modificare il contenuto della Biblioteca."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Alla lunghezza di blocco desiderata non si arriverÃ  se Airtime non puÃ² trovare abbastanza tracce uniche per accoppiare i suoi criteri.Abiliti questa scelta se desidera permettere alle tracce di essere aggiunte molteplici volte al blocco intelligente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Blocco intelligente casuale"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Blocco Intelligente generato ed criteri salvati"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Blocco intelligente salvato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Elaborazione in corso..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Seleziona modificatore"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contiene"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "non contiene"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "Ã¨ "
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "non Ã¨"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "inizia con"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "finisce con"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "Ã¨ piÃ¹ di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "Ã¨ meno di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "nella seguenza"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Scelga l'archivio delle cartelle"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Scelga le cartelle da guardare"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "E' sicuro di voler cambiare l'archivio delle cartelle?\n Questo rimuoverÃ  i file dal suo archivio Airtime!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Gestisci cartelle media"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "E' sicuro di voler rimuovere le cartelle guardate?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Questo percorso non Ã¨ accessibile attualmente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Connesso al server di streaming."
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Stream  disattivato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Ottenere informazioni dal server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Non puÃ² connettersi al server di streaming"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Se Airtime Ã¨ dietro un router o firewall, puÃ² avere bisogno di configurare il trasferimento e queste informazioni di campo saranno incorrette. In questo caso avrÃ² bisogno di aggiornare  manualmente questo campo per mostrare ospite/trasferimento/installa di cui il suo Dj ha bisogno per connettersi. La serie permessa Ã¨ tra 1024 e 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Per maggiori informazioni, legga per favore il %sManuale Airtime%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Controllo questa opzione per abilitare metadata per  le stream OGG (lo stream metadata Ã¨ il titolo della traccia,artista, e nome dello show esposto in un audio player). VLC e mplayer riscontrano un grave errore nel eseguire le stream OGG/VORBIS che ha abilitata l'informazione metadata:si disconnetterÃ  lo stream dopo ogni canzone. Se sta usando uno stream OGG ed i suoi ascoltatori non richiedono supporto nelle eseguzionu audio, puÃ² scegliere di abilitare questa opzione."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Controlli questo spazio per uscire automaticamente dalla fonte Master/Show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Controlli questo spazio per accendere automaticamente alla fonte di Master / Show su collegamento di fonte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Se il suo server Icecast si aspetta un nome utente di 'fonte', questo spazio puÃ² essere lasciato in bianco."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Se la live stream non risponde al nome utente, questo campo dovrebbe essere 'fonte'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nessun risultato trovato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Questo segue lo stesso modello di sicurezza per gli show: solo gli utenti assegnati allo show possono connettersi."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Imposta autenticazione personalizzata  che funzionerÃ  solo per questo show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "L'istanza dello show non esiste piÃ¹!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Lo show Ã¨ vuoto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Recupera data dal server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Lo show non ha un contenuto programmato."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Gennaio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Febbraio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Marzo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Aprile"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Maggio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Giugno"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Luglio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Agosto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Settembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Ottobre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Novembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Dicembre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Gen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Giu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Lug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Ago"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Set"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Ott"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dic"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Domenica"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "LunedÃ¬"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "MartedÃ¬"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "MercoledÃ¬"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "GiovedÃ¬"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "VenerdÃ¬"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Sabato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Dom"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Lun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Mer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Gio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Ven"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sab"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Gli show piÃ¹ lunghi del tempo programmato saranno tagliati dallo show successivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Cancellare lo show attuale?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Fermare registrazione dello show attuale?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "OK"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Contenuti dello Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Rimuovere tutto il contenuto?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Cancellare la/e voce/i selezionata/e?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Start"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Fine"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Durata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Dissolvenza in entrata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Dissolvenza in uscita"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show vuoto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Registrando da Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Anteprima traccia"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Non puÃ² programmare fuori show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Spostamento di un elemento in corso"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Spostamento degli elementi %s in corso"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Salva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancella"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Seleziona tutto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Nessuna selezione"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Rimuovi la voce selezionata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Salta alla traccia dell'attuale playlist"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancella show attuale"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Apri biblioteca per aggiungere o rimuovere contenuto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Aggiungi/Rimuovi contenuto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "in uso"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disco"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Cerca in"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Apri"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Amministratore "
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programma direttore"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Ospite"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Invia supporto feedback:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Mostra/nascondi colonne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Da {da} a {a}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Dom"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Lun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Mer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Gio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Ven"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sab"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Chiudi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Ore"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Completato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Stato"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Seleziona cursore"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Rimuovere il cursore"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "lo show non esiste"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Ritrasmetti show %s da %s a %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "L'anno %s deve essere compreso nella serie 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s non Ã¨ una data valida"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s non Ã¨ un ora valida"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Seleziona stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "disattiva microfono"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "attiva microfono"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Chi siamo"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Per aiuto dettagliato, legga %suser manual%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Storico playlist"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Espandi blocco statico"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Espandi blocco dinamico "
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Nome:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Descrizione:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Durata:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Riproduzione casuale"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Casuale"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Playlist crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Dissolvenza in entrata:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Dissolvenza in chiusura:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Salva playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Non aprire playlist"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue in:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Lunghezza originale:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Impostazioni Stream"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Accedi"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nuova password"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Prego inserire e confermare la sua nuova password nel seguente spazio."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Gestione utenti"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nuovo Utente"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Nome utente"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Nome"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Cognome"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Tipo di utente"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Trova Shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Ripeti giorni:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Rimuovi"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Aggiungi "
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Mostra fonte"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Registro Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Richiesto)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(per scopi di verifica, non ci saranno pubblicazioni)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Note: La lunghezze superiori a 600x600 saranno ridimensionate."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Mostra cosa sto inviando"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Termini e condizioni"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Scegli giorni:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "a"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "Files e criteri"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtra storia"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Per promuovere la sua stazione, 'Spedisca aderenza feedback' deve essere abilitato)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Opzioni aggiuntive"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "La seguente informazione sarÃ  esposta agli ascoltatori nelle loro eseguzione:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Il sito della tua radio)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Scegli cartella"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Imposta"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Importa cartelle:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Rimuovi elenco visionato"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Sta guardando i cataloghi media."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Fonte principale"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Impostazioni SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Aggiungi show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Aggiorna show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Cosa"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Quando"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Ingresso Stream diretta"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Chi"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stile"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Spazio disco"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "File importato in corso..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Opzioni di ricerca avanzate"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Titolo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Creatore:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Traccia:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Lunghezza"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Percentuale"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "VelocitÃ  di trasmissione: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Umore:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Genere:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Anno:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Etichetta:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Compositore:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conduttore:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Seleziona cursore"
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Numero ISRC:"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Rimuovere il cursore"
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Sito web:"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "lo show non esiste"
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Lingua:"
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "User aggiunto con successo!"
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Blocco intelligente e dinamico"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Blocco intelligente e statico"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Traccia audio"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Contenuti playlist:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Contenuto di blocco intelligente e statico:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Criteri di blocco intelligenti e dinamici:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limiti"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "La sua versione di prova scade entro"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "giorni"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Precedente:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Successivo:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Source Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "IN ONDA"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Ascolta"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Esci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Nome"
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "User aggiornato con successo!"
 
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Descrizione"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Lunghezza predefinita:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "No webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Aiuto"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Pagina non trovata!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "La pagina che stai cercando non esiste! "
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "precedente"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "riproduci"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pausa"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "next"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "volume massimo"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Webstream senza titolo"
 
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Aggiornamenti richiesti"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Per riproduzione media, avrÃ  bisogno di aggiornare il suo browser ad una recente versione o aggiornare il suo %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream salvate."
 
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Data inizio:"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Valori non validi."
 
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2506,6 @@ msgstr "Data inizio:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Carattere inserito non valido"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Data fine:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Tutti i miei show:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Cerca utenti:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Dj:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Nome stazione"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefono:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Stazione sito web:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Paese:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "CittÃ :"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Descrizione stazione:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo stazione: "
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Autorizzo il trattamento dei miei dati personali."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Registra da Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Ritrasmetti?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Il calore richiesto non puÃ² rimanere vuoto"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' non Ã¨ valido l'indirizzo e-mail nella forma base local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' non va bene con il formato data '%formato%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' Ã¨ piÃ¹ corto di %min% caratteri"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' Ã¨ piÃ¹ lungo di %max% caratteri"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' non Ã¨ tra '%min%' e '%max%' compresi"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2522,55 @@ msgstr "L'ora dev'essere specificata"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Aspettare almeno un'ora prima di ritrasmettere"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Reimposta password"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Show senza nome"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Numero ISRC :"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "Ok"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Disattivato"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Abilitato"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "La settimana inizia il"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Username:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Password:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Nome:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Cognome:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Cellulare:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "tipo di utente:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Il nome utente esiste giÃ ."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Importa Folder:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Folder visionati:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Catalogo non valido"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Licenza predefinita:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Tutti i diritti riservati"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Il lavoro Ã¨ nel dominio pubblico"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "In esecuzione"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Seleziona criteri"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "VelocitÃ  campione (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "ore"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minuti"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "elementi"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinamico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Genera contenuto playlist e salva criteri"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Genere"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Eseguzione casuale playlist"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Il margine non puÃ² essere vuoto o piÃ¹ piccolo di 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Il margine non puÃ² superare le 24ore"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Il valore deve essere un numero intero"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 Ã¨ il limite massimo di elementi che puÃ² inserire"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Devi selezionare da Criteri e Modifica"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "La lunghezza deve essere nel formato '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Il valore deve essere nel formato (es. 0000-00-00 o 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Il valore deve essere numerico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Il valore deve essere inferiore a 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Il valore deve essere inferiore a %s caratteri"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Il valore non deve essere vuoto"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Etichetta Stream:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artista - Titolo"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artista - Titolo"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Nome stazione - Nome show"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Conferma nuova password"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "La password di conferma non corrisponde con la sua password."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Attiva:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Tipo di stream:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Tipo di servizio:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Canali:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Solo numeri."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Mount Point"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Il server non Ã¨ libero."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Il port non puÃ² essere libero."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount non puÃ² essere vuoto con il server Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' non si adatta al formato dell'ora 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Ripetizioni?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Non creare show al passato"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Non modificare data e ora di inizio degli slot in eseguzione"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "L'ora e la data finale non possono precedere quelle iniziali"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Non ci puÃ² essere  una durata <0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Non ci puÃ² essere una durata 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Non ci puÃ² essere una durata superiore a 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Usa autenticazione clienti:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Personalizza nome utente "
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Personalizza Password"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Il campo nome utente non puÃ² rimanere vuoto."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Il campo della password non puÃ² rimanere vuoto."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Colore sfondo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Colore testo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Digita le parole del riquadro."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "giorni"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2616,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Data fine:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Ripeti all'infinito?"
@@ -3878,115 +2634,1174 @@ msgstr "La data di fine deve essere posteriore  a quella di inizio"
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Registra da Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Ritrasmetti?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Colore sfondo:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Colore testo:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendario"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Rimuovi"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Utenti"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Nome:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Show senza nome"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Genere:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Descrizione:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Statistiche ascolto"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' non si adatta al formato dell'ora 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Durata:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Ripetizioni?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Non creare show al passato"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Non modificare data e ora di inizio degli slot in eseguzione"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "L'ora e la data finale non possono precedere quelle iniziali"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Non ci puÃ² essere  una durata <0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Non ci puÃ² essere una durata 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Non ci puÃ² essere una durata superiore a 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Non puoi sovrascrivere gli show"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Cerca utenti:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Dj:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Username:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Password:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Iniziare"
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Nome:"
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Cognome:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Cellulare:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "tipo di utente:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Il nome utente esiste giÃ ."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Manuale utente"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Il calore richiesto non puÃ² rimanere vuoto"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Data inizio:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Titolo:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Creatore:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Anno:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Etichetta:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Compositore:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conduttore:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Umore:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Numero ISRC :"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Sito web:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Lingua:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Nome stazione"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo stazione: "
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Note: La lunghezze superiori a 600x600 saranno ridimensionate."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Disattivato"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Abilitato"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "La settimana inizia il"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' non Ã¨ valido l'indirizzo e-mail nella forma base local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' non va bene con il formato data '%formato%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' Ã¨ piÃ¹ corto di %min% caratteri"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' Ã¨ piÃ¹ lungo di %max% caratteri"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' non Ã¨ tra '%min%' e '%max%' compresi"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Solo numeri."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Accedi"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Digita le parole del riquadro."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Conferma nuova password"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "La password di conferma non corrisponde con la sua password."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Nome utente"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Reimposta password"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "In esecuzione"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefono:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Stazione sito web:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Paese:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "CittÃ :"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Descrizione stazione:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Autorizzo il trattamento dei miei dati personali."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Tutti i miei show:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Seleziona criteri"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Descrizione"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "VelocitÃ  campione (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "ore"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minuti"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "elementi"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinamico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Genera contenuto playlist e salva criteri"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Genere"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Eseguzione casuale playlist"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Casuale"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Il margine non puÃ² essere vuoto o piÃ¹ piccolo di 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Il margine non puÃ² superare le 24ore"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Il valore deve essere un numero intero"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 Ã¨ il limite massimo di elementi che puÃ² inserire"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Devi selezionare da Criteri e Modifica"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "La lunghezza deve essere nel formato '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Il valore deve essere nel formato (es. 0000-00-00 o 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Il valore deve essere numerico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Il valore deve essere inferiore a 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Il valore deve essere inferiore a %s caratteri"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Il valore non deve essere vuoto"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Licenza predefinita:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Tutti i diritti riservati"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Il lavoro Ã¨ nel dominio pubblico"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Etichetta Stream:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artista - Titolo"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artista - Titolo"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Nome stazione - Nome show"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Attiva:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Tipo di stream:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "VelocitÃ  di trasmissione: "
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Tipo di servizio:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Canali:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Nome"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Mount Point"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Il server non Ã¨ libero."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Il port non puÃ² essere libero."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount non puÃ² essere vuoto con il server Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Importa Folder:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Folder visionati:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Catalogo non valido"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue in e cue out sono nulli."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Il cue out non puÃ² essere piÃ¹ grande della lunghezza del file."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Il cue in non puÃ² essere piÃ¹ grande del cue out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Il cue out non puÃ² essere piÃ¹ piccolo del cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Ritrasmetti da %s a %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Seleziona paese"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3826,12 @@ msgstr "%s non Ã¨ una directory valida."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s Ã¨ giÃ  impostato come attuale cartella archivio o appartiene alle cartelle visionate"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s Ã¨ giÃ  impostato come attuale cartella archivio o appartiene alle cartelle visionate."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3839,18 @@ msgstr "%s Ã¨ giÃ  impostato come attuale cartella archivio o appartiene alle
 msgid "%s doesn't exist in the watched list."
 msgstr "%s non esiste nella lista delle cartelle visionate."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Seleziona paese"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Gli show possono avere una lunghezza massima di 24 ore."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Non  si possono programmare show sovrapposti.\n Note: Ridimensionare uno slot a ripetizione colpisce tutte le sue ripetizioni."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3865,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Il programma che sta visionando Ã¨ fuori data! (disadattamento dell'esempio)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Il programma che sta visionando Ã¨ fuori data!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Non Ã¨ abilitato all'elenco degli show%s"
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Non puÃ² aggiungere file a show registrati."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Lo show % supera la lunghezza massima e non puÃ² essere programmato."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Lo show  %s Ã¨ giÃ  stato aggiornato! "
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Il File selezionato non esiste!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Gli show possono avere una lunghezza massima di 24 ore."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Non  si possono programmare show sovrapposti.\n"
+" Note: Ridimensionare uno slot a ripetizione colpisce tutte le sue ripetizioni."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Ritrasmetti da %s a %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3965,1046 @@ msgstr "Webstream non valido - Questo potrebbe essere un file scaricato."
 msgid "Unrecognized stream type: %s"
 msgstr "Tipo di stream sconosciuto: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Vedi file registrati Metadata"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edita"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edita show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Non puoi spostare show ripetuti"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Non puoi spostare uno show passato"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Non puoi spostare uno show nel passato"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Non puoi spostare uno show registrato meno di un'ora prima che sia ritrasmesso."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Lo show Ã¨ stato cancellato perchÃ© lo show registrato non esiste!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Devi aspettare un'ora prima di ritrasmettere."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Riprodotti"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "precedente"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "riproduci"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pausa"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "next"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "disattiva microfono"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "attiva microfono"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "volume massimo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Aggiornamenti richiesti"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Per riproduzione media, avrÃ  bisogno di aggiornare il suo browser ad una recente versione o aggiornare il suo %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Chi siamo"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Per aiuto dettagliato, legga %suser manual%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Seleziona stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Pagina non trovata!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "La pagina che stai cercando non esiste! "
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Mostra fonte"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Scegli giorni:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Aggiungi "
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Ripeti giorni:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtra storia"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Impostazioni SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Fonte principale"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "Ok"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Scegli cartella"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Imposta"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Importa cartelle:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Rimuovi elenco visionato"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Sta guardando i cataloghi media."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Registro Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Richiesto)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(per scopi di verifica, non ci saranno pubblicazioni)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Mostra cosa sto inviando"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Termini e condizioni"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Trova Shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "a"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "Files e criteri"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Opzioni aggiuntive"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "La seguente informazione sarÃ  esposta agli ascoltatori nelle loro eseguzione:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Il sito della tua radio)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Per promuovere la sua stazione, 'Spedisca aderenza feedback' deve essere abilitato)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Traccia:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Lunghezza"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Percentuale"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Numero ISRC:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Blocco intelligente e dinamico"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Blocco intelligente e statico"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Traccia audio"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Contenuti playlist:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Contenuto di blocco intelligente e statico:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Criteri di blocco intelligenti e dinamici:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limiti"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "File importato in corso..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Opzioni di ricerca avanzate"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nuova password"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Prego inserire e confermare la sua nuova password nel seguente spazio."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Precedente:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Successivo:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Source Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "IN ONDA"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Ascolta"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Esci"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "La sua versione di prova scade entro"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Riproduzione casuale"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Playlist crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Dissolvenza in chiusura:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Salva playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Non aprire playlist"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue in:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Lunghezza originale:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Dissolvenza in entrata:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Espandi blocco statico"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Espandi blocco dinamico "
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Impostazioni Stream"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Aggiungi show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Aggiorna show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Cosa"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Quando"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Ingresso Stream diretta"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Chi"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stile"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Spazio disco"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Gestione utenti"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nuovo Utente"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Nome"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Cognome"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Tipo di utente"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Lunghezza predefinita:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "No webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "inserisca per favore il tempo in secondi '00(.0)'"

--- a/airtime_mvc/locale/it_IT/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/it_IT/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Akemi Makino <akemi.makino@mail.rakuten.com>, 2014
 # Kazuhiro Shimbo <kazuhiro.shimbo@mail.rakuten.com>, 2014
@@ -10,266 +10,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Japanese (http://www.transifex.com/sourcefabric/airtime/language/ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "録音ファイルは存在しません。"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "%s年は、1753 - 9999の範囲内である必要があります。"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "録音ファイルのメタデータを確認"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%sは正しい日付ではありません。"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%sは正しい時間ではありません。"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "編集"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "番組の編集"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "削除"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "許可されていない操作です。"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "定期配信している番組を移動することはできません。"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "過去の番組を移動することはできません。"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "番組を過去の日付に移動することはできません。"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "番組を重複して予約することはできません。"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "録音された番組を再配信時間の直前1時間の枠に移動することはできません。"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "録音された番組が存在しないので番組は削除されました。"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "再配信には１時間待たなければなりません。"
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "タイトル"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "アーティスト"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "アルバム"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "時間"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "ジャンル"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "ムード"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "レーベル"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "作曲者"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "著作権"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "年"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "トラック"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "コンダクター"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "言語"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "開始時間"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "終了時間"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "再生済み"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "カレンダー"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "ユーザー"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "配信設定"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "ステータス"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "配信履歴"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "配信履歴のテンプレート"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "リスナー統計"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "ヘルプ"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "はじめに"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "ユーザーマニュアル"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "このリソースへのアクセスは許可されていません。"
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "このリソースへのアクセスは許可されていません。"
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Bad Request：パスした「mode」パラメータはありません。"
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Bad Request：'mode' パラメータが無効です。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "ソースを切断する権限がありません。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "この入力に接続されたソースが存在しません。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "ソースを切り替える権限がありません。"
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s は見つかりませんでした。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "問題が生じました。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "プレビュー"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "プレイリストに追加"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "スマートブロックに追加"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "メタデータの編集"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "削除"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -278,81 +892,1500 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "プレイリストのコピー"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "実行可能な操作はありません。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "選択した項目を削除する権限がありません。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "%sのコピー"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "無題のウェブ配信"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "ウェブ配信が保存されました。"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "入力欄に無効な値があります。"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "管理ユーザー・パスワードが正しいか、システム＞配信のページで確認して下さい。"
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "ユーザーの追加に成功しました。"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "オーディオプレイヤー"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "ユーザーの更新に成功しました。"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "設定の更新に成功しました。"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "録音中："
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "マスターストリーム"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "ライブ配信"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "何も予約されていません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "現在の番組："
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Now Playing"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "最新バージョンを使用しています。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "新しいバージョンがあります："
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "新しいバージョンがあります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "このバージョンのサポートは終了しました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "こちらにアップグレードしてください："
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "現在のプレイリストに追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "現在のスマートブロックに追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "1個の項目を追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr " %s個の項目を追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "スマートブロックに追加できるのはトラックのみです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "プレイリストに追加できるのはトラック・スマートブロック・ウェブ配信のみです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "タイムライン上のカーソル位置を選択して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "メタデータの編集"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "選択した番組へ追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "選択"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "このページを選択"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "このページを選択解除"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "全てを選択解除"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "選択した項目を削除してもよろしいですか?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "配信予約済み"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "タイトル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "アーティスト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "アルバム"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "ビットレート"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM "
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "作曲者"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "コンダクター"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "著作権"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "エンコード"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "ジャンル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "レーベル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "言語"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "最終修正"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "最終配信日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "時間"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "MIMEタイプ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "ムード"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "所有者"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "リプレイゲイン"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "サンプルレート"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "トラック番号"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "アップロード完了"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "ウェブサイト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "年"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "ロード中…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "全て"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "ファイル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "プレイリスト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "スマートブロック"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "ウェブ配信"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "種類不明："
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "選択した項目を削除してもよろしいですか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "アップロード中…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "サーバーからデータを取得しています…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "このファイルのSoundCloud IDは以下の通りです："
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "SoundCloudへのアップロード中にエラーが発生しました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "エラーコード："
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "エラーメッセージ："
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "0より大きい半角数字で入力して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "半角数字で入力して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "yyyy-mm-ddの形で入力して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "01:22:33.4の形式で入力して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "現在ファイルをアップロードしています。%s別の画面に移行するとアップロードプロセスはキャンセルされます。%sこのページを離れますか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "メディアビルダーを開く"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "時間は01:22:33(.4)の形式で入力して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "お使いのブラウザはこのファイル形式の再生に対応していません："
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "自動生成スマート・ブロックはプレビューできません"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "次の値に制限："
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "プレイリストが保存されました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "プレイリストがシャッフルされました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "このファイルのステータスが不明です。これは、ファイルがアクセス不能な外付けドライブに存在するか、またはファイルが同期されていないディレクトリに存在する場合に起こります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "%sのリスナー視聴数：%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "1週間前に通知"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "通知しない"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Rakuten.FMを支援します"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "画像は、jpg, jpeg, png, または gif の形式にしてください。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "スマート・ブロックは基準を満たし、即時にブロック・コンテンツを生成します。これにより、コンテンツをショーに追加する前にライブラリーにおいてコンテンツを編集および閲覧できます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "自動生成スマートブロックは基準の設定のみ操作できます。ブロックコンテンツは番組に追加するとすぐに生成されます。生成したコンテンツをライブラリ内で編集することはできません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Rakuten.FMがあなたの条件に一致するトラックを十分に見つけることができない場合、ご希望のブロック時間になりません。スマートブロックに同じトラックを複数回追加できるようにしたい場合は、このオプションを有効にしてください。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "スマートブロックがシャッフルされました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "スマートブロックが生成されて基準が保存されました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "スマートブロックを保存しました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "処理中…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "条件を選択してください"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "以下を含む"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "以下を含まない"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "以下と一致する"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "以下と一致しない"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "以下で始まる"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "以下で終わる"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "次の値より大きい"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "次の値より小さい"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "次の範囲内"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "フォルダを選択してください。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "同期するフォルダを選択"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr "保存先のフォルダを変更しますか？Rakuten.FMライブラリからファイルを削除することになります！"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "メディアフォルダの管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "同期されているフォルダを削除してもよろしいですか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "このパスは現在アクセス不可能です。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "配信種別の中には追加の設定が必要なものがあります。詳細設定を行うと%sAAC+ Support%s または %sOpus Support%sが可能になります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "ストリーミングサーバーに接続しています。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "配信が切断されています。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "サーバーから情報を取得しています…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "ストリーミングサーバーに接続できません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Rakuten.FMがルータやファイアウォールで制御されている場合は、ポート転送を設定する必要があり、このフィールドの情報が不正確になる可能性があります。その場合は、DJの接続に必須の正しいホスト/ポート/マウントを示し、手動でこのフィールドを更新する必要があります。許容範囲は1024〜49151の間です。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "詳細については、 %sRakuten.FM マニュアル%sを読んで下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "このオプションをチェックしてOGGストリームのメタデータを有効にしてください（ストリームメタデータとは、トラックタイトル、アーティスト、オーディオプレーヤーに表示される名前のことです）。メタデータ情報を有効にしてOGG/ Vorbisのストリームを再生すると、VLCとmplayerはすべての曲を再生した後にストリームから切断される重大なバグを発生させます。OGGストリームを使用していて、リスナーがこれらのオーディオプレーヤーのためのサポートを必要としない場合は、このオプションを有効にして下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "このボックスにチェックを入れると、ソースが切断された時に番組ソースに自動的に切り替わります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "このボックスをクリックすると、ソースが接続された時にマスターソースに自動的に切り替わります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr " Icecastサーバーから ソースのユーザー名を要求された場合、このフィールドは空白にすることができます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "ライブ配信クライアントでユーザー名を要求されなかった場合、このフィールドはソースとなります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr " Icecast/SHOUTcastでリスナー統計を参照するためのユーザー名とパスワードです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "注意：番組の配信中にこの項目は変更できません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "結果は見つかりませんでした。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "番組と同様のセキュリティーパターンを採用します。番組を割り当てられているユーザーのみ接続することができます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "この番組に対してのみ有効なカスタム認証を指定してください。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "この番組の配信回が存在しません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "注意：番組は再度リンクできません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "配信内容を同期すると、配信内容の変更が対応するすべての再配信にも反映されます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "タイムゾーンは初期設定ではステーション所在地に合わせて設定されています。タイムゾーンを変更するには、ユーザー設定からインターフェイスのタイムゾーンを変更して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "番組"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "番組内容がありません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "サーバーからデータを取得しています…"
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "この番組には予約されているコンテンツがありません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "この番組はコンテンツが足りていません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "1月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "2月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "3月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "4月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "5月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "6月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "7月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "8月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "9月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "10月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "11月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "12月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "1月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "2月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "3月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "4月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "6月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "7月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "8月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "9月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "10月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "11月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "12月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "日曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "月曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "火曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "水曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "木曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "金曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "土曜日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "火"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "水"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "木"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "金"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "土"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "番組が予約された時間より長くなった場合はカットされ、次の番組が始まります。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "現在の番組をキャンセルしますか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "配信中の番組の録音を中止しますか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "番組内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "全てのコンテンツを削除しますか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "選択した項目を削除しますか？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "開始"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "終了"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "長さ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "キューイン"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "キューアウト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "フェードイン"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "フェードアウト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "番組内容がありません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "ライン入力から録音"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "試聴する"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "番組外に予約することは出来ません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "1個の項目を移動"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "%s 個の項目を移動"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "保存"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "フェードの編集"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "キューの編集"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "波形表示機能はWeb Audio APIに対応するブラウザで利用できます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "全て選択"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "全て解除"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "選択した項目を削除"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "現在再生中のトラックに移動"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "配信中の番組をキャンセル"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "ライブラリを開いてコンテンツを追加・削除する"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "コンテンツの追加・削除"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "使用中"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "ディスク"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "閲覧"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "開く"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "管理者"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "プログラムマネージャー"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "ゲスト"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "ゲストは以下の操作ができます："
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "スケジュールを見る"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "番組内容を見る"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJは以下の操作ができます："
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "割り当てられた番組内容を管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "メディアファイルをインポートする"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "プレイリスト・スマートブロック・ウェブストリームを作成"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "ライブラリのコンテンツを管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "プログラムマネージャーは以下の操作が可能です："
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "番組内容の表示と管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "番組を予約する"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "ライブラリの全てのコンテンツを管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "管理者は次の操作が可能です："
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "設定を管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "ユーザー管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "同期されているフォルダを管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "サポートにフィードバックを送る"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "システムステータスを見る"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "配信レポートへ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "リスナー統計を確認"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "表示設定"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "{from}から{to}へ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "火"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "水"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "木"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "金"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "土"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "閉じる"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "時"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "分"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "完了"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "ファイルを選択"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "ファイルを追加して「アップロード開始」ボタンをクリックして下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "ファイルを追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "アップロード中止"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "アップロード開始"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "ファイルを追加"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "%d/%d ファイルをアップロードしました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "こちらにファイルをドラッグしてください。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "ファイル拡張子エラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "ファイルサイズエラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "ファイルカウントのエラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Initエラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTPエラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "セキュリティエラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "エラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "入出力エラーです。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "ファイル： %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d のファイルが待機中"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "ファイル： %f, サイズ： %s, ファイルサイズ最大： %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "アップロードURLに誤りがあるか存在しません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "エラー：ファイルサイズが大きすぎます。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "エラー：ファイル拡張子が無効です。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "初期設定として保存"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "エントリーを作成"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "配信履歴を編集"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "番組はありません。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s 列の%s をクリップボードにコピー しました。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%s印刷用表示%sお使いのブラウザの印刷機能を使用してこの表を印刷してください。印刷が完了したらEscボタンを押して下さい。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "メールが送信できませんでした。メールサーバーの設定を確認してください。"
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "入力されたユーザー名またはパスワードが誤っています。"
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2405,6 @@ msgstr "選択された%sを削除する権限がありません。"
 msgid "You can only add tracks to smart block."
 msgstr "スマートブロックに追加できるのはトラックのみです。"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "プレイリストに追加できるのはトラック・スマートブロック・ウェブ配信のみです。"
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "無題のプレイリスト"
@@ -385,2627 +2413,88 @@ msgstr "無題のプレイリスト"
 msgid "Untitled Smart Block"
 msgstr "無題のスマートブロック"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "不明なプレイリスト"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "このリソースへのアクセスは許可されていません。"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "設定が更新されました。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "サポート設定が更新されました。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "サポートフィードバック"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "配信設定が更新されました。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "パスを指定する必要があります"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Liquidsoapに問題があります。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "ソースを切断する権限がありません。"
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "この入力に接続されたソースが存在しません。"
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "ソースを切り替える権限がありません。"
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "入力されたユーザー名またはパスワードが誤っています。"
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "メールが送信できませんでした。メールサーバーの設定を確認してください。"
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "このリソースへのアクセスは許可されていません。"
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Bad Request：パスした「mode」パラメータはありません。"
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Bad Request：'mode' パラメータが無効です。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "オーディオプレイヤー"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "録音中："
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "マスターストリーム"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "ライブ配信"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "何も予約されていません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "現在の番組："
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Now Playing"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "最新バージョンを使用しています。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "新しいバージョンがあります："
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "新しいバージョンがあります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "このバージョンのサポートは終了しました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "こちらにアップグレードしてください："
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "現在のプレイリストに追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "現在のスマートブロックに追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "1個の項目を追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr " %s個の項目を追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "スマートブロックに追加できるのはトラックのみです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "タイムライン上のカーソル位置を選択して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "選択した番組へ追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "選択"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "このページを選択"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "このページを選択解除"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "全てを選択解除"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "選択した項目を削除してもよろしいですか?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "配信予約済み"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "ビットレート"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM "
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "エンコード"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "最終修正"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "最終配信日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "MIMEタイプ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "所有者"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "リプレイゲイン"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "サンプルレート"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "トラック番号"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "アップロード完了"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "ウェブサイト"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "ロード中…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "全て"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "ファイル"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "プレイリスト"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "スマートブロック"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "ウェブ配信"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "種類不明："
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "選択した項目を削除してもよろしいですか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "アップロード中…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "サーバーからデータを取得しています…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "このファイルのSoundCloud IDは以下の通りです："
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "SoundCloudへのアップロード中にエラーが発生しました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "エラーコード："
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "エラーメッセージ："
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "0より大きい半角数字で入力して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "半角数字で入力して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "yyyy-mm-ddの形で入力して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "01:22:33.4の形式で入力して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "現在ファイルをアップロードしています。%s別の画面に移行するとアップロードプロセスはキャンセルされます。%sこのページを離れますか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "メディアビルダーを開く"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "時間は01:22:33(.4)の形式で入力して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "秒数は00 (.0)の形式で入力してください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "お使いのブラウザはこのファイル形式の再生に対応していません："
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "自動生成スマート・ブロックはプレビューできません"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "次の値に制限："
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "プレイリストが保存されました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "プレイリストがシャッフルされました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "このファイルのステータスが不明です。これは、ファイルがアクセス不能な外付けドライブに存在するか、またはファイルが同期されていないディレクトリに存在する場合に起こります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "%sのリスナー視聴数：%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "1週間前に通知"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "通知しない"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Rakuten.FMを支援します"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "画像は、jpg, jpeg, png, または gif の形式にしてください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "スマート・ブロックは基準を満たし、即時にブロック・コンテンツを生成します。これにより、コンテンツをショーに追加する前にライブラリーにおいてコンテンツを編集および閲覧できます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "自動生成スマートブロックは基準の設定のみ操作できます。ブロックコンテンツは番組に追加するとすぐに生成されます。生成したコンテンツをライブラリ内で編集することはできません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Rakuten.FMがあなたの条件に一致するトラックを十分に見つけることができない場合、ご希望のブロック時間になりません。スマートブロックに同じトラックを複数回追加できるようにしたい場合は、このオプションを有効にしてください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "スマートブロックがシャッフルされました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "スマートブロックが生成されて基準が保存されました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "スマートブロックを保存しました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "処理中…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "条件を選択してください"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "以下を含む"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "以下を含まない"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "以下と一致する"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "以下と一致しない"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "以下で始まる"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "以下で終わる"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "次の値より大きい"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "次の値より小さい"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "次の範囲内"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "フォルダを選択してください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "同期するフォルダを選択"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "保存先のフォルダを変更しますか？Rakuten.FMライブラリからファイルを削除することになります！"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "メディアフォルダの管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "同期されているフォルダを削除してもよろしいですか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "このパスは現在アクセス不可能です。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "配信種別の中には追加の設定が必要なものがあります。詳細設定を行うと%sAAC+ Support%s または %sOpus Support%sが可能になります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "ストリーミングサーバーに接続しています。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "配信が切断されています。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "サーバーから情報を取得しています…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "ストリーミングサーバーに接続できません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Rakuten.FMがルータやファイアウォールで制御されている場合は、ポート転送を設定する必要があり、このフィールドの情報が不正確になる可能性があります。その場合は、DJの接続に必須の正しいホスト/ポート/マウントを示し、手動でこのフィールドを更新する必要があります。許容範囲は1024〜49151の間です。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "詳細については、 %sRakuten.FM マニュアル%sを読んで下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "このオプションをチェックしてOGGストリームのメタデータを有効にしてください（ストリームメタデータとは、トラックタイトル、アーティスト、オーディオプレーヤーに表示される名前のことです）。メタデータ情報を有効にしてOGG/ Vorbisのストリームを再生すると、VLCとmplayerはすべての曲を再生した後にストリームから切断される重大なバグを発生させます。OGGストリームを使用していて、リスナーがこれらのオーディオプレーヤーのためのサポートを必要としない場合は、このオプションを有効にして下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "このボックスにチェックを入れると、ソースが切断された時に番組ソースに自動的に切り替わります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "このボックスをクリックすると、ソースが接続された時にマスターソースに自動的に切り替わります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr " Icecastサーバーから ソースのユーザー名を要求された場合、このフィールドは空白にすることができます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "ライブ配信クライアントでユーザー名を要求されなかった場合、このフィールドはソースとなります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr " Icecast/SHOUTcastでリスナー統計を参照するためのユーザー名とパスワードです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "注意：番組の配信中にこの項目は変更できません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "結果は見つかりませんでした。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "番組と同様のセキュリティーパターンを採用します。番組を割り当てられているユーザーのみ接続することができます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "この番組に対してのみ有効なカスタム認証を指定してください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "この番組の配信回が存在しません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "注意：番組は再度リンクできません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "配信内容を同期すると、配信内容の変更が対応するすべての再配信にも反映されます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "タイムゾーンは初期設定ではステーション所在地に合わせて設定されています。タイムゾーンを変更するには、ユーザー設定からインターフェイスのタイムゾーンを変更して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "番組"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "番組内容がありません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "サーバーからデータを取得しています…"
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "この番組には予約されているコンテンツがありません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "この番組はコンテンツが足りていません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "1月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "2月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "3月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "4月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "5月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "6月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "7月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "8月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "9月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "10月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "11月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "12月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "1月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "2月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "3月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "4月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "6月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "7月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "8月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "9月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "10月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "11月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "12月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "日曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "月曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "火曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "水曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "木曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "金曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "土曜日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "火"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "水"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "木"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "金"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "土"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "番組が予約された時間より長くなった場合はカットされ、次の番組が始まります。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "現在の番組をキャンセルしますか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "配信中の番組の録音を中止しますか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "番組内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "全てのコンテンツを削除しますか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "選択した項目を削除しますか？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "開始"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "終了"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "長さ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "キューイン"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "キューアウト"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "フェードイン"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "フェードアウト"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "番組内容がありません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "ライン入力から録音"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "試聴する"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "番組外に予約することは出来ません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "1個の項目を移動"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "%s 個の項目を移動"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "保存"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "フェードの編集"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "キューの編集"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "波形表示機能はWeb Audio APIに対応するブラウザで利用できます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "全て選択"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "全て解除"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "選択した項目を削除"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "現在再生中のトラックに移動"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "配信中の番組をキャンセル"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "ライブラリを開いてコンテンツを追加・削除する"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "コンテンツの追加・削除"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "使用中"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "ディスク"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "閲覧"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "開く"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "管理者"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "プログラムマネージャー"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "ゲスト"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "ゲストは以下の操作ができます："
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "スケジュールを見る"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "番組内容を見る"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJは以下の操作ができます："
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "割り当てられた番組内容を管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "メディアファイルをインポートする"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "プレイリスト・スマートブロック・ウェブストリームを作成"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "ライブラリのコンテンツを管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "プログラムマネージャーは以下の操作が可能です："
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "番組内容の表示と管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "番組を予約する"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "ライブラリの全てのコンテンツを管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "管理者は次の操作が可能です："
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "設定を管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "ユーザー管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "同期されているフォルダを管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "サポートにフィードバックを送る"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "システムステータスを見る"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "配信レポートへ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "リスナー統計を確認"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "表示設定"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "{from}から{to}へ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "火"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "水"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "木"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "金"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "土"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "閉じる"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "時"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "分"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "完了"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "ファイルを選択"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "ファイルを追加して「アップロード開始」ボタンをクリックして下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "ステータス"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "ファイルを追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "アップロード中止"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "アップロード開始"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "ファイルを追加"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "%d/%d ファイルをアップロードしました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "こちらにファイルをドラッグしてください。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "ファイル拡張子エラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "ファイルサイズエラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "ファイルカウントのエラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Initエラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTPエラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "セキュリティエラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "エラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "入出力エラーです。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "ファイル： %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d のファイルが待機中"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "ファイル： %f, サイズ： %s, ファイルサイズ最大： %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "アップロードURLに誤りがあるか存在しません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "エラー：ファイルサイズが大きすぎます。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "エラー：ファイル拡張子が無効です。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "初期設定として保存"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "エントリーを作成"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "配信履歴を編集"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "番組はありません。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s 列の%s をクリップボードにコピー しました。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%s印刷用表示%sお使いのブラウザの印刷機能を使用してこの表を印刷してください。印刷が完了したらEscボタンを押して下さい。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "カーソルを選択"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "カーソルを削除"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "番組が存在しません。"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "%sの再配信：%s　%s時"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "カーソルを選択"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "カーソルを削除"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "番組が存在しません。"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "ユーザーの追加に成功しました。"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "ユーザーの更新に成功しました。"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "設定の更新に成功しました。"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "無題のウェブ配信"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "ウェブ配信が保存されました。"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "入力欄に無効な値があります。"
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "%s年は、1753 - 9999の範囲内である必要があります。"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%sは正しい日付ではありません。"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%sは正しい時間ではありません。"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "ライブ配信"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "再生"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "停止"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "キューインの設定"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "キューアウトの設定"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "カーソル"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "共有"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "配信先の選択："
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "ミュート"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "ミュート解除"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Rakuten.FMについて"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "より詳細なヘルプは、%sユーザーマニュアル%sをお読み下さい。 "
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "配信履歴"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "配信レポート"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "トラック別レポート"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "番組別レポート"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "スマート・ブロックの拡張"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "自動生成スマート・ブロックを拡張する"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "名前："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "説明："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "長さ："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "プレイリストのシャッフル"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "シャッフル"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "プレイリスト クロスフェード"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "プレイリストを空にする。"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "クリア"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "フェードイン："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "フェードアウト："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "プレイリストを保存"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "プレイリストが開かれていません。"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "波形の表示"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t) "
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "キューイン："
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "例：01:22:33.4"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "キューアウト："
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "オリジナルの長さ："
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "配信設定"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB "
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "ログイン"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "新しいパスワード"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "下記のフィールドに新しいパスワードを入力し確認して下さい。"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "ユーザー管理"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "ユーザー追加"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id "
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "ユーザー名"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "名"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "姓"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "ユーザー種別"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "番組を探す"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "番組配信回の選択"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "検索"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "再配信日："
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "削除"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "追加"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "番組ソース"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Rakuten.FMに登録"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(必須)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "（確認目的の為だけであり、公開はされません。） "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "注意：大きさが600x600以上の場合はサイズが変更されます。"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "送信中のものを表示"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "利用規約"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "日付選択： "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "or"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "and"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "～"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "件の条件を満たすファイルがありました。"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "絞り込み履歴"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "（ステーションを宣伝するためには、「サポートフィードバックを送信する」の設定をオンにしておく必要があります。）"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "配信"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "詳細設定"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "以下の情報はリスナーが利用するプレイヤー上に表示されます。"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "（あなたのラジオステーションウェブサイト）"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "配信先URL："
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "フォルダ選択"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "設定"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "現在のインポートフォルダ"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "同期ディレクトリを削除する"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "いかなるメディアフォルダも見ていません"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "マスターソース"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloudの設定"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "この番組を追加"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "番組を更新"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "番組内容"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "番組配信時間"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "ライブ配信の入力"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "DJ"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "スタイル"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "ディスク容量"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "ファイルをインポート中…"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "詳細検索"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "タイトル："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "アーティスト："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "アルバム："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "トラック："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "時間："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "サンプルレート："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "ビットレート："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "ムード："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "ジャンル："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "年："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "ラベル："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "作曲者"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "コンダクター："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "著作権："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC番号："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "ウェブサイト："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "言語："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "ファイルの場所： "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "ウェブ配信"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "自動生成スマート・ブロック"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "スマート・ブロック"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "オーディオトラック"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "プレイリストの内容："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "スマート・ブロックの内容："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "自動生成スマート・ブロックの基準："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "次の値に制限する："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL："
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "試用期間終了まで："
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "日"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "前の曲："
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "次の曲："
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "配信ソース"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "試聴"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "ログアウト"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "配信レポートテンプレート"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "新規テンプレート作成"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "テンプレートはありません。"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "トラック別レポートテンプレート"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "新規テンプレート作成"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "テンプレートはありません。"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "トラック別レポートテンプレート作成"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "配信レポートテンプレートの作成"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "名前"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "さらに要素を追加"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "あたしいフィールドの追加"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "初期設定テンプレートを作成"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "説明"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "配信元URL："
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "ウェブ配信の長さ（初期値）："
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "ウェブ配信がありません。"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "ヘルプ"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "ページが見つかりませんでした。"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "お探しのページは存在しないようです。"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "前"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "再生"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "一時停止"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "次"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "停止"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "最大音量"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "アップデートが必要です。"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "メディアを再生するためには、お使いのブラウザを最新のバージョンにアップデートするか、%sフラッシュプラグイン%sをアップデートする必要があります。"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "開始日："
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2504,6 @@ msgstr "開始日："
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "使用できない文字が入力されました。"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "終了日："
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "全ての番組："
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "ユーザーを検索："
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJ："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "ステーション名"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "電話："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "メール："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "ステーションのウェブサイト："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "国："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "市："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "ステーションの説明："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "ステーションロゴ："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "プライバシーポリシーに同意する必要があります。"
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "ライン入力から録音"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "再配信"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "値を入力してください"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%'は無効なEメールアドレスです。local-part@hostnameの形式に沿ったEメールアドレスを登録してください。"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%'は、'%format%'の日付形式に一致しません。"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%'は、%min%文字より短くなっています。"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%'は、%max%文字を越えています。"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%'は、'%min%'以上'%max%'以下の条件に一致しません。"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "パスワードが一致しません。"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2520,55 @@ msgstr "時間を指定する必要があります。"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "再配信するには、1時間以上待たなければなりません"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "パスワードをリセット"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "無題の番組"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC番号："
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "クロスフェードの時間（初期値）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "デフォルトフェードイン（初期値）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "デフォルトフェードアウト（初期値）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "無効"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "有効"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "ステーションのタイムゾーン"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "週の開始曜日"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "ユーザー名："
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "パスワード："
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "確認用パスワード："
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "名："
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "姓："
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "携帯電話："
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype："
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber："
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "ユーザー種別："
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "ログイン名はすでに使用されています。"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "インポートフォルダ："
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "同期フォルダ："
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "正しいディレクトリではありません。"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "ライセンス（初期値）："
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "All rights are reserved"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "The work is in the public domain"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "インターフェイスのタイムゾーン："
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "基準を選択してください"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "ビットレート (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "サンプリング周波数 (kHz) "
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "時間"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "分"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "項目"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "スマート･ブロック"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "自動生成スマート・ブロック"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "プレイリストコンテンツを生成し、基準を保存"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "生成"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "プレイリストの内容をシャッフル"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "制限は空欄または0以下には設定できません。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "制限は24時間以内に設定してください。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "値は整数である必要があります。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "設定できるアイテムの最大数は500です。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "「基準」と「条件」を選択してください。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "「長さ」は、'00:00:00'の形式で入力してください。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "値はタイムスタンプの形式に適合する必要があります。 (例: 0000-00-00 or 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "値は数字である必要があります。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "値は2147483648未満にする必要があります。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "値は%s未満にする必要があります。"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "値を入力してください。"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbisメタデータ"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "配信表示設定："
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "アーティスト - タイトル"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "番組 - アーティスト - タイトル"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "ステーション名 - 番組名"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "オフエアーメタデータ"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "リプレイゲインを有効化"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "リプレイゲイン調整"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "パスワード"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "新しいパスワードを確認してください。"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "パスワード確認がパスワードと一致しません。"
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "有効："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "配信種別："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "サービスタイプ："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "再生方式"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - モノラル"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - ステレオ"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "サーバー"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "ポート"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "数値で入力してください。"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "マウントポイント"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "管理者"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "管理者パスワード"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "サーバーを入力してください。"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "ポートを入力してください。"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Icecastサーバーを使用する際はマウント欄を入力してください。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%'は、'01:22'の形式に適合していません"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "タイムゾーン："
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "定期番組に設定"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "過去の日付に番組は作成できません。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "すでに開始されている番組の開始日、開始時間を変更することはできません。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "終了日時は過去に設定できません。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "0分以下の長さに設定することはできません。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "00h 00mの長さに設定することはできません。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "24時間を越える長さに設定することはできません。"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "カスタム認証を使用："
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "カスタムユーザー名"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "カスタムパスワード"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "ユーザー名を入力してください。"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "パスワードを入力してください。"
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "背景色："
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "文字色："
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "下記画像の中に見える文字を入力してください。"
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "日"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2614,12 @@ msgstr "毎月特定日"
 msgid "day of the week"
 msgstr "毎月特定曜日"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "終了日："
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "無期限"
@@ -3878,115 +2632,1174 @@ msgstr "終了日は開始日より後に設定してください。"
 msgid "Please select a repeat day"
 msgstr "繰り返す日を選択してください"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "ライン入力から録音"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "再配信"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "背景色："
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "文字色："
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "カレンダー"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "削除"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "ユーザー"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "名前："
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "配信設定"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "無題の番組"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "ジャンル："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "説明："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "リスナー統計"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%'は、'01:22'の形式に適合していません"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "配信履歴のテンプレート"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "長さ："
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "タイムゾーン："
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "定期番組に設定"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "過去の日付に番組は作成できません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "すでに開始されている番組の開始日、開始時間を変更することはできません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "終了日時は過去に設定できません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "0分以下の長さに設定することはできません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "00h 00mの長さに設定することはできません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "24時間を越える長さに設定することはできません。"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "番組を重複して予約することはできません。"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "ユーザーを検索："
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJ："
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "ユーザー名："
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "パスワード："
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "確認用パスワード："
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "名："
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "姓："
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "メール："
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "携帯電話："
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype："
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber："
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "ユーザー種別："
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "ログイン名はすでに使用されています。"
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "はじめに"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "ユーザーマニュアル"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "値を入力してください"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "開始日："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "タイトル："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "アーティスト："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "アルバム："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "年："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "ラベル："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "作曲者"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "コンダクター："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "ムード："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "著作権："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC番号："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "ウェブサイト："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "言語："
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "開始時間"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "終了時間"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "インターフェイスのタイムゾーン："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "ステーション名"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "ステーションロゴ："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "注意：大きさが600x600以上の場合はサイズが変更されます。"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "クロスフェードの時間（初期値）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "デフォルトフェードイン（初期値）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "デフォルトフェードアウト（初期値）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "無効"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "有効"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "ステーションのタイムゾーン"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "週の開始曜日"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%'は無効なEメールアドレスです。local-part@hostnameの形式に沿ったEメールアドレスを登録してください。"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%'は、'%format%'の日付形式に一致しません。"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%'は、%min%文字より短くなっています。"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%'は、%max%文字を越えています。"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%'は、'%min%'以上'%max%'以下の条件に一致しません。"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "パスワードが一致しません。"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "数値で入力してください。"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "ログイン"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "下記画像の中に見える文字を入力してください。"
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "パスワード"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "新しいパスワードを確認してください。"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "パスワード確認がパスワードと一致しません。"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "ユーザー名"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "パスワードをリセット"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "電話："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "ステーションのウェブサイト："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "国："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "市："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "ステーションの説明："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "プライバシーポリシーに同意する必要があります。"
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "全ての番組："
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "基準を選択してください"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "ビットレート (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "説明"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "サンプリング周波数 (kHz) "
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "時間"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "分"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "項目"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "スマート･ブロック"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "自動生成スマート・ブロック"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "プレイリストコンテンツを生成し、基準を保存"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "生成"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "プレイリストの内容をシャッフル"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "シャッフル"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "制限は空欄または0以下には設定できません。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "制限は24時間以内に設定してください。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "値は整数である必要があります。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "設定できるアイテムの最大数は500です。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "「基準」と「条件」を選択してください。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "「長さ」は、'00:00:00'の形式で入力してください。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "値はタイムスタンプの形式に適合する必要があります。 (例: 0000-00-00 or 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "値は数字である必要があります。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "値は2147483648未満にする必要があります。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "値は%s未満にする必要があります。"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "値を入力してください。"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "ライセンス（初期値）："
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "All rights are reserved"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "The work is in the public domain"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbisメタデータ"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "配信表示設定："
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "アーティスト - タイトル"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "番組 - アーティスト - タイトル"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "ステーション名 - 番組名"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "オフエアーメタデータ"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "リプレイゲインを有効化"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "リプレイゲイン調整"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "有効："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "配信種別："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "ビットレート："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "サービスタイプ："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "再生方式"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - モノラル"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - ステレオ"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "サーバー"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "ポート"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "名前"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "マウントポイント"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "管理者"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "管理者パスワード"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "サーバーを入力してください。"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "ポートを入力してください。"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Icecastサーバーを使用する際はマウント欄を入力してください。"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "インポートフォルダ："
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "同期フォルダ："
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "正しいディレクトリではありません。"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "再生"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "停止"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "キューインの設定"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "キューアウトの設定"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "カーソル"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "ライブ配信"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "キューインとキューアウトが設定されていません。"
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "キューアウトはファイルの長さより長く設定できません。"
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "キューインをキューアウトより大きく設定することはできません。"
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "キューアウトをキューインより小さく設定することはできません。"
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "%sの再配信%sから"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "国の選択"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3824,12 @@ msgstr "%sは有効なディレクトリではありません。"
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%sはすでに保存ディレクトリまたは同期フォルダに設定されています。"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%sはすでに保存ディレクトリまたは同期フォルダに設定されています。"
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3837,18 @@ msgstr "%sはすでに保存ディレクトリまたは同期フォルダに設�
 msgid "%s doesn't exist in the watched list."
 msgstr "%sは同期リストの中に存在しません。"
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "国の選択"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "番組は最大24時間まで設定可能です。"
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "番組を重複して予約することはできません。\n注意：再配信番組のサイズ変更は全ての再配信に反映されます。"
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3863,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "参照中のスケジュールは有効ではありません。"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "参照中のスケジュールは有効ではありません。"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "番組を%sに予約することはできません。"
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "録音中の番組にファイルを追加することはできません。"
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "番組 %s は終了しておりスケジュールに入れることができません。"
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "番組 %s は以前に更新されています。"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "同期された配信内容を配信中に変更することはできません。"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "選択したファイルは存在しません。"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "番組は最大24時間まで設定可能です。"
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"番組を重複して予約することはできません。\n"
+"注意：再配信番組のサイズ変更は全ての再配信に反映されます。"
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "%sの再配信%sから"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3963,1049 @@ msgstr "無効なウェブ配信です。"
 msgid "Unrecognized stream type: %s"
 msgstr "不明な配信種別です： %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "録音ファイルは存在しません。"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "録音ファイルのメタデータを確認"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "編集"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "番組の編集"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "許可されていない操作です。"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "定期配信している番組を移動することはできません。"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "過去の番組を移動することはできません。"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "番組を過去の日付に移動することはできません。"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "録音された番組を再配信時間の直前1時間の枠に移動することはできません。"
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "録音された番組が存在しないので番組は削除されました。"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "再配信には１時間待たなければなりません。"
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "トラック"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "再生済み"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "前"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "再生"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "一時停止"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "次"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "停止"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "ミュート"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "ミュート解除"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "最大音量"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "アップデートが必要です。"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "メディアを再生するためには、お使いのブラウザを最新のバージョンにアップデートするか、%sフラッシュプラグイン%sをアップデートする必要があります。"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Rakuten.FMについて"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "より詳細なヘルプは、%sユーザーマニュアル%sをお読み下さい。 "
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "共有"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "配信先の選択："
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "ページが見つかりませんでした。"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "お探しのページは存在しないようです。"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "番組ソース"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "日付選択： "
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "追加"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "再配信日："
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "絞り込み履歴"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "番組配信回の選択"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "検索"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloudの設定"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "マスターソース"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "フォルダ選択"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "設定"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "現在のインポートフォルダ"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "同期ディレクトリを削除する"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "いかなるメディアフォルダも見ていません"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Rakuten.FMに登録"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(必須)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "（確認目的の為だけであり、公開はされません。） "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "送信中のものを表示"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "利用規約"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "番組を探す"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "or"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "and"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "～"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "件の条件を満たすファイルがありました。"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "配信"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "詳細設定"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "以下の情報はリスナーが利用するプレイヤー上に表示されます。"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "（あなたのラジオステーションウェブサイト）"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "配信先URL："
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "（ステーションを宣伝するためには、「サポートフィードバックを送信する」の設定をオンにしておく必要があります。）"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "トラック："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "時間："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "サンプルレート："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC番号："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "ファイルの場所： "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "ウェブ配信"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "自動生成スマート・ブロック"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "スマート・ブロック"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "オーディオトラック"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "プレイリストの内容："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "スマート・ブロックの内容："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "自動生成スマート・ブロックの基準："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "次の値に制限する："
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "ファイルをインポート中…"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "詳細検索"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "新しいパスワード"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "下記のフィールドに新しいパスワードを入力し確認して下さい。"
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "前の曲："
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "次の曲："
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "配信ソース"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "試聴"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "ログアウト"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "試用期間終了まで："
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "プレイリストのシャッフル"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "プレイリスト クロスフェード"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "プレイリストを空にする。"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "クリア"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "フェードアウト："
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "プレイリストを保存"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "プレイリストが開かれていません。"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "波形の表示"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "キューイン："
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "例：01:22:33.4"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "キューアウト："
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "オリジナルの長さ："
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t) "
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "フェードイン："
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "スマート・ブロックの拡張"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "自動生成スマート・ブロックを拡張する"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "配信レポート"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "トラック別レポート"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "番組別レポート"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "配信レポートテンプレート"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "新規テンプレート作成"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "テンプレートはありません。"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "トラック別レポートテンプレート"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "新規テンプレート作成"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "テンプレートはありません。"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "トラック別レポートテンプレート作成"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "配信レポートテンプレートの作成"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "さらに要素を追加"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "あたしいフィールドの追加"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "初期設定テンプレートを作成"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "配信設定"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB "
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "この番組を追加"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "番組を更新"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "番組内容"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "番組配信時間"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "ライブ配信の入力"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "DJ"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "スタイル"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "ディスク容量"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "ユーザー管理"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "ユーザー追加"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id "
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "名"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "姓"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "ユーザー種別"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "配信元URL："
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "ウェブ配信の長さ（初期値）："
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "ウェブ配信がありません。"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "秒数は00 (.0)の形式で入力してください。"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "同期された配信内容を配信中に変更することはできません。"

--- a/airtime_mvc/locale/ja/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/ja/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ja_JP/LC_MESSAGES/airtime.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2014-07-28 11:49+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Japanese (Japan) (http://www.transifex.com/projects/p/airtime/language/ja_JP/)\n"
@@ -14,6 +14,3947 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
+#: airtime_mvc/application/controllers/PlaylistController.php:147
+#, php-format
+msgid "%s not found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:37
+#: airtime_mvc/application/controllers/PlaylistController.php:168
+msgid "Something went wrong."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
+msgid "Preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
+msgid "Add to Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:114
+msgid "Add to Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
+msgid "Download"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:147
+msgid "View track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:148
+msgid "Update track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:155
+msgid "Duplicate Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:199
+msgid "No action available"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:219
+msgid "You don't have permission to delete selected items."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:265
+msgid "Could not delete file because it is scheduled in the future."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:268
+msgid "Could not delete file(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:308
+#, php-format
+msgid "Copy of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:53
+#, php-format
+msgid "You are viewing an older version of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:140
+msgid "You cannot add tracks to dynamic blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:161
+#, php-format
+msgid "You don't have permission to delete selected %s(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:174
+msgid "You can only add tracks to smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:192
+msgid "Untitled Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:194
+msgid "Untitled Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:521
+msgid "Unknown Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:76
+msgid "Preferences updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:141
+msgid "Support setting updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:149
+msgid "Support Feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:351
+msgid "Stream Setting Updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:399
+msgid "path should be specified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:494
+msgid "Problem with Liquidsoap..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:556
+msgid "Request method not accepted"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ScheduleController.php:380
+#, php-format
+msgid "Rebroadcast of show %s from %s at %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
+msgid "Invalid character entered"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
+msgid "Day must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
+msgid "Time must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
+msgid "Must wait at least 1 hour to rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
+#, php-format
+msgid "Use %s Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
+msgid "Use Custom Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
+msgid "Custom Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
+msgid "Custom Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
+msgid "Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
+msgid "Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
+msgid "Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
+msgid "Username field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
+msgid "Password field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:10
+msgid "Link:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:16
+msgid "Repeat Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:19
+msgid "weekly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:20
+msgid "every 2 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:21
+msgid "every 3 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:22
+msgid "every 4 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:23
+msgid "monthly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:32
+msgid "Select Days:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:47
+msgid "Repeat By:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the month"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the week"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:69
+msgid "No End?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:106
+msgid "End date must be after start date"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:113
+msgid "Please select a repeat day"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
+msgid "Cue in and cue out are null."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
+msgid "Can't set cue out to be greater than file length."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
+msgid "Can't set cue in to be larger than cue out."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
+msgid "Can't set cue out to be smaller than cue in."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:1372
+msgid "Upload Time"
+msgstr ""
+
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:160
+#, php-format
+msgid "%s is already watched."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:164
+#, php-format
+msgid "%s contains nested watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:168
+#, php-format
+msgid "%s is nested within existing watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:189
+#: airtime_mvc/application/models/MusicDir.php:370
+#, php-format
+msgid "%s is not a valid directory."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:232
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:388
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:431
+#, php-format
+msgid "%s doesn't exist in the watched list."
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:470
+#, php-format
+msgid "Powered by %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr ""
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:73
+msgid "Cannot move items out of linked shows"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:119
+msgid "The schedule you're viewing is out of date! (sched mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:124
+msgid "The schedule you're viewing is out of date! (instance mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:132
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
+msgid "The schedule you're viewing is out of date!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:143
+#, php-format
+msgid "You are not allowed to schedule show %s."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:147
+msgid "You cannot add files to recording shows."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:153
+#, php-format
+msgid "The show %s is over and cannot be scheduled."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:160
+#, php-format
+msgid "The show %s has been previously updated!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:196
+msgid "Cannot schedule a playlist that contains missing files."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
+msgid "A selected File does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:166
+msgid "Length needs to be greater than 0 minutes"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:171
+msgid "Length should be of form \"00h 00m\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:184
+msgid "URL should be of form \"http://domain\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:187
+msgid "URL should be 512 characters or less"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:193
+msgid "No MIME type found for webstream."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:209
+msgid "Webstream name cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:278
+msgid "Could not parse XSPF playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:298
+msgid "Could not parse PLS playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:318
+msgid "Could not parse M3U playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:332
+msgid "Invalid webstream - This appears to be a file download."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:336
+#, php-format
+msgid "Unrecognized stream type: %s"
+msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:50
 msgid "Record file doesn't exist"
@@ -47,24 +3988,12 @@ msgid "Edit Instance"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
 msgid "Edit"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:158
 #: airtime_mvc/application/services/CalendarService.php:172
 msgid "Edit Show"
-msgstr ""
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:194
@@ -91,13 +4020,6 @@ msgstr ""
 msgid "Can't move show into past"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr ""
-
 #: airtime_mvc/application/services/CalendarService.php:322
 msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
 msgstr ""
@@ -110,1848 +4032,55 @@ msgstr ""
 msgid "Must wait 1 hour to rebroadcast."
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr ""
-
 #: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1128
 msgid "Track"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1176
+#: airtime_mvc/application/services/HistoryService.php:1174
 msgid "Played"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
-#: airtime_mvc/application/controllers/PlaylistController.php:147
-#, php-format
-msgid "%s not found"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
-#: airtime_mvc/application/controllers/PlaylistController.php:168
-msgid "Something went wrong."
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
-msgid "Preview"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
-msgid "Add to Playlist"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
-msgid "Add to Smart Block"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
-msgid "Download"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:147
-msgid "View track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
-msgid "Duplicate Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:213
-msgid "No action available"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:233
-msgid "You don't have permission to delete selected items."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:279
-msgid "Could not delete file because it is scheduled in the future."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:282
-msgid "Could not delete file(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:322
-#, php-format
-msgid "Copy of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid "Please make sure admin user/password is correct on System->Streams page."
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:53
-#, php-format
-msgid "You are viewing an older version of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:140
-msgid "You cannot add tracks to dynamic blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:161
-#, php-format
-msgid "You don't have permission to delete selected %s(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:174
-msgid "You can only add tracks to smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:192
-msgid "Untitled Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:194
-msgid "Untitled Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:522
-msgid "Unknown Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
-msgid "Preferences updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:115
-msgid "Support setting updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:123
-msgid "Support Feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:251
-msgid "Stream Setting Updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:342
-msgid "path should be specified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:437
-msgid "Problem with Liquidsoap..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:493
-msgid "Request method not accepted"
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid "Check this box to automatically switch on Master/Show source upon source connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid "If your Icecast server expects a username of 'source', this field can be left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid "If your live streaming client does not ask for a username, this field should be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid "Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid "Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid "Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
-#, php-format
-msgid "Rebroadcast of show %s from %s at %s"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 msgid "mute"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
@@ -2012,266 +4141,94 @@ msgstr ""
 msgid "For more detailed help, read the %suser manual%s."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid "Choose some search criteria above and click Generate to create this playlist."
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid "A track list will be generated when you schedule this smart block into a show."
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
@@ -2282,42 +4239,89 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
 #, php-format
 msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
@@ -2337,9 +4341,9 @@ msgid "Click the box below to promote your station on %s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 msgid "(Required)"
 msgstr ""
 
@@ -2350,11 +4354,6 @@ msgstr ""
 msgid "(for verification purposes only, will not be published)"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
 msgid "Show me what I am sending "
 msgstr ""
@@ -2363,8 +4362,12 @@ msgstr ""
 msgid "Terms and Conditions"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
@@ -2400,19 +4403,6 @@ msgstr ""
 msgid "file meets the criteria"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
 msgid "Stream "
 msgstr ""
@@ -2433,120 +4423,24 @@ msgstr ""
 msgid "Stream URL: "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid "Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
@@ -2564,66 +4458,8 @@ msgstr ""
 msgid "Sample Rate:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
 msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
@@ -2662,13 +4498,54 @@ msgstr ""
 msgid "Limit to "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
@@ -2679,13 +4556,37 @@ msgstr ""
 msgid "Stream Data Collection Status"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
@@ -2710,6 +4611,123 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
 msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
@@ -2748,11 +4766,6 @@ msgstr ""
 msgid "Creating Log Sheet Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
 msgid "Add more elements"
 msgstr ""
@@ -2765,9 +4778,207 @@ msgstr ""
 msgid "Set Default Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
@@ -2782,1256 +4993,6 @@ msgstr ""
 msgid "No webstream"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
-msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid "'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
-msgid "Day must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
-msgid "Time must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
-msgid "Must wait at least 1 hour to rebroadcast"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
-#, php-format
-msgid "Use %s Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
-msgid "Use Custom Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
-msgid "Custom Username"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
-msgid "Custom Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
-msgid "Host:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
-msgid "Port:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
-msgid "Mount:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
-msgid "Username field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
-msgid "Password field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:10
-msgid "Link:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:16
-msgid "Repeat Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:19
-msgid "weekly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:20
-msgid "every 2 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:21
-msgid "every 3 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:22
-msgid "every 4 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:23
-msgid "monthly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:32
-msgid "Select Days:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:47
-msgid "Repeat By:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the month"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the week"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:69
-msgid "No End?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:106
-msgid "End date must be after start date"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:113
-msgid "Please select a repeat day"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
-msgid "Cue in and cue out are null."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
-msgid "Can't set cue out to be greater than file length."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
-msgid "Can't set cue in to be larger than cue out."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
-msgid "Can't set cue out to be smaller than cue in."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:1366
-msgid "Upload Time"
-msgstr ""
-
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:160
-#, php-format
-msgid "%s is already watched."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:164
-#, php-format
-msgid "%s contains nested watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:168
-#, php-format
-msgid "%s is nested within existing watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:189
-#: airtime_mvc/application/models/MusicDir.php:370
-#, php-format
-msgid "%s is not a valid directory."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:232
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:388
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:431
-#, php-format
-msgid "%s doesn't exist in the watched list."
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:33
-#, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:73
-msgid "Cannot move items out of linked shows"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:119
-msgid "The schedule you're viewing is out of date! (sched mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:124
-msgid "The schedule you're viewing is out of date! (instance mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
-msgid "The schedule you're viewing is out of date!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:142
-#, php-format
-msgid "You are not allowed to schedule show %s."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:146
-msgid "You cannot add files to recording shows."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:152
-#, php-format
-msgid "The show %s is over and cannot be scheduled."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:159
-#, php-format
-msgid "The show %s has been previously updated!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:195
-msgid "Cannot schedule a playlist that contains missing files."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
-msgid "A selected File does not exist!"
-msgstr ""
-
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:166
-msgid "Length needs to be greater than 0 minutes"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:171
-msgid "Length should be of form \"00h 00m\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:184
-msgid "URL should be of form \"http://domain\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:187
-msgid "URL should be 512 characters or less"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:193
-msgid "No MIME type found for webstream."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:209
-msgid "Webstream name cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:278
-msgid "Could not parse XSPF playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:298
-msgid "Could not parse PLS playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:318
-msgid "Could not parse M3U playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:332
-msgid "Invalid webstream - This appears to be a file download."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:336
-#, php-format
-msgid "Unrecognized stream type: %s"
-msgstr ""
-
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
 msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/ja_JP/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/ja_JP/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ka/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Georgian (http://www.transifex.com/sourcefabric/airtime/language/ka/)\n"
+"Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ka\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/ka/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/ka/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ko_KR/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Sourcefabric <contact@sourcefabric.org>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Korean (Korea) (http://www.transifex.com/sourcefabric/airtime/language/ko_KR/)\n"
+"Language: ko_KR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ko_KR\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "년도 값은 %s 1753 - 9999 입니다"
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s는 맞지 않는 날짜 입니다"
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s는 맞지 않는 시간 입니다"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "녹음된 파일의 메타데이타 보기"
-
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "수정"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "쇼 수정"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "삭제"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "스케쥴"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "계정"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "스트림"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "상태"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "방송 기록"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "청취자 통계"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "도움"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "초보자 가이드"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "사용자 메뉴얼"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
 msgstr "권한이 부족합니다"
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "반복쇼는 드래그 앤 드롭 할수 없습니다"
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "권한이 부족합니다"
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "지난 쇼는 이동할수 없습니다"
-
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "과거로 쇼를 이동할수 없습니다"
-
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "쇼를 중복되게 스케쥴할수 없습니다"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "녹화 쇼를 재방송 시작 1시간 안으로 이동할수 없습니다"
-
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "녹화 쇼가 없으로 쇼가 삭제 되었습니다"
-
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "녹화 쇼와 재방송 사이에는 1시간의 간격이 필요합니다 "
-
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "제목"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "제작자"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "앨범"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "길이"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "장르"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "무드"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "레이블"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "작곡가"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "저작권"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "년도"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "지휘자"
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "언어"
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "소스를 끊을수 있는 권한이 부족합니다"
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "연결된 소스가 없습니다"
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "소스를 바꿀수 있는 권한이 부족합니다"
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "방송됨"
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s를 찾을수 없습니다"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "알수없는 에러."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "프리뷰"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "재생 목록에 추가"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "스마트 블록에 추가"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "메타데이타 수정"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "삭제"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "다운로드"
 
@@ -276,81 +890,1500 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "중복된 플레이 리스트"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "액션 없음"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "선택된 아이템을 지울수 있는 권한이 부족합니다."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "%s의 사본"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "제목없는 웹스트림"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "웹스트림이 저장 되었습니다"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "잘못된 값입니다"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "시스템->스트림 에서 관리자 아이디/암호를 다시 확인하세요."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "사용자가 추가 되었습니다!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "오디오 플레이어"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "사용자 정보가 업데이트 되었습니다!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "세팅이 성공적으로 업데이트 되었습니다!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "녹음:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "마스터 스트림"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "라이브 스트림"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "스케쥴 없음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "현재 쇼:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "현재"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "최신 버전입니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "새 버젼이 있습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "지금 사용중인 버전은 조만간 지원 하지 않을것입니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "지금 사용중인 버전은 더 이상 지원 되지 않습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "새 버전으로 업그래이드 "
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "현제 플레이리스트에 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "현제 스마트 블록에 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "아이템 1개 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "아이템 %s개 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "스마트 블록에는 파일만 추가 가능합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "재생 몰록에는 파일, 스마트 블록, 웹스트림만 추가 가능합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "타임 라인에서 커서를 먼져 선택 하여 주세요."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "메타데이타 수정"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "선택된 쇼에 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "현재 페이지 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "현재 페이지 선택 취소 "
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "모두 선택 취소"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "선택된 아이템들을 모두 지우시겠습니다?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "스케쥴됨"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "제목"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "제작자"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "앨범"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "비트 레이트"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "작곡가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "지휘자"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "저작권"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "장르"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "레이블"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "언어"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "마지막 수정일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "마지막 방송일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "길이"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "무드"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "소유자"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "리플레이 게인"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "샘플 레이트"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "트랙 번호"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "업로드 날짜"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "웹싸이트"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "년도"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "로딩..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "전체"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "파일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "재생 목록"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "스마트 블록"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "웹스트림"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "알수 없는 유형:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "선택된 아이템을 모두 삭제 하시겠습니까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "업로딩중..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "서버에서 정보를 가져오는중..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "파일의 SoundCloud 아이디:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "SoundCloud에 업로딩중 에러가 발생했습니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "에러 코드: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "에러 메세지: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "이 값은 0보다 큰 숫자만 허용 됩니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "이 값은 숫자만 허용합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "yyyy-mm-dd의 형태로 입력해주세요"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "hh:mm:ss.t의 형태로 입력해주세요"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "현재 파일이 업로드 중입니다. %s다른 화면으로 이동하면 현재까지 업로드한 프로세스가 취소됩니다. %s이동하겠습니까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "미디아 빌더 열기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "'00:00:00 (.0)' 형태로 입력해주세요"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "현재 사용중인 브라우저에선 이 파일을 play할수 없습니다: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "동적인 스마트 블록은 프리뷰 할수 없습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "길이 제한: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "재생 목록이 저장 되었습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "플레이 리스트가 셔플 되었습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime이 파일에 대해 정확히 알수 없습니다. 이 경우는 파일이 접근할수 없는 리모트 드라이브에 있거나, 파일이 있는 폴더가 더이상 모니터 되지 않을때 일어날수 있습니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "%s의청취자 숫자 : %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "1주후에 다시 알림"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "이 창을 다시 표시 하지 않음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Airtime 도와주기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "허용된 이미지 파일 타입은 jpg, jpeg, png 또는 gif 입니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "정적 스마트 블록은 크라이테리아를 저장하고 내용을 생성 합니다. 그러므로 쇼에 추가 하기전에 내용을 수정하실수 있습니다 "
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "동적 스마트 블록은 크라이테리아만 저장하고 내용은 쇼에 추가 할때까지 생성하지 않습니다. 이는 동적 스마트 블록을 쇼에 추가 할때마다 다른 내용을 추가하게 됩니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "블록 생성시 충분한 파일을 찾지 못하면, 블록 길이가 원하는 길이보다 짧아 질수 있습니다. 이 옵션을 선택하시면,Airtime이 트랙을 반복적으로 사용하여 길이를 채웁니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "스마트 블록이 셔플 되었습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "스마트 블록이 생성 되고 크라이테리아가 저장 되었습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "스마트 블록이 저장 되었습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "진행중..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "모디파이어 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "다음을 포합"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "다음을 포함하지 않는"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "다음과 같음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "다음과 같지 않음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "다음으로 시작"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "다음으로 끝남"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "다음 보다 큰"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "다음 보타 작은"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "다음 범위 안에 있는 "
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "저장 폴더 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "모니터 폴더 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr "저장 폴더를 수정하길 원하십니까? 수정시 모든 파일이 라이브러리에서 사라집니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "미디어 폴더 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "선택하신 폴더를 모니터 리스트에서 삭제 하시겠습ㄴ지까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "경로에 접근할수 없습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "어떤 스트림은 추가 설정이 필요합니다. %sAAC+ 지원%s 또는 %sOpus 지원%s 설명"
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "스트리밍 서버에 접속됨"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "스트림이 사용되지 않음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "서버에서 정보를 받는중..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "스트리밍 서버에 접속 할수 없음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Airtime이 방화벽 뒤에 설치 되었다면, 포트 포워딩을 설정해야 할수도 있습니다. 이 경우엔  자동으로 생성된 이 정보가 틀릴수 있습니다. 수동적으로 이 필드를 수정하여 DJ들이 접속해야 하는서버/마운트/포트 등을 공지 하십시오. 포트 범위는 1024~49151 입니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "더 자세한 정보는 %sAirtime Manual%s에서 찾으실수 있습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "OGG 스트림의 메타데이타를 사용하고 싶으시면, 이 옵션을 체크 해주세요. VLC나 mplayer 같은 플래이어들에서 버그가 발견되어 OGG 스트림을 메타데이타와 함꼐 사용시, 각 파일 종료시 스트림을 끊어버립니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "마스터/쇼 소스가 끊어졌을때 자동으로 스위치를 끔."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "마스터/쇼 소스가 접속 되었을때 자동으로 스위를 켬."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Icecast 서버 인증 아이디가 source로 설정이 되어있다면, 이 필드는 입렵 하실필요 없습니다."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "현재 사용중이신 라이브 스트리밍 클라이언트에 사용자 필드가 없다면, 이 필드에 'source'라고 입력 해주세요."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "관리자 아이디/암호는 Icecast와 SHOUTcast에서 청취자 통계를 얻기 위해 필요합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "결과 없음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "쇼에 지정된 사람들만 접속 할수 있습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "커스텁 인증을 설정하시면, 아무나 그걸 사용하여 해당 쇼에 접속 가능합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "쇼 인스턴스가 존재 하지 않습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "주의: 쇼는 다시 링크 될수 없습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "반복 되는 쇼를 링크하면, 반복 쇼에 스케쥴된 아이템들이 다른 반복 쇼에도 스케쥴이 됩니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "쇼"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "쇼가 비어 있습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "서버로부터 데이타를 불러오는중..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "내용이 없는 쇼입니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "쇼가 완전히 채워지지 않았습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "1월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "2월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "3월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "4월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "5월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "6월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "7월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "8월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "9월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "10월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "11월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "12월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "1월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "2월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "3월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "4월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "6월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "7월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "8월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "9월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "10월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "11월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "12월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "일요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "월요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "화요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "수요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "목요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "금요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "토요일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "화"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "수"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "목"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "금"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "토"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "쇼가 자신의 길이보다 더 길게 스케쥴 되었다면, 쇼 길이에 맞게 짤라지며, 다음 쇼가 시작 됩니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "현재 방송중인 쇼를 중단 하시겠습니까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "현재 녹음 중인 쇼를 중단 하시겠습니까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "확인"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "쇼 내용"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "모든 내용물 삭제하시겠습까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "선택한 아이템을 삭제 하시겠습니까?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "시작"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "종료"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "길이"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "큐 인"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "큐 아웃"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "페이드 인"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "패이드 아웃"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "내용 없음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "라인 인으로 부터 녹음"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "트랙 프리뷰"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "쇼 범위 밖에 스케쥴 할수 없습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "아이템 1개 이동"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "아이템 %s개 이동"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "저장"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "취소"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "페이드 에디터"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "큐 에디터"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "웨이브 폼 기능은 Web Audio API를 지원하면 브라우저에서만 사용 가능합니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "전체 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "전체 선택 취소"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "선택된 아이템 제거"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "현재 방송중인 트랙으로 가기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "현재 쇼 취소"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "라이브러리 열기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "내용 추가/제거"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "사용중"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "디스크"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "경로"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "열기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "관리자"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "프로그램 매니저"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "손님"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "손님의 권한:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "스케쥴 보기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "쇼 내용 보기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJ의 권한:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "할당된 쇼의 내용 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "미디아 파일 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "플레이 리스트, 스마트 블록, 웹스트림 생성"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "자신의 라이브러리 내용 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "프로그램 매니저의 권한:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "쇼 내용 보기및 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "쇼 스케쥴 하기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "모든 라이브러리 내용 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "관리자의 권한:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "설정 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "사용자 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "모니터 폴터 관리"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "사용자 피드백을 보냄"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "이시스템 상황 보기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "방송 기록 접근 권한"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "청취자 통계 보기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "컬럼 보이기/숨기기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "<span style='display:inline-block;width:31px'>&nbsp;</span>{from}부터 {to}까지"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "일"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "월"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "화"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "수"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "목"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "금"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "토"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "닫기"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "시"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "분"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "확인"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "파일 선택"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "업로드를 원하는 파일을 선택하신후 시작 버틑을 눌러주세요."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "파일 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "업로드 중지"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "업로드 시작"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "파일 추가"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "%d/%d 파일이 업로드됨"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "파일을 여기로 드래그 앤 드랍 하세요"
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "파일 확장자 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "파일 크기 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "파일 갯수 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "초기화 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "보안 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "일반적인 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO 에러."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "파일: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d개의 파일이 대기중"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "파일: %f, 크기: %s, 최대 파일 크기: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "업로드 URL이 맞지 않거나 존재 하지 않습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "에러: 파일이 너무 큽니다:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "에러: 지원하지 않는 확장자:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s row %s를 클립보드로 복사 하였습니다"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%s프린트를 하려면 브라우저의 프린트 기능을 사용하여주세요. 종료를 원하시면 ESC키를 누르세요"
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "이메일을 전송 할수 없습니다. 메일 서버 세팅을 다시 확인 하여 주세요"
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "아이디와 암호가 맞지 않습니다. 다시 시도해주세요"
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -370,11 +2403,6 @@ msgstr "선택하신 %s를 삭제 할수 있는 권한이 부족합니다."
 msgid "You can only add tracks to smart block."
 msgstr "스마트 블록에는 트랙만 추가 가능합니다"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "재생 몰록에는 파일, 스마트 블록, 웹스트림만 추가 가능합니다"
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "제목없는 재생목록"
@@ -383,2627 +2411,88 @@ msgstr "제목없는 재생목록"
 msgid "Untitled Smart Block"
 msgstr "제목없는 스마트 블록"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "모르는 재생목록"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "권한이 부족합니다"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "설정이 업데이트 되었습니다"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "지원 설정이 업데이트 되었습니다"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "사용자 피드백"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "스트림 설정이 업데이트 되었습니다"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "경로를 입력해주세요"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Liquidsoap 문제..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "소스를 끊을수 있는 권한이 부족합니다"
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "연결된 소스가 없습니다"
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "소스를 바꿀수 있는 권한이 부족합니다"
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "아이디와 암호가 맞지 않습니다. 다시 시도해주세요"
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "이메일을 전송 할수 없습니다. 메일 서버 세팅을 다시 확인 하여 주세요"
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "권한이 부족합니다"
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "오디오 플레이어"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "녹음:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "마스터 스트림"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "라이브 스트림"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "스케쥴 없음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "현재 쇼:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "현재"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "최신 버전입니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "새 버젼이 있습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "지금 사용중인 버전은 조만간 지원 하지 않을것입니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "지금 사용중인 버전은 더 이상 지원 되지 않습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "새 버전으로 업그래이드 "
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "현제 플레이리스트에 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "현제 스마트 블록에 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "아이템 1개 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "아이템 %s개 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "스마트 블록에는 파일만 추가 가능합니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "타임 라인에서 커서를 먼져 선택 하여 주세요."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "선택된 쇼에 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "현재 페이지 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "현재 페이지 선택 취소 "
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "모두 선택 취소"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "선택된 아이템들을 모두 지우시겠습니다?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "스케쥴됨"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "비트 레이트"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "마지막 수정일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "마지막 방송일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "소유자"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "리플레이 게인"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "샘플 레이트"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "트랙 번호"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "업로드 날짜"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "웹싸이트"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "로딩..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "전체"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "파일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "재생 목록"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "스마트 블록"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "웹스트림"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "알수 없는 유형:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "선택된 아이템을 모두 삭제 하시겠습니까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "업로딩중..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "서버에서 정보를 가져오는중..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "파일의 SoundCloud 아이디:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "SoundCloud에 업로딩중 에러가 발생했습니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "에러 코드: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "에러 메세지: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "이 값은 0보다 큰 숫자만 허용 됩니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "이 값은 숫자만 허용합니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "yyyy-mm-dd의 형태로 입력해주세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "hh:mm:ss.t의 형태로 입력해주세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "현재 파일이 업로드 중입니다. %s다른 화면으로 이동하면 현재까지 업로드한 프로세스가 취소됩니다. %s이동하겠습니까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "미디아 빌더 열기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "'00:00:00 (.0)' 형태로 입력해주세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "초단위 '00 (.0)'로 입력해주세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "현재 사용중인 브라우저에선 이 파일을 play할수 없습니다: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "동적인 스마트 블록은 프리뷰 할수 없습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "길이 제한: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "재생 목록이 저장 되었습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "플레이 리스트가 셔플 되었습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime이 파일에 대해 정확히 알수 없습니다. 이 경우는 파일이 접근할수 없는 리모트 드라이브에 있거나, 파일이 있는 폴더가 더이상 모니터 되지 않을때 일어날수 있습니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "%s의청취자 숫자 : %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "1주후에 다시 알림"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "이 창을 다시 표시 하지 않음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Airtime 도와주기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "허용된 이미지 파일 타입은 jpg, jpeg, png 또는 gif 입니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "정적 스마트 블록은 크라이테리아를 저장하고 내용을 생성 합니다. 그러므로 쇼에 추가 하기전에 내용을 수정하실수 있습니다 "
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "동적 스마트 블록은 크라이테리아만 저장하고 내용은 쇼에 추가 할때까지 생성하지 않습니다. 이는 동적 스마트 블록을 쇼에 추가 할때마다 다른 내용을 추가하게 됩니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "블록 생성시 충분한 파일을 찾지 못하면, 블록 길이가 원하는 길이보다 짧아 질수 있습니다. 이 옵션을 선택하시면,Airtime이 트랙을 반복적으로 사용하여 길이를 채웁니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "스마트 블록이 셔플 되었습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "스마트 블록이 생성 되고 크라이테리아가 저장 되었습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "스마트 블록이 저장 되었습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "진행중..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "모디파이어 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "다음을 포합"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "다음을 포함하지 않는"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "다음과 같음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "다음과 같지 않음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "다음으로 시작"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "다음으로 끝남"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "다음 보다 큰"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "다음 보타 작은"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "다음 범위 안에 있는 "
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "저장 폴더 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "모니터 폴더 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "저장 폴더를 수정하길 원하십니까? 수정시 모든 파일이 라이브러리에서 사라집니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "미디어 폴더 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "선택하신 폴더를 모니터 리스트에서 삭제 하시겠습ㄴ지까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "경로에 접근할수 없습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "어떤 스트림은 추가 설정이 필요합니다. %sAAC+ 지원%s 또는 %sOpus 지원%s 설명"
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "스트리밍 서버에 접속됨"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "스트림이 사용되지 않음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "서버에서 정보를 받는중..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "스트리밍 서버에 접속 할수 없음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Airtime이 방화벽 뒤에 설치 되었다면, 포트 포워딩을 설정해야 할수도 있습니다. 이 경우엔  자동으로 생성된 이 정보가 틀릴수 있습니다. 수동적으로 이 필드를 수정하여 DJ들이 접속해야 하는서버/마운트/포트 등을 공지 하십시오. 포트 범위는 1024~49151 입니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "더 자세한 정보는 %sAirtime Manual%s에서 찾으실수 있습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "OGG 스트림의 메타데이타를 사용하고 싶으시면, 이 옵션을 체크 해주세요. VLC나 mplayer 같은 플래이어들에서 버그가 발견되어 OGG 스트림을 메타데이타와 함꼐 사용시, 각 파일 종료시 스트림을 끊어버립니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "마스터/쇼 소스가 끊어졌을때 자동으로 스위치를 끔."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "마스터/쇼 소스가 접속 되었을때 자동으로 스위를 켬."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Icecast 서버 인증 아이디가 source로 설정이 되어있다면, 이 필드는 입렵 하실필요 없습니다."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "현재 사용중이신 라이브 스트리밍 클라이언트에 사용자 필드가 없다면, 이 필드에 'source'라고 입력 해주세요."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "관리자 아이디/암호는 Icecast와 SHOUTcast에서 청취자 통계를 얻기 위해 필요합니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "결과 없음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "쇼에 지정된 사람들만 접속 할수 있습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "커스텁 인증을 설정하시면, 아무나 그걸 사용하여 해당 쇼에 접속 가능합니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "쇼 인스턴스가 존재 하지 않습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "주의: 쇼는 다시 링크 될수 없습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "반복 되는 쇼를 링크하면, 반복 쇼에 스케쥴된 아이템들이 다른 반복 쇼에도 스케쥴이 됩니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "쇼"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "쇼가 비어 있습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "서버로부터 데이타를 불러오는중..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "내용이 없는 쇼입니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "쇼가 완전히 채워지지 않았습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "1월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "2월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "3월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "4월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "5월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "6월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "7월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "8월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "9월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "10월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "11월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "12월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "1월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "2월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "3월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "4월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "6월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "7월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "8월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "9월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "10월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "11월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "12월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "일요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "월요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "화요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "수요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "목요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "금요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "토요일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "화"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "수"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "목"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "금"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "토"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "쇼가 자신의 길이보다 더 길게 스케쥴 되었다면, 쇼 길이에 맞게 짤라지며, 다음 쇼가 시작 됩니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "현재 방송중인 쇼를 중단 하시겠습니까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "현재 녹음 중인 쇼를 중단 하시겠습니까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "확인"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "쇼 내용"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "모든 내용물 삭제하시겠습까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "선택한 아이템을 삭제 하시겠습니까?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "시작"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "종료"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "길이"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "큐 인"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "큐 아웃"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "페이드 인"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "패이드 아웃"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "내용 없음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "라인 인으로 부터 녹음"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "트랙 프리뷰"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "쇼 범위 밖에 스케쥴 할수 없습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "아이템 1개 이동"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "아이템 %s개 이동"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "저장"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "취소"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "페이드 에디터"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "큐 에디터"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "웨이브 폼 기능은 Web Audio API를 지원하면 브라우저에서만 사용 가능합니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "전체 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "전체 선택 취소"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "선택된 아이템 제거"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "현재 방송중인 트랙으로 가기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "현재 쇼 취소"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "라이브러리 열기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "내용 추가/제거"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "사용중"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "디스크"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "경로"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "열기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "관리자"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "프로그램 매니저"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "손님"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "손님의 권한:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "스케쥴 보기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "쇼 내용 보기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJ의 권한:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "할당된 쇼의 내용 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "미디아 파일 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "플레이 리스트, 스마트 블록, 웹스트림 생성"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "자신의 라이브러리 내용 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "프로그램 매니저의 권한:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "쇼 내용 보기및 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "쇼 스케쥴 하기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "모든 라이브러리 내용 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "관리자의 권한:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "설정 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "사용자 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "모니터 폴터 관리"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "사용자 피드백을 보냄"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "이시스템 상황 보기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "방송 기록 접근 권한"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "청취자 통계 보기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "컬럼 보이기/숨기기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "<span style='display:inline-block;width:31px'>&nbsp;</span>{from}부터 {to}까지"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "일"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "월"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "화"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "수"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "목"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "금"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "토"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "닫기"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "시"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "분"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "확인"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "파일 선택"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "업로드를 원하는 파일을 선택하신후 시작 버틑을 눌러주세요."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "상태"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "파일 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "업로드 중지"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "업로드 시작"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "파일 추가"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "%d/%d 파일이 업로드됨"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "파일을 여기로 드래그 앤 드랍 하세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "파일 확장자 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "파일 크기 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "파일 갯수 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "초기화 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "보안 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "일반적인 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO 에러."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "파일: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d개의 파일이 대기중"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "파일: %f, 크기: %s, 최대 파일 크기: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "업로드 URL이 맞지 않거나 존재 하지 않습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "에러: 파일이 너무 큽니다:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "에러: 지원하지 않는 확장자:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s row %s를 클립보드로 복사 하였습니다"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%s프린트를 하려면 브라우저의 프린트 기능을 사용하여주세요. 종료를 원하시면 ESC키를 누르세요"
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "커서 선택"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "커서 제거"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "쇼가 존재 하지 않음"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "%s의 재방송 %s부터 %s까지"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "커서 선택"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "커서 제거"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "쇼가 존재 하지 않음"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "사용자가 추가 되었습니다!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "사용자 정보가 업데이트 되었습니다!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "세팅이 성공적으로 업데이트 되었습니다!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "제목없는 웹스트림"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "웹스트림이 저장 되었습니다"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "잘못된 값입니다"
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "년도 값은 %s 1753 - 9999 입니다"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s는 맞지 않는 날짜 입니다"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s는 맞지 않는 시간 입니다"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "라이브 스트림"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "재생"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "정지"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "큐 아웃 설정"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "커서"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "공유"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "스트림 선택"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "음소거"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "음소거 해제"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "정보"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "더 자세한 도움을 원하시면,  메뉴얼을 참고 하여 주세요. %suser manual%s"
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "방송 기록"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "정적 블록 확장"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "동적 블록 확장"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "이름:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "설명:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "길이:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "재생 목록 셔플"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "셔플"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "재생 목록 크로스페이드"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "재생 목록 비우기"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "지우기"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "페이드 인: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "페이드 아웃:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "재생 목록 저장"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "열린 재생 목록 없음"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "웨이브 폼 보기"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "큐 인:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "큐 아웃:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "오리지날 길이"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "락스트림 설정"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "로그인"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "새 암호"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "새 암호 확인"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "사용자 관리"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "새 사용자"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "아이디"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "아이디"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "이름"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "성"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "사용자  유형"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "쇼 찾기"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "반복 날짜:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "제거"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "추가"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "쇼 소스"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime 등록"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(*)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(확인을 위한것입니다, 이 정보는 어디에도 게시 되지 않습니다)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "주의: 600*600보다 큰 이미지는 사이즈가 수정 됩니다"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "보내지는 데이타 보기"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "사용자 약관"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "날짜 선택"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " 부터 "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "개의 파일들"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "필터 히스토리"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(체크 하기 위해선 '피드백 보내기'를 체크 하셔야 합니다)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "스트림 "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "추가 설정"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "밑에 정보들은 청취자에 플래이어에 표시 됩니다:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(방송국 웹사이트 주소)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "스트림 URL: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "폴더 선택"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "저장"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "현재 저장 폴더:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "모니터중인 폴더를 리스트에서 삭제"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "모니터중인 폴더가 없습니다"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "마스터 소스"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud 설정"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "쇼 추가"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "쇼 업데이트"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "무엇"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "언제"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "라이브 스트림"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "누구"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "스타일"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "디스크 공간"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "파일 가져오기 진행중"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "고급 검색 옵션"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "제목:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "제작자:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "앨범:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "트랙:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "길이:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "샘플 레이트:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "비트 레이트:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "무드"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "장르:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "년도:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "상표:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "작곡가:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "지휘자"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "저작권:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC 넘버:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "웹사이트"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "언어"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "파일 위치:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "웹스트림"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "동적 스마트 블록"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "정적 스마트 블록"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "오디오 트랙"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "재생목록 내용"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "정적 스마트 블록 내용: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "동적 스마트 블록 내용: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "길이 제한 "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr " "
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "일"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "이전:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "다음:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "소스 스트림"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "방송중"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "듣기"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "로그아웃"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "이름"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "설명"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "스트림 URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "기본 길이:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "열린 웹스트림 없음"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "도움"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "페이지를 찾을수 없습니다!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "찾는 페이지가 존재 하지 않습니다!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "이전"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "재생"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "중지"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "다음"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "정지"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "최대 음량 "
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "업데이트가 필요함"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "미디어를 재생하기 위해선, 브라우저를 최신 버젼으로 업데이트 하시고, %sFlash plugin%s도 업데이트 해주세요"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "시작"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2502,6 @@ msgstr "시작"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "허용되지 않는 문자입니다"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "종료"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "내 쇼:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "사용자 검색:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJ들:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "방송국 이름"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "전화"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "이메일"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "방송국 웹사이트"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "나라"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "도시"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "방송국 설명"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "방송국 로고"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "사용자 약관에 동의 하십시오"
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Line In으로 녹음"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "재방송?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "이 필드는 비워둘수 없습니다."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%'은 맞지 않는 이메일 형식 입니다."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%'은 날짜 형식('%format%')에 맞지 않습니다."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%'는 %min%글자 보다 짧을수 없습니다"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%'는 %max%글자 보다 길수 없습니다"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%'은 '%min%'와   '%max%' 사이에 있지 않습니다."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "암호가 맞지 않습니다"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2518,55 @@ msgstr "시간을 설정하세요"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "재방송 설정까지 1시간 기간이 필요합니다"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "암호 초기화"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "이름없는 쇼"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC 넘버"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "확인"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "기본 크로스페이드 길이(s)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "기본 페이드 인(s)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "기본 페이드 아웃(s)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "미사용"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "사용"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "주 시작일"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "아이디: "
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "암호: "
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "암호 확인:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "이름:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "성:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "휴대전화:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "스카입:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "유저 타입"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "사용할수 없는 아이디 입니다"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "폴더 가져오기"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "모니터중인 폴더"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "옳치 않은 폴더 입니다"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "기본 라이센스:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "방송중"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "기준 선택"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "비트 레이트(Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "샘플 레이트"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "시간"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "분"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "아이템"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "정적(Static)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "동적(Dynamic)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "재생 목록 내용  생성후 설정 저장"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "생성"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "재생 목록 내용 셔플하기"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "길이 제한은 비어두거나 0으로 설정할수 없습니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "길이 제한은 24h 보다 클수 없습니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "이 값은 정수(integer) 입니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "아이템 곗수의 최대값은 500 입니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "기준과 모디파이어를 골라주세요"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "길이는 00:00:00 형태로 입력하세요"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "이 값은 timestamp 형태 (e.g. 0000-00-00 or 0000-00-00 00:00:00) 로 입력해주세요"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "이 값은 숫자만 허용 됩니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "이 값은 2147483648보다 작은 수만 허용 됩니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "이 값은 %s 문자보다 작은 길이만 허용 됩니다"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "이 값은 비어둘수 없습니다"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis 메타데이타"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "스트림 레이블"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "아티스트 - 제목"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "쇼 - 아티스트 - 제목"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "방송국 이름 - 쇼 이름"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "오프 에어 메타데이타"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "리플레이 게인 활성화"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "리플레이 게인 설정"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "암호"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "새 암호 확인"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "암호와 암호 확인 값이 일치 하지 않습니다."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "사용:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "스트림 타입:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "서비스 타입:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "채널:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - 모노"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - 스테레오"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "서버"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "포트"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "숫자만 허용 됩니다"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "마운트 지점"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "관리자 아이디"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "관리자 암호"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "서버를 지정해주세요"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "포트를 지정해주세요"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Icecast 서버는 마운트 지점을 지정해야 합니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%'은 시간 형식('HH:mm')에 맞지 않습니다."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "시간대:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "반복?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "쇼를 과거에 생성 할수 없습니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "이미 시작한 쇼의 시작 날짜/시간을 바꿀수 없습니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "종료 날짜/시간을 과거로 설정할수 없습니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "길이가 0m 보다 작을수 없습니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "길이가 00h 00m인 쇼를 생성 할수 없습니다"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "쇼의 길이가 24h를 넘을수 없습니다"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Custom 인증 사용"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Custom 아이디"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Custom 암호"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "아이디를 입력해주세요"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "암호를 입력해주세요"
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "배경 색:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "글자 색:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "밑에 보이는 그림에 나온 문자를 입력하세요"
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "일"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2612,12 @@ msgstr "월중 날짜"
 msgid "day of the week"
 msgstr "주중 날짜"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "종료"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "무한 반복?"
@@ -3876,115 +2630,1174 @@ msgstr "종료 일이 시작일 보다 먼져 입니다."
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Line In으로 녹음"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "재방송?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "배경 색:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "글자 색:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "스케쥴"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "제거"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "계정"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "이름:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "스트림"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "이름없는 쇼"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "청취자 통계"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "장르:"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "설명:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%'은 시간 형식('HH:mm')에 맞지 않습니다."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "길이:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "시간대:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "반복?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "쇼를 과거에 생성 할수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "이미 시작한 쇼의 시작 날짜/시간을 바꿀수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "종료 날짜/시간을 과거로 설정할수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "길이가 0m 보다 작을수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "길이가 00h 00m인 쇼를 생성 할수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "쇼의 길이가 24h를 넘을수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "쇼를 중복되게 스케쥴할수 없습니다"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "사용자 검색:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJ들:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "아이디: "
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "암호: "
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "암호 확인:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "이름:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "성:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "이메일"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "휴대전화:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "스카입:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "초보자 가이드"
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "유저 타입"
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "사용할수 없는 아이디 입니다"
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "사용자 메뉴얼"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "이 필드는 비워둘수 없습니다."
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "시작"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "제목:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "제작자:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "앨범:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "년도:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "상표:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "작곡가:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "지휘자"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "무드"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "저작권:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC 넘버"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "웹사이트"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "언어"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "방송국 이름"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "방송국 로고"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "주의: 600*600보다 큰 이미지는 사이즈가 수정 됩니다"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "기본 크로스페이드 길이(s)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "기본 페이드 인(s)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "기본 페이드 아웃(s)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "미사용"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "사용"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "주 시작일"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%'은 맞지 않는 이메일 형식 입니다."
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%'은 날짜 형식('%format%')에 맞지 않습니다."
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%'는 %min%글자 보다 짧을수 없습니다"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%'는 %max%글자 보다 길수 없습니다"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%'은 '%min%'와   '%max%' 사이에 있지 않습니다."
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "암호가 맞지 않습니다"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "숫자만 허용 됩니다"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "로그인"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "밑에 보이는 그림에 나온 문자를 입력하세요"
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "암호"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "새 암호 확인"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "암호와 암호 확인 값이 일치 하지 않습니다."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "아이디"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "암호 초기화"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "방송중"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "전화"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "방송국 웹사이트"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "나라"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "도시"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "방송국 설명"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "사용자 약관에 동의 하십시오"
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "내 쇼:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "기준 선택"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "비트 레이트(Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "설명"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "샘플 레이트"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "시간"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "분"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "아이템"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "정적(Static)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "동적(Dynamic)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "재생 목록 내용  생성후 설정 저장"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "생성"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "재생 목록 내용 셔플하기"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "셔플"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "길이 제한은 비어두거나 0으로 설정할수 없습니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "길이 제한은 24h 보다 클수 없습니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "이 값은 정수(integer) 입니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "아이템 곗수의 최대값은 500 입니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "기준과 모디파이어를 골라주세요"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "길이는 00:00:00 형태로 입력하세요"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "이 값은 timestamp 형태 (e.g. 0000-00-00 or 0000-00-00 00:00:00) 로 입력해주세요"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "이 값은 숫자만 허용 됩니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "이 값은 2147483648보다 작은 수만 허용 됩니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "이 값은 %s 문자보다 작은 길이만 허용 됩니다"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "이 값은 비어둘수 없습니다"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "기본 라이센스:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis 메타데이타"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "스트림 레이블"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "아티스트 - 제목"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "쇼 - 아티스트 - 제목"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "방송국 이름 - 쇼 이름"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "오프 에어 메타데이타"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "리플레이 게인 활성화"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "리플레이 게인 설정"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "사용:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "스트림 타입:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "비트 레이트:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "서비스 타입:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "채널:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - 모노"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - 스테레오"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "서버"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "포트"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "이름"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "마운트 지점"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "관리자 아이디"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "관리자 암호"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "서버를 지정해주세요"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "포트를 지정해주세요"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Icecast 서버는 마운트 지점을 지정해야 합니다"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "폴더 가져오기"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "모니터중인 폴더"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "옳치 않은 폴더 입니다"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "재생"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "정지"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "큐 아웃 설정"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "커서"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "라이브 스트림"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "큐-인 과 큐 -아웃 이 null 입니다"
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "큐-아웃 값은 파일 길이보다 클수 없습니다"
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "큐-인 값은 큐-아웃 값보다 클수 없습니다."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "큐-아웃 값은 큐-인 값보다 작을수 없습니다."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "%s 재방송( %s에 시작) "
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "국가 선택"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4009,14 +3822,12 @@ msgstr "%s는 옳은 경로가 아닙니다."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s는 이미 현재 저장 폴더로 지정이 되었거나 모니터중인 폴더 입니다."
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s는 이미 현재 저장 폴더로 지정이 되었거나 모니터중인 폴더 입니다."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,28 +3835,18 @@ msgstr "%s는 이미 현재 저장 폴더로 지정이 되었거나 모니터중
 msgid "%s doesn't exist in the watched list."
 msgstr "%s가 모니터 목록에 없습니다"
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "국가 선택"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "쇼 길이는 24시간을 넘을수 없습니다."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "쇼를 중복되게 스케줄 할수 없습니다.\n주의: 반복 쇼의 크기를 조정하면, 모든 반복 쇼의 크기가 바뀝니다."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4060,48 +3861,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "현재 보고 계신 스케쥴이 맞지 않습니다(instance mismatch)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "현재 보고 계신 스케쥴이 맞지 않습니다"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "쇼를 스케쥴 할수 있는 권한이 없습니다 %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "녹화 쇼에는 파일을 추가 할수 없습니다"
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "지난 쇼(%s)에 더이상 스케쥴을 할수 없스니다"
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "쇼 %s 업데이트 되었습니다!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "링크 쇼의 내용은 이미 방송된 쇼의 전후에만 스케쥴 할수 있습니다"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "선택하신 파일이 존재 하지 않습니다"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "쇼 길이는 24시간을 넘을수 없습니다."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"쇼를 중복되게 스케줄 할수 없습니다.\n"
+"주의: 반복 쇼의 크기를 조정하면, 모든 반복 쇼의 크기가 바뀝니다."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "%s 재방송( %s에 시작) "
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4148,8 +3961,1049 @@ msgstr "잘못된 웹스트림 - 웹스트림이 아니고 파일 다운로드 �
 msgid "Unrecognized stream type: %s"
 msgstr "알수 없는 스트림 타입: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "녹음된 파일의 메타데이타 보기"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "수정"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "쇼 수정"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "권한이 부족합니다"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "반복쇼는 드래그 앤 드롭 할수 없습니다"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "지난 쇼는 이동할수 없습니다"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "과거로 쇼를 이동할수 없습니다"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "녹화 쇼를 재방송 시작 1시간 안으로 이동할수 없습니다"
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "녹화 쇼가 없으로 쇼가 삭제 되었습니다"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "녹화 쇼와 재방송 사이에는 1시간의 간격이 필요합니다 "
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "방송됨"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "이전"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "재생"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "중지"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "다음"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "정지"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "음소거"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "음소거 해제"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "최대 음량 "
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "업데이트가 필요함"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "미디어를 재생하기 위해선, 브라우저를 최신 버젼으로 업데이트 하시고, %sFlash plugin%s도 업데이트 해주세요"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "정보"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "더 자세한 도움을 원하시면,  메뉴얼을 참고 하여 주세요. %suser manual%s"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "공유"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "스트림 선택"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "페이지를 찾을수 없습니다!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "찾는 페이지가 존재 하지 않습니다!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "쇼 소스"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "날짜 선택"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "추가"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "반복 날짜:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "필터 히스토리"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud 설정"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "마스터 소스"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "확인"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "폴더 선택"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "저장"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "현재 저장 폴더:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "모니터중인 폴더를 리스트에서 삭제"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "모니터중인 폴더가 없습니다"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime 등록"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(*)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(확인을 위한것입니다, 이 정보는 어디에도 게시 되지 않습니다)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "보내지는 데이타 보기"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "사용자 약관"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "쇼 찾기"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " 부터 "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "개의 파일들"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "스트림 "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "추가 설정"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "밑에 정보들은 청취자에 플래이어에 표시 됩니다:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(방송국 웹사이트 주소)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "스트림 URL: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(체크 하기 위해선 '피드백 보내기'를 체크 하셔야 합니다)"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "트랙:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "길이:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "샘플 레이트:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC 넘버:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "파일 위치:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "웹스트림"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "동적 스마트 블록"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "정적 스마트 블록"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "오디오 트랙"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "재생목록 내용"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "정적 스마트 블록 내용: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "동적 스마트 블록 내용: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "길이 제한 "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "파일 가져오기 진행중"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "고급 검색 옵션"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "새 암호"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "새 암호 확인"
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "이전:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "다음:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "소스 스트림"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "방송중"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "듣기"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "로그아웃"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr " "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "재생 목록 셔플"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "재생 목록 크로스페이드"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "재생 목록 비우기"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "지우기"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "페이드 아웃:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "재생 목록 저장"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "열린 재생 목록 없음"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "웨이브 폼 보기"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "큐 인:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "큐 아웃:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "오리지날 길이"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "페이드 인: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "정적 블록 확장"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "동적 블록 확장"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "락스트림 설정"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "쇼 추가"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "쇼 업데이트"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "무엇"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "언제"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "라이브 스트림"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "누구"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "스타일"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "디스크 공간"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "사용자 관리"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "새 사용자"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "아이디"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "이름"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "성"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "사용자  유형"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "스트림 URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "기본 길이:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "열린 웹스트림 없음"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "초단위 '00 (.0)'로 입력해주세요"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "링크 쇼의 내용은 이미 방송된 쇼의 전후에만 스케쥴 할수 있습니다"

--- a/airtime_mvc/locale/ko_KR/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/ko_KR/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/lt/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Moo, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Lithuanian (http://www.transifex.com/sourcefabric/airtime/language/lt/)\n"
+"Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -276,80 +890,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -370,11 +2403,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -383,2627 +2411,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3012,127 +2501,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3150,674 +2518,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3864,6 +2612,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3876,114 +2630,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4009,14 +3822,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,27 +3835,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4060,47 +3861,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4148,8 +3959,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/nl_NL/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # dave van den berg <d.berg501@gmail.com>, 2015
 # terwey <terwey@gmail.com>, 2014
@@ -10,266 +10,882 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-28 12:25+0000\n"
 "Last-Translator: dave van den berg <d.berg501@gmail.com>\n"
 "Language-Team: Dutch (Netherlands) (http://www.transifex.com/sourcefabric/airtime/language/nl_NL/)\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Record bestand bestaat niet"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Het jaar %s moet binnen het bereik van 1753-9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Weergave opgenomen bestand Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s dit is geen geldige datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
-msgstr "Weergeven"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s Dit is geen geldige tijd."
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
-msgstr "Schema Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
-msgstr "Wissen show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
-msgstr "Annuleren show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
-msgstr "Aanleg bewerken"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Bewerken"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Bewerken van Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Verwijderen"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
-msgstr "Exemplaar verwijderen"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
-msgstr "Exemplaar verwijderen en alle volgende"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Toestemming geweigerd"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Kan niet slepen en neerzetten herhalende shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Een verleden Show verplaatsen niet"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Niet verplaatsen show in verleden"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "kan Niet gepland overlappen shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Een opgenomen programma minder dan 1 uur vóór haar rebroadcasts verplaatsen niet."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Toon is verwijderd omdat opgenomen programma niet bestaat!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Moet wachten 1 uur opnieuw uitzenden.."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Titel"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Aangemaakt door"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Lengte"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Componist"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright:"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Jaar"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Taal"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Begintijd"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Eindtijd"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Gespeeld"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr "Uploaden sommige tracks hieronder toe te voegen aan uw bibliotheek!"
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr "Het lijkt erop dat u alle audio bestanden nog niet hebt geüpload. %sUpload een bestand nu%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr "Klik op de knop 'Nieuwe Show' en vul de vereiste velden."
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr "Het lijkt erop dat u niet alle shows gepland. %sCreate een show nu%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr "Om te beginnen omroep, de huidige gekoppelde show te annuleren door op te klikken en te selecteren 'Annuleren Show'."
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+"Gekoppelde toont dienen te worden opgevuld met tracks voordat het begint. Om te beginnen met omroep annuleren de huidige gekoppeld Toon en plannen van een niet-gekoppelde show.\n"
+"%sCreate een niet-gekoppelde Toon nu%s."
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr "Om te beginnen omroep, klik op de huidige show en selecteer 'Schema Tracks'"
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calender"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "gebruikers"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "streams"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Playout geschiedenis"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Geschiedenis sjablonen"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "luister status"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Help"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Aan de slag"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Gebruikershandleiding"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "U bent niet toegestaan voor toegang tot deze bron."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "U bent niet toegestaan voor toegang tot deze bron."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr "Bestand bestaat niet in %s"
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Slecht verzoek. geen 'mode' parameter doorgegeven."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Slecht verzoek. 'mode' parameter is ongeldig"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Je hebt geen toestemming om te bron verbreken"
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Er is geen bron die aangesloten op deze ingang."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Je hebt geen toestemming om over te schakelen van de bron."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr "Pagina niet gevonden"
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr "De gevraagde actie wordt niet ondersteund."
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr "U bent niet gemachtigd voor toegang tot deze bron."
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr "Een interne toepassingsfout opgetreden."
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s niet gevonden"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Er ging iets mis."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Toevoegen aan afspeellijst"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Toevoegen aan slimme blok"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Metagegevens bewerken"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Verwijderen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -278,81 +894,1502 @@ msgid "View track"
 msgstr "Weergave track"
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
-msgstr "Nummer verwijderen"
+msgid "Update track"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr "Uploaden van track"
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Dubbele afspeellijst"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Geen actie beschikbaar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Je hebt geen toestemming om geselecteerde items te verwijderen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr "Kan bestand niet verwijderen omdat het in de toekomst is gepland."
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr "Bestand(en) kan geen gegevens verwijderen."
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopie van %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Naamloze Webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Webstream opgeslagen."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Ongeldige formulierwaarden."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr " Configureren en de integreerbare speler u moet gebruiken:<br><br>1. Inschakelen ten minste één MP3, AAC en OGG stream onder systeem->Streams<br>\n2. De openbare Airtime API inschakelen onder systeem->voorkeuren"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr "De integreerbare per schema widget u moet gebruiken:<br><br>\nde openbare Airtime API inschakelen onder systeem->voorkeuren"
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Controleer of admin gebruiker/wachtwoord klopt op systeem-> Streams pagina."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "gebruiker Succesvol Toegevoegd"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "gebruiker Succesvol bijgewerkt"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Instellingen met succes bijgewerkt!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Opname"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Master Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Niets gepland"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Huidige Show:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Huidige"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "U werkt de meest recente versie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nieuwe versie beschikbaar:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Deze versie zal binnenkort verouderd."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Deze versie wordt niet langer ondersteund."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Gelieve te upgraden naar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Toevoegen aan huidige afspeellijst"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Toevoegen aan huidigeslimme block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "1 Item toevoegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "%s Items toe te voegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "U kunt alleen nummers naar slimme blokken toevoegen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "U kunt alleen nummers, slimme blokken en webstreams toevoegen aan afspeellijsten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Selecteer een cursorpositie op de tijdlijn."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr "U hebt de nummers nog niet toegevoegd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr "U heb niet alle afspeellijsten toegevoegd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr "U nog niet toegevoegd een slimme blokken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr "U hebt webstreams nog niet toegevoegd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr "Informatie over nummers"
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr "Meer informatie over afspeellijsten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr "Informatie over slimme blokken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr "Meer informatie over webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr "Klik op 'Nieuw' te maken."
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Metagegevens bewerken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Toevoegen aan geselecteerde Toon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Selecteer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Selecteer deze pagina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Hef de selectie van deze pagina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Alle selecties opheffen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Weet u zeker dat u wilt verwijderen van de geselecteerde bestand(en)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Gepland"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr "track"
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr "Afspeellijsten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Titel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Aangemaakt door"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bit Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Componist"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encoded Bij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Genre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "label"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Taal"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Laatst Gewijzigd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Laatst gespeeld"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Lengte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Mood"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Eigenaar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Herhalen Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Sample Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Track nummer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Uploaded"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Jaar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Bezig met laden..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Alle"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Bestanden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Afspeellijsten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "slimme blokken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Streams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Onbekend type"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Wilt u de geselecteerde gegevens werkelijk verwijderen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Uploaden in vooruitgang..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Gegevens op te halen van de server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "De soundcloud id voor dit bestand is:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Er is een fout opgetreden bij het uploaden naar soundcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "foutcode"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Fout msg:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Invoer moet een positief getal"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Invoer moet een getal"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Invoer moet worden in de indeling: jjjj-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Invoer moet worden in het formaat: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "U zijn momenteel het uploaden van bestanden. %sGoing naar een ander scherm wordt het uploadproces geannuleerd. %sAre u zeker dat u wilt de pagina verlaten?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Open Media opbouw"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "Gelieve te zetten in een tijd '00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Uw browser biedt geen ondersteuning voor het spelen van dit bestandstype:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dynamische blok is niet previewable"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Beperk tot:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Afspeellijst opgeslagen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Afspeellijst geschud"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime is onzeker over de status van dit bestand. Dit kan gebeuren als het bestand zich op een externe schijf die is ontoegankelijk of het bestand bevindt zich in een map die is niet '' meer bekeken."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Luisteraar rekenen op %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Stuur me een herinnering in 1 week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Herinner me nooit"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Ja, help Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Afbeelding moet een van jpg, jpeg, png of gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Een statisch slimme blok zal opslaan van de criteria en de inhoud blokkeren onmiddellijk te genereren. Dit kunt u bewerken en het in de bibliotheek te bekijken voordat u deze toevoegt aan een show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Een dynamische slimme blok bespaart alleen de criteria. Het blok inhoud zal krijgen gegenereerd op het toe te voegen aan een show. U zal niet zitten kundig voor weergeven en bewerken van de inhoud in de mediabibliotheek."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "De lengte van het gewenste blok zal niet worden bereikt als Airtime niet kunt vinden genoeg unieke nummers aan uw criteria voldoen. Schakel deze optie in als u wilt toestaan tracks meerdere keren worden toegevoegd aan het slimme blok."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "slimme blok geschud"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "slimme blok gegenereerd en opgeslagen criteria"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart blok opgeslagen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Wordt verwerkt..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Selecteer modifier"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "bevat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "bevat niet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "is"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "is niet gelijk aan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "Begint met"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "Eindigt op"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "is groter dan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "is minder dan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "in het gebied"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Kies opslagmap"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Kies map voor bewaken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Weet u zeker dat u wilt wijzigen de opslagmap?\n"
+"Hiermee verwijdert u de bestanden uit uw Airtime bibliotheek!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Mediamappen beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Weet u zeker dat u wilt verwijderen van de gecontroleerde map?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Dit pad is momenteel niet toegankelijk."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Sommige typen stream vereist extra configuratie. Details over het inschakelen van %sAAC + ondersteunt %s of %sOpus %s steun worden verstrekt."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Aangesloten op de streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "De stream is uitgeschakeld"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Het verkrijgen van informatie van de server ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Kan geen verbinding maken met de streaming server"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Als Airtime zich achter een router of firewall, u wellicht configureren poort forwarding en deze informatie zal worden onjuist. In dit geval zal u wilt dit veld handmatig worden bijgewerkt zodat het toont de juiste host/poort/mount die uw DJ wilt verbinden. Het toegestane bereik is tussen 1024 en 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Voor meer informatie, lees de %sAirtime handleiding%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Schakel deze optie in om metagegevens voor OGG streams (stream metadata is de tracktitel, artiest, en Toon-naam die wordt weergegeven in een audio-speler). VLC en mplayer hebben een ernstige bug wanneer spelen een OGG/VORBIS stroom die metadata informatie ingeschakeld heeft: ze de stream zal verbreken na elke song. Als u een OGG stream gebruikt en uw luisteraars geen ondersteuning voor deze Audiospelers vereisen, dan voel je vrij om deze optie."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Dit selectievakje automatisch uit te schakelen Master/Toon bron op bron verbreking van de aansluiting."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Dit selectievakje automatisch uit te schakelen Master/Toon bron op bron verbreking van de aansluiting."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Als uw Icecast server verwacht een gebruikersnaam van 'Bron', kan dit veld leeg worden gelaten."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Als je live streaming client niet om een gebruikersnaam vraagt, moet dit veld 'Bron'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr "Waarschuwing: Dit zal opnieuw opstarten van uw stream en een korte dropout kan veroorzaken voor uw luisteraars!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Dit is de admin gebuiker en wachtwoord voor Icecast/SHOUTcast om luisteraar statistieken."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Waarschuwing: U het veld niet wijzigen terwijl de show is momenteel aan het spelen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Geen resultaat gevonden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Dit volgt op de dezelfde beveiliging-patroon voor de shows: alleen gebruikers die zijn toegewezen aan de show verbinding kunnen maken."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Geef aangepaste verificatie die alleen voor deze show werken zal."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "De Toon-exemplaar bestaat niet meer!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Waarschuwing: Shows kunnen niet opnieuw gekoppelde"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Door het koppelen van toont uw herhalende alle media objecten later in elke herhaling show zal ook krijgen gepland in andere herhalen shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "tijdzone is standaard ingesteld op de tijdzone station. Shows in de kalender wordt getoond in uw lokale tijd gedefinieerd door de Interface tijdzone in uw gebruikersinstellingen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Show Is leeg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Retreiving gegevens van de server..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Deze show heeft geen geplande inhoud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Deze show is niet volledig gevuld met inhoud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Januari"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Februari"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "maart"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "april"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "mei"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "juni"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "juli"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "augustus"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "september"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "oktober"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "november"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "december"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "maa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "aug"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "okt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr "vandaag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr "dag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr "week"
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr "maand"
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "zondag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "maandag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "dinsdag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "woensdag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "donderdag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "vrijdag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "zaterdag"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "zon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "ma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "wo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "vrij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "zat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Toont meer dan de geplande tijd onbereikbaar worden door een volgende voorstelling."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Annuleer Huidige Show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Stop de opname huidige show?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "oke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Inhoud van Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Alle inhoud verwijderen?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "verwijderd geselecteerd object(en)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Start"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "einde"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr "Filteren op"
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr "of"
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr "records"
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Infaden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "uitfaden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Show leeg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Opname van de Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Track Voorbeeld"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Niet gepland buiten een show."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "1 Item verplaatsen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "%s Items verplaatsen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "opslaan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "anuleren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Fade Bewerken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Bewerken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Waveform functies zijn beschikbaar in een browser die ondersteuning van de Web Audio API"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Selecteer alles"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Niets selecteren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr "Trim overboekte shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Geselecteerde geplande items verwijderen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Jump naar de huidige playing track"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Annuleren van de huidige show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Open bibliotheek toevoegen of verwijderen van inhoud"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Toevoegen / verwijderen van inhoud"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "In gebruik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "hardeschijf"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Zoeken in:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "open"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Admin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Programmabeheer"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "gast"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Gasten kunnen het volgende doen:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Schema weergeven"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Weergave show content"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJ's kunnen het volgende doen:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Toegewezen Toon inhoud beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Mediabestanden importeren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Maak afspeellijsten, slimme blokken en webstreams"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "De inhoud van hun eigen bibliotheek beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Programa Managers kunnen het volgende doen:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Bekijken en beheren van inhoud weergeven"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Schema shows"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Alle inhoud van de bibliotheek beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Beheerders kunnen het volgende doen:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Voorkeuren beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Gebruikers beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Bewaakte mappen beheren"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Ondersteuning feedback verzenden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Bekijk systeem status"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Toegang playout geschiedenis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Weergave luisteraar status"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Geef weer / verberg kolommen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Van {from} tot {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "jjjj-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Zo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Ma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Di"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Wo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Vr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Za"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Sluiten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Uur"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Klaar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Selecteer bestanden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Voeg bestanden aan de upload wachtrij toe en klik op de begin knop"
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Bestanden toevoegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Stop upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Begin upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Bestanden toevoegen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Geüploade %d/%d bestanden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/B"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Sleep bestanden hierheen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Bestandsextensie fout"
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Bestandsgrote fout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Graaf bestandsfout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init fout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP fout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Beveiligingsfout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generieke fout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO fout."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Bestand: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d bestanden in de wachtrij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "File: %f, grootte: %s, max bestandsgrootte: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Upload URL zou verkeerd kunnen zijn of bestaat niet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Fout: Bestand is te groot"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Fout: Niet toegestane bestandsextensie "
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Standaard instellen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Aangemaakt op:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Geschiedenis Record bewerken"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "geen show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Rij gekopieerde %s %s naar het Klembord"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint weergave%sA.u.b. gebruik printfunctie in uw browser wilt afdrukken van deze tabel. Druk op ESC wanneer u klaar bent."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr "Nieuw Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr "Nieuwe logboekvermelding"
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr "Voer uw gebruikersnaam en wachtwoord."
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-mail kan niet worden verzonden. Controleer de instellingen van uw e-mailserver en controleer dat goed is geconfigureerd."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr "Er was een probleem met de gebruikersnaam of email adres dat u hebt ingevoerd."
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Onjuiste gebruikersnaam of wachtwoord opgegeven. Probeer het opnieuw."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2409,6 @@ msgstr "Je hebt geen toestemming om te verwijderen van de geselecteerde %s(s)"
 msgid "You can only add tracks to smart block."
 msgstr "U kunt alleen nummers toevoegen aan smart blok."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "U kunt alleen nummers, slimme blokken en webstreams toevoegen aan afspeellijsten."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Naamloze afspeellijst"
@@ -385,2627 +2417,88 @@ msgstr "Naamloze afspeellijst"
 msgid "Untitled Smart Block"
 msgstr "Naamloze slimme block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Onbekende afspeellijst"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr "Pagina niet gevonden"
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr "De gevraagde actie wordt niet ondersteund."
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr "U bent niet gemachtigd voor toegang tot deze bron."
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr "Een interne toepassingsfout opgetreden."
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "U bent niet toegestaan voor toegang tot deze bron."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Voorkeuren bijgewerkt."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Instelling bijgewerkt ondersteunt."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Ondersteuning Feedback"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Stream vaststelling van bijgewerkte."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "pad moet worden opgegeven"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Probleem met Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr "Verzoek methode niet geaccepteerd"
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Je hebt geen toestemming om te bron verbreken"
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Er is geen bron die aangesloten op deze ingang."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Je hebt geen toestemming om over te schakelen van de bron."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr "Voer uw gebruikersnaam en wachtwoord."
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Onjuiste gebruikersnaam of wachtwoord opgegeven. Probeer het opnieuw."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-mail kan niet worden verzonden. Controleer de instellingen van uw e-mailserver en controleer dat goed is geconfigureerd."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr "Er was een probleem met de gebruikersnaam of email adres dat u hebt ingevoerd."
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "U bent niet toegestaan voor toegang tot deze bron."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr "Bestand bestaat niet in %s"
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Slecht verzoek. geen 'mode' parameter doorgegeven."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Slecht verzoek. 'mode' parameter is ongeldig"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Opname"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Master Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Niets gepland"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Huidige Show:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Huidige"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "U werkt de meest recente versie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nieuwe versie beschikbaar:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Deze versie zal binnenkort verouderd."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Deze versie wordt niet langer ondersteund."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Gelieve te upgraden naar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Toevoegen aan huidige afspeellijst"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Toevoegen aan huidigeslimme block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "1 Item toevoegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "%s Items toe te voegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "U kunt alleen nummers naar slimme blokken toevoegen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Selecteer een cursorpositie op de tijdlijn."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr "U hebt de nummers nog niet toegevoegd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr "U heb niet alle afspeellijsten toegevoegd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr "U nog niet toegevoegd een slimme blokken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr "U hebt webstreams nog niet toegevoegd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr "Informatie over nummers"
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr "Meer informatie over afspeellijsten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr "Informatie over slimme blokken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr "Meer informatie over webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr "Klik op 'Nieuw' te maken."
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Toevoegen aan geselecteerde Toon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Selecteer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Selecteer deze pagina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Hef de selectie van deze pagina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Alle selecties opheffen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Weet u zeker dat u wilt verwijderen van de geselecteerde bestand(en)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Gepland"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr "track"
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr "Afspeellijsten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bit Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encoded Bij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Laatst Gewijzigd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Laatst gespeeld"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Eigenaar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Herhalen Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Sample Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Track nummer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Uploaded"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Bezig met laden..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Alle"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Bestanden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Afspeellijsten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "slimme blokken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Streams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Onbekend type"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Wilt u de geselecteerde gegevens werkelijk verwijderen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Uploaden in vooruitgang..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Gegevens op te halen van de server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "De soundcloud id voor dit bestand is:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Er is een fout opgetreden bij het uploaden naar soundcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "foutcode"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Fout msg:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Invoer moet een positief getal"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Invoer moet een getal"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Invoer moet worden in de indeling: jjjj-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Invoer moet worden in het formaat: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "U zijn momenteel het uploaden van bestanden. %sGoing naar een ander scherm wordt het uploadproces geannuleerd. %sAre u zeker dat u wilt de pagina verlaten?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Open Media opbouw"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "Gelieve te zetten in een tijd '00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "Gelieve te zetten in een tijd in seconden '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Uw browser biedt geen ondersteuning voor het spelen van dit bestandstype:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dynamische blok is niet previewable"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Beperk tot:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Afspeellijst opgeslagen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Afspeellijst geschud"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime is onzeker over de status van dit bestand. Dit kan gebeuren als het bestand zich op een externe schijf die is ontoegankelijk of het bestand bevindt zich in een map die is niet '' meer bekeken."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Luisteraar rekenen op %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Stuur me een herinnering in 1 week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Herinner me nooit"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Ja, help Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Afbeelding moet een van jpg, jpeg, png of gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Een statisch slimme blok zal opslaan van de criteria en de inhoud blokkeren onmiddellijk te genereren. Dit kunt u bewerken en het in de bibliotheek te bekijken voordat u deze toevoegt aan een show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Een dynamische slimme blok bespaart alleen de criteria. Het blok inhoud zal krijgen gegenereerd op het toe te voegen aan een show. U zal niet zitten kundig voor weergeven en bewerken van de inhoud in de mediabibliotheek."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "De lengte van het gewenste blok zal niet worden bereikt als Airtime niet kunt vinden genoeg unieke nummers aan uw criteria voldoen. Schakel deze optie in als u wilt toestaan tracks meerdere keren worden toegevoegd aan het slimme blok."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "slimme blok geschud"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "slimme blok gegenereerd en opgeslagen criteria"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart blok opgeslagen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Wordt verwerkt..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Selecteer modifier"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "bevat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "bevat niet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "is"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "is niet gelijk aan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "Begint met"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "Eindigt op"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "is groter dan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "is minder dan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "in het gebied"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Kies opslagmap"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Kies map voor bewaken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Weet u zeker dat u wilt wijzigen de opslagmap?\nHiermee verwijdert u de bestanden uit uw Airtime bibliotheek!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Mediamappen beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Weet u zeker dat u wilt verwijderen van de gecontroleerde map?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Dit pad is momenteel niet toegankelijk."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Sommige typen stream vereist extra configuratie. Details over het inschakelen van %sAAC + ondersteunt %s of %sOpus %s steun worden verstrekt."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Aangesloten op de streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "De stream is uitgeschakeld"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Het verkrijgen van informatie van de server ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Kan geen verbinding maken met de streaming server"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Als Airtime zich achter een router of firewall, u wellicht configureren poort forwarding en deze informatie zal worden onjuist. In dit geval zal u wilt dit veld handmatig worden bijgewerkt zodat het toont de juiste host/poort/mount die uw DJ wilt verbinden. Het toegestane bereik is tussen 1024 en 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Voor meer informatie, lees de %sAirtime handleiding%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Schakel deze optie in om metagegevens voor OGG streams (stream metadata is de tracktitel, artiest, en Toon-naam die wordt weergegeven in een audio-speler). VLC en mplayer hebben een ernstige bug wanneer spelen een OGG/VORBIS stroom die metadata informatie ingeschakeld heeft: ze de stream zal verbreken na elke song. Als u een OGG stream gebruikt en uw luisteraars geen ondersteuning voor deze Audiospelers vereisen, dan voel je vrij om deze optie."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Dit selectievakje automatisch uit te schakelen Master/Toon bron op bron verbreking van de aansluiting."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Dit selectievakje automatisch uit te schakelen Master/Toon bron op bron verbreking van de aansluiting."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Als uw Icecast server verwacht een gebruikersnaam van 'Bron', kan dit veld leeg worden gelaten."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Als je live streaming client niet om een gebruikersnaam vraagt, moet dit veld 'Bron'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr "Waarschuwing: Dit zal opnieuw opstarten van uw stream en een korte dropout kan veroorzaken voor uw luisteraars!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Dit is de admin gebuiker en wachtwoord voor Icecast/SHOUTcast om luisteraar statistieken."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Waarschuwing: U het veld niet wijzigen terwijl de show is momenteel aan het spelen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Geen resultaat gevonden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Dit volgt op de dezelfde beveiliging-patroon voor de shows: alleen gebruikers die zijn toegewezen aan de show verbinding kunnen maken."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Geef aangepaste verificatie die alleen voor deze show werken zal."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "De Toon-exemplaar bestaat niet meer!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Waarschuwing: Shows kunnen niet opnieuw gekoppelde"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Door het koppelen van toont uw herhalende alle media objecten later in elke herhaling show zal ook krijgen gepland in andere herhalen shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "tijdzone is standaard ingesteld op de tijdzone station. Shows in de kalender wordt getoond in uw lokale tijd gedefinieerd door de Interface tijdzone in uw gebruikersinstellingen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Show Is leeg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Retreiving gegevens van de server..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Deze show heeft geen geplande inhoud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Deze show is niet volledig gevuld met inhoud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Januari"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Februari"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "maart"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "april"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "mei"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "juni"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "juli"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "augustus"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "september"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "oktober"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "november"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "december"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "maa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "aug"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "okt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr "vandaag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr "dag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr "week"
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr "maand"
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "zondag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "maandag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "dinsdag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "woensdag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "donderdag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "vrijdag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "zaterdag"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "zon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "ma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "wo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "vrij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "zat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Toont meer dan de geplande tijd onbereikbaar worden door een volgende voorstelling."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Annuleer Huidige Show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Stop de opname huidige show?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "oke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Inhoud van Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Alle inhoud verwijderen?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "verwijderd geselecteerd object(en)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Start"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "einde"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duur"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr "Filteren op"
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr "of"
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr "records"
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Infaden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "uitfaden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Show leeg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Opname van de Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Track Voorbeeld"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Niet gepland buiten een show."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "1 Item verplaatsen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "%s Items verplaatsen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "opslaan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "anuleren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Fade Bewerken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Bewerken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Waveform functies zijn beschikbaar in een browser die ondersteuning van de Web Audio API"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Selecteer alles"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Niets selecteren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr "Trim overboekte shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Geselecteerde geplande items verwijderen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Jump naar de huidige playing track"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Annuleren van de huidige show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Open bibliotheek toevoegen of verwijderen van inhoud"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Toevoegen / verwijderen van inhoud"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "In gebruik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "hardeschijf"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Zoeken in:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "open"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Admin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Programmabeheer"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "gast"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Gasten kunnen het volgende doen:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Schema weergeven"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Weergave show content"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJ's kunnen het volgende doen:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Toegewezen Toon inhoud beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Mediabestanden importeren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Maak afspeellijsten, slimme blokken en webstreams"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "De inhoud van hun eigen bibliotheek beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Programa Managers kunnen het volgende doen:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Bekijken en beheren van inhoud weergeven"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Schema shows"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Alle inhoud van de bibliotheek beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Beheerders kunnen het volgende doen:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Voorkeuren beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Gebruikers beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Bewaakte mappen beheren"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Ondersteuning feedback verzenden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Bekijk systeem status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Toegang playout geschiedenis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Weergave luisteraar status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Geef weer / verberg kolommen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Van {from} tot {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "jjjj-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Zo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Ma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Di"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Wo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Vr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Za"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Sluiten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Uur"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Klaar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Selecteer bestanden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Voeg bestanden aan de upload wachtrij toe en klik op de begin knop"
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Bestanden toevoegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Stop upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Begin upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Bestanden toevoegen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Geüploade %d/%d bestanden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/B"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Sleep bestanden hierheen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Bestandsextensie fout"
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Bestandsgrote fout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Graaf bestandsfout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init fout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP fout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Beveiligingsfout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generieke fout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO fout."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Bestand: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d bestanden in de wachtrij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "File: %f, grootte: %s, max bestandsgrootte: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Upload URL zou verkeerd kunnen zijn of bestaat niet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Fout: Bestand is te groot"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Fout: Niet toegestane bestandsextensie "
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Standaard instellen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Aangemaakt op:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Geschiedenis Record bewerken"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "geen show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Rij gekopieerde %s %s naar het Klembord"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint weergave%sA.u.b. gebruik printfunctie in uw browser wilt afdrukken van deze tabel. Druk op ESC wanneer u klaar bent."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr "Nieuw Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr "Nieuwe logboekvermelding"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Selecteer cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Cursor verwijderen"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "show bestaat niet"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Rebroadcast van show %s van %s in %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr "Uploaden sommige tracks hieronder toe te voegen aan uw bibliotheek!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Selecteer cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Cursor verwijderen"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "show bestaat niet"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "gebruiker Succesvol Toegevoegd"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "gebruiker Succesvol bijgewerkt"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Instellingen met succes bijgewerkt!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Naamloze Webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Webstream opgeslagen."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Ongeldige formulierwaarden."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr "Het lijkt erop dat u alle audio bestanden nog niet hebt geüpload. %sUpload een bestand nu%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr "Klik op de knop 'Nieuwe Show' en vul de vereiste velden."
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr "Het lijkt erop dat u niet alle shows gepland. %sCreate een show nu%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr "Om te beginnen omroep, de huidige gekoppelde show te annuleren door op te klikken en te selecteren 'Annuleren Show'."
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr "Gekoppelde toont dienen te worden opgevuld met tracks voordat het begint. Om te beginnen met omroep annuleren de huidige gekoppeld Toon en plannen van een niet-gekoppelde show.\n%sCreate een niet-gekoppelde Toon nu%s."
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr "Om te beginnen omroep, klik op de huidige show en selecteer 'Schema Tracks'"
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Het jaar %s moet binnen het bereik van 1753-9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s dit is geen geldige datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s Dit is geen geldige tijd."
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Live stream"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Play"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Set Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Set Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Deel"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Selecteer stream:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "dempen"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "microfoon"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Over"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr "%1$s %2$s, de open radio software voor planning en extern beheer van het station."
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr "%1$s %2$s wordt gedistribueerd onder de %3$s"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr "Welkom tot %s!"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr "Hier is hoe je kunt krijgen gestart met behulp van %s te automatiseren uw uitzendingen:"
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Voor meer gedetailleerde hulp, lees de %sgebruikershandleiding%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Playout geschiedenis"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Log blad"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Bestand samenvatting"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Samenvatting weergeven"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Statisch blok uitbreiden"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Dynamische blok uitbreiden"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "naam"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Omschrijving:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Looptijd:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Shuffle afspeellijst"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Shuffle"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Afspeellijst crossfade"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Lege afspeellijst inhoud"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Wissen"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade in:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade out:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Afspeellijst opslaan"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Geen open afspeellijst"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Show Waveform"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Oorspronkelijke lengte:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Instellingen voor stream"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Inloggen"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr "Welkom op de %s demo! U kunt zich aanmelden met de gebruikersnaam 'admin' en het wachtwoord 'admin'."
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nieuw wachtwoord"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Voer in en bevestig uw nieuwe wachtwoord in de velden hieronder."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Gebruikers beheren"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nieuwe gebruiker"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "gebuikersnaam"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Voornaam"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Achternaam"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Gebruikerstype"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "zoek Shows"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Kies show exemplaar"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Zoeken"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Herhaal dagen:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "verwijderen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "toevoegen"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Bron weergeven"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime registreren"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr "Klik in het vak hieronder om uw station op %s."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Vereist)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(voor verificatie doeleinden alleen, zal niet worden gepubliceerd)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Opmerking: Om het even wat groter zijn dan 600 x 600 zal worden aangepast."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Toon mij wat ik ben verzenden"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Algemene voorwaarden"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Kies dagen:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "of"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "en"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "tot"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "bestanden voldoen aan de criteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filter geschiedenis"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Ter bevordering van uw station, 'Feedback verzenden ondersteuning' moet worden ingeschakeld)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Stream"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Extra opties"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "De volgende info worden getoond aan luisteraars in hun mediaspeler"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Uw radio station website)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Kies map"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Instellen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Huidige Import map:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr "Scannen van gevolgde directory (dit is handig als het netwerk mount is en gesynchroniseerd met %s worden kan)"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "gecontroleerde map verwijderen"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Niet bekijkt u alle Mediamappen."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master bron"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud instellingen"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Deze show toevoegen"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Bijwerken van show"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Wat"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Wanneer"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Live Stream Input"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Wie"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stijl"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Hardeschijf ruimte"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Bestand importeren in vooruitgang..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Geadvanceerde zoek opties"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Titel"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Aangemaakt door"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "track"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Lengte:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Sample Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Mood:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "genre:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Jaar"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "label"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "schrijver van een muziekwerk"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Conductor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC nummer:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Website:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Taal:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Bestandspad:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dynamische slimme blok"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statisch slimme blok"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Audiotrack"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Inhoud van de afspeellijst:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statisch slimme blok inhoud:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dynamische slimme blok Criteria:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Beperken tot"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Uw proefperiode verloopt in"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dagen"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Vorige:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Volgende:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Bron Streams"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ON AIR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Luister"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "loguit"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Log blad sjablonen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Nieuwe Log werkbladsjabloon"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Geen Log blad sjablonen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Bestand samenvatting sjablonen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Nieuwe bestand samenvatting sjabloon"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Geen bestand samenvatting sjablonen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Bestand samenvatting sjabloon maken"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Log werkbladsjabloon maken"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "naam"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Meer elementen toevoegen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Nieuw veld toevoegen"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Standaardsjabloon"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Beschrijving"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "Stream URL:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Standaard lengte:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Geen webstream"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Help"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Pagina niet gevonden!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Het lijkt erop dat de pagina die u zocht bestaat niet!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "vorige"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "spelen"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pauze"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "volgende"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "Stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "Max volume"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Update vereist"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Om te spelen de media moet u uw browser bijwerkt naar een recente versie of update uw %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "datum start"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2508,6 @@ msgstr "datum start"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Ongeldig teken ingevoerd"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "datum einde"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "al mij shows"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "zoek gebruikers"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "station naam"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefoon"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "e-mail"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Station Web Site:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Land:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "plaats"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Beschrijving van het station:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Station Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Promoot mijn station aan %s"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "Door dit vakje aan, ik ga akkoord met %s's van %s privacy beleid %s"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Je moet eens met privacy policy."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Opnemen vanaf de lijn In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Rebroadcast?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Waarde is vereist en mag niet leeg zijn"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' is geen geldig e-mailadres in de basis formaat lokale-onderdeel @ hostnaam"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' past niet in de datumnotatie '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' is minder dan %min% tekens lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' is meer dan %max% karakters lang"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' is niet tussen '%min%' en '%max%', inclusief"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Wachtwoorden komen niet overeen."
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2524,55 @@ msgstr "Tijd moet worden opgegeven"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Ten minste 1 uur opnieuw uitzenden moet wachten"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Reset wachtwoord"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Zonder titel show"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC nummer:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "Oke"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Standaardduur Crossfade (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "standaard fade in (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "standaard fade uit (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Uitgeschakeld"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Ingeschakeld"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "station tijdzone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Week start aan"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "gebuikersnaam"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "wachtwoord"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Wachtwoord verifiëren:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "voornaam"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "achternaam"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "mobiel nummer"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "skype"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Gebruiker Type :"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Login naam is niet uniek."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "mappen importeren"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Gecontroleerde mappen:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Niet een geldige map"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Standaard licentie:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Alle rechten voorbehouden"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Het werk bestaat uit het publieke domein"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creatief Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Naamsvermelding geen afgeleide werken"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Naamsvermelding Gelijk delen"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Naamsvermelding nietcommerciële niet afgeleide werken"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creatief Meent Auteursvermelding niet-commerciële Deel Zowel"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Interface tijdzone:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Nu spelen"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Selecteer criteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Sample Rate (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "Uren"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minuten"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "artikelen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "status"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamisch"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Genereren van inhoud van de afspeellijst en criteria opslaan"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Genereren"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Shuffle afspeellijst inhoud"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limiet kan niet leeg zijn of kleiner is dan 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limiet mag niet meer dan 24 uur"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "De waarde moet een geheel getal"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 is de grenswaarde max object die kunt u instellen"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "U moet Criteria en Modifier selecteren"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Lengte' moet in ' 00:00:00 ' formaat"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "De waarde moet in timestamp indeling (bijvoorbeeld 0000-00-00 of 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "De waarde moet worden numerieke"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "De waarde moet minder dan 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "De waarde moet kleiner zijn dan %s tekens"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Waarde kan niet leeg"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Stream Label:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artiest - Titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Artiest - titel"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Station naam - Show naam"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Inschakelen Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifier"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "wachtwoord"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Bevestig nieuw wachtwoord"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Wachtwoord bevestiging komt niet overeen met uw wachtwoord."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Ingeschakeld"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Stream Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Service Type:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "kanalen:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1- Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "poort"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Alleen cijfers zijn toegestaan."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Aankoppelpunt"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "admin gebuiker "
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "admin wachtwoord "
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server kan niet leeg zijn"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "poort kan niet leeg zijn"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Mount kan niet leeg zijn met Icecast server"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' past niet de tijdnotatie 'UU:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "tijdzone:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "herhaalt?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "kan niet aanmaken show in het verleden weergeven"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Start datum/tijd van de show die is al gestart wijzigen niet"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Eind datum/tijd mogen niet in het verleden"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Geen duur hebben < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Kan niet hebben duur 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Duur groter is dan 24h kan niet hebben"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "verificatie %s  gebruiken:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Gebruik aangepaste verificatie:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Aangepaste gebruikersnaam"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Aangepaste wachtwoord"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Veld Gebruikersnaam mag niet leeg."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "veld wachtwoord mag niet leeg."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "achtergrond kleur"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "tekst kleur"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Typ de tekens die u ziet in de afbeelding hieronder."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dagen"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2618,12 @@ msgstr "dag van de maand"
 msgid "day of the week"
 msgstr "Dag van de week"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "datum einde"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Geen einde?"
@@ -3878,115 +2636,1174 @@ msgstr "Einddatum moet worden na begindatum ligt"
 msgid "Please select a repeat day"
 msgstr "Selecteer een Herhaal dag"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Opnemen vanaf de lijn In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Rebroadcast?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "achtergrond kleur"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "tekst kleur"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calender"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "verwijderen"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "gebruikers"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "naam"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "streams"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Zonder titel show"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "genre:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Omschrijving:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "luister status"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' past niet de tijdnotatie 'UU:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Geschiedenis sjablonen"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Looptijd:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "tijdzone:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "herhaalt?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "kan niet aanmaken show in het verleden weergeven"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Start datum/tijd van de show die is al gestart wijzigen niet"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Eind datum/tijd mogen niet in het verleden"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Geen duur hebben < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Kan niet hebben duur 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Duur groter is dan 24h kan niet hebben"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "kan Niet gepland overlappen shows"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "zoek gebruikers"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "gebuikersnaam"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "wachtwoord"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Wachtwoord verifiëren:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "voornaam"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "achternaam"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "e-mail"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "mobiel nummer"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "skype"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Gebruiker Type :"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Login naam is niet uniek."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Aan de slag"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Gebruikershandleiding"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Waarde is vereist en mag niet leeg zijn"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "datum start"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Titel"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Aangemaakt door"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Jaar"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "label"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "schrijver van een muziekwerk"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Conductor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Mood:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC nummer:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Website:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Taal:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Begintijd"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Eindtijd"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Interface tijdzone:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "station naam"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Station Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Opmerking: Om het even wat groter zijn dan 600 x 600 zal worden aangepast."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Standaardduur Crossfade (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "standaard fade in (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "standaard fade uit (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Uitgeschakeld"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Ingeschakeld"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "station tijdzone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Week start aan"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' is geen geldig e-mailadres in de basis formaat lokale-onderdeel @ hostnaam"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' past niet in de datumnotatie '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' is minder dan %min% tekens lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' is meer dan %max% karakters lang"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' is niet tussen '%min%' en '%max%', inclusief"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Wachtwoorden komen niet overeen."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Alleen cijfers zijn toegestaan."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Inloggen"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Typ de tekens die u ziet in de afbeelding hieronder."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "wachtwoord"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Bevestig nieuw wachtwoord"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Wachtwoord bevestiging komt niet overeen met uw wachtwoord."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "gebuikersnaam"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Reset wachtwoord"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Nu spelen"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefoon"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Station Web Site:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Land:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "plaats"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Beschrijving van het station:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Promoot mijn station aan %s"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "Door dit vakje aan, ik ga akkoord met %s's van %s privacy beleid %s"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Je moet eens met privacy policy."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "al mij shows"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Selecteer criteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Beschrijving"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Sample Rate (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "Uren"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minuten"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "artikelen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "status"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamisch"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Genereren van inhoud van de afspeellijst en criteria opslaan"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Genereren"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Shuffle afspeellijst inhoud"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Shuffle"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limiet kan niet leeg zijn of kleiner is dan 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limiet mag niet meer dan 24 uur"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "De waarde moet een geheel getal"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 is de grenswaarde max object die kunt u instellen"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "U moet Criteria en Modifier selecteren"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Lengte' moet in ' 00:00:00 ' formaat"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "De waarde moet in timestamp indeling (bijvoorbeeld 0000-00-00 of 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "De waarde moet worden numerieke"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "De waarde moet minder dan 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "De waarde moet kleiner zijn dan %s tekens"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Waarde kan niet leeg"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Standaard licentie:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Alle rechten voorbehouden"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Het werk bestaat uit het publieke domein"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creatief Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Naamsvermelding geen afgeleide werken"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Naamsvermelding Gelijk delen"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Naamsvermelding nietcommerciële niet afgeleide werken"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creatief Meent Auteursvermelding niet-commerciële Deel Zowel"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Stream Label:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artiest - Titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Artiest - titel"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Station naam - Show naam"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Inschakelen Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifier"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Ingeschakeld"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Stream Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Rate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Service Type:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "kanalen:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1- Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "poort"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "naam"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Aankoppelpunt"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "admin gebuiker "
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "admin wachtwoord "
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server kan niet leeg zijn"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "poort kan niet leeg zijn"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Mount kan niet leeg zijn met Icecast server"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "mappen importeren"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Gecontroleerde mappen:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Niet een geldige map"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Play"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Set Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Set Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Live stream"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr "%s wachtwoord Reset"
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Het Cue in en cue uit null zijn."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Niet instellen cue uit groter zijn dan de bestandslengte van het"
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Niet instellen cue in groter dan cue uit."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Niet instellen cue uit op kleiner zijn dan het cue in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Rebroadcast van %s van %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Selecteer land"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3828,12 @@ msgstr "%s is niet een geldige directory."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s is al ingesteld als de huidige opslag dir of in de lijst van gecontroleerde mappen"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s is al ingesteld als de huidige opslag dir of in de lijst van gecontroleerde mappen."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3841,18 @@ msgstr "%s is al ingesteld als de huidige opslag dir of in de lijst van gecontro
 msgid "%s doesn't exist in the watched list."
 msgstr "%s bestaat niet in de lijst met gevolgde."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr "%s wachtwoord Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Selecteer land"
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Shows kunnen hebben een maximale lengte van 24 uur."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Niet gepland overlappende shows.\nOpmerking: vergroten/verkleinen een herhalende show heeft invloed op alle van de herhalingen."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3867,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Het schema dat u aan het bekijken bent is verouderd! (exemplaar wanverhouding)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Het schema dat u aan het bekijken bent is verouderd!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "U zijn niet toegestaan om te plannen show %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "U kunt bestanden toevoegen aan het opnemen van programma's."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "De show %s is voorbij en kan niet worden gepland."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "De show %s heeft al eerder zijn bijgewerkt!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Inhoud in gekoppelde shows moet worden gepland vóór of na een een wordt uitgezonden"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr "Niet gepland een afspeellijst die ontbrekende bestanden bevat."
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Een geselecteerd bestand bestaat niet!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Shows kunnen hebben een maximale lengte van 24 uur."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Niet gepland overlappende shows.\n"
+"Opmerking: vergroten/verkleinen een herhalende show heeft invloed op alle van de herhalingen."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Rebroadcast van %s van %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3967,1070 @@ msgstr "Ongeldige webstream - dit lijkt te zijn een bestand te downloaden."
 msgid "Unrecognized stream type: %s"
 msgstr "Niet herkende type stream: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Record bestand bestaat niet"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Weergave opgenomen bestand Metadata"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr "Weergeven"
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr "Schema Tracks"
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr "Wissen show"
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr "Annuleren show"
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr "Aanleg bewerken"
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Bewerken"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Bewerken van Show"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr "Exemplaar verwijderen"
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr "Exemplaar verwijderen en alle volgende"
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Toestemming geweigerd"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Kan niet slepen en neerzetten herhalende shows"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Een verleden Show verplaatsen niet"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Niet verplaatsen show in verleden"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Een opgenomen programma minder dan 1 uur vóór haar rebroadcasts verplaatsen niet."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Toon is verwijderd omdat opgenomen programma niet bestaat!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Moet wachten 1 uur opnieuw uitzenden.."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "track"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Gespeeld"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "vorige"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "spelen"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pauze"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "volgende"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "Stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "dempen"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "microfoon"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "Max volume"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Update vereist"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Om te spelen de media moet u uw browser bijwerkt naar een recente versie of update uw %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Over"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr "%1$s %2$s, de open radio software voor planning en extern beheer van het station."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr "%1$s %2$s wordt gedistribueerd onder de %3$s"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr "Welkom tot %s!"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr "Hier is hoe je kunt krijgen gestart met behulp van %s te automatiseren uw uitzendingen:"
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
 msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Voor meer gedetailleerde hulp, lees de %sgebruikershandleiding%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Deel"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Selecteer stream:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Pagina niet gevonden!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Het lijkt erop dat de pagina die u zocht bestaat niet!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Bron weergeven"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Kies dagen:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "toevoegen"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Herhaal dagen:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filter geschiedenis"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Kies show exemplaar"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Zoeken"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud instellingen"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master bron"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "Oke"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Kies map"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Instellen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Huidige Import map:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr "Scannen van gevolgde directory (dit is handig als het netwerk mount is en gesynchroniseerd met %s worden kan)"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "gecontroleerde map verwijderen"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Niet bekijkt u alle Mediamappen."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime registreren"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr "Klik in het vak hieronder om uw station op %s."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Vereist)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(voor verificatie doeleinden alleen, zal niet worden gepubliceerd)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Toon mij wat ik ben verzenden"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Algemene voorwaarden"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "zoek Shows"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "of"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "en"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "tot"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "bestanden voldoen aan de criteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Stream"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Extra opties"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "De volgende info worden getoond aan luisteraars in hun mediaspeler"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Uw radio station website)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Ter bevordering van uw station, 'Feedback verzenden ondersteuning' moet worden ingeschakeld)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "track"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Lengte:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Sample Rate:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC nummer:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Bestandspad:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dynamische slimme blok"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statisch slimme blok"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Audiotrack"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Inhoud van de afspeellijst:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statisch slimme blok inhoud:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dynamische slimme blok Criteria:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Beperken tot"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Bestand importeren in vooruitgang..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Geadvanceerde zoek opties"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr "Welkom op de %s demo! U kunt zich aanmelden met de gebruikersnaam 'admin' en het wachtwoord 'admin'."
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nieuw wachtwoord"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Voer in en bevestig uw nieuwe wachtwoord in de velden hieronder."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Vorige:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Volgende:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Bron Streams"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ON AIR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Luister"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "loguit"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Uw proefperiode verloopt in"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Shuffle afspeellijst"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Afspeellijst crossfade"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Lege afspeellijst inhoud"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Wissen"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade out:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Afspeellijst opslaan"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Geen open afspeellijst"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Show Waveform"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Oorspronkelijke lengte:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade in:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Statisch blok uitbreiden"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Dynamische blok uitbreiden"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Log blad"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Bestand samenvatting"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Samenvatting weergeven"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Log blad sjablonen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Nieuwe Log werkbladsjabloon"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Geen Log blad sjablonen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Bestand samenvatting sjablonen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Nieuwe bestand samenvatting sjabloon"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Geen bestand samenvatting sjablonen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Bestand samenvatting sjabloon maken"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Log werkbladsjabloon maken"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Meer elementen toevoegen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Nieuw veld toevoegen"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Standaardsjabloon"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Instellingen voor stream"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Deze show toevoegen"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Bijwerken van show"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Wat"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Wanneer"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Live Stream Input"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Wie"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stijl"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Hardeschijf ruimte"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Gebruikers beheren"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nieuwe gebruiker"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Voornaam"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Achternaam"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Gebruikerstype"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "Stream URL:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Standaard lengte:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Geen webstream"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "Remove track"
+#~ msgstr "Nummer verwijderen"
+
+#~ msgid "Upload track"
+#~ msgstr "Uploaden van track"
+
+#~ msgid ""
+#~ "To configure and use the embeddable player you must:<br><br>\n"
+#~ "            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
+#~ "            2. Enable the Public Airtime API under System -> Preferences"
+#~ msgstr ""
+#~ " Configureren en de integreerbare speler u moet gebruiken:<br><br>1. Inschakelen ten minste één MP3, AAC en OGG stream onder systeem->Streams<br>\n"
+#~ "2. De openbare Airtime API inschakelen onder systeem->voorkeuren"
+
+#~ msgid ""
+#~ "To use the embeddable weekly schedule widget you must:<br><br>\n"
+#~ "            Enable the Public Airtime API under System -> Preferences"
+#~ msgstr ""
+#~ "De integreerbare per schema widget u moet gebruiken:<br><br>\n"
+#~ "de openbare Airtime API inschakelen onder systeem->voorkeuren"
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "Gelieve te zetten in een tijd in seconden '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Inhoud in gekoppelde shows moet worden gepland vóór of na een een wordt uitgezonden"

--- a/airtime_mvc/locale/nl_NL/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/nl_NL/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pl_PL/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # thedead4fun <matizochol@gmail.com>, 2015
 # Sourcefabric <contact@sourcefabric.org>, 2012
@@ -9,266 +9,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Polish (Poland) (http://www.transifex.com/sourcefabric/airtime/language/pl_PL/)\n"
+"Language: pl_PL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl_PL\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Rok %s musi być w przedziale od 1753 do 9999"
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s nie jest poprawną datą"
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s nie jest prawidłowym czasem"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Przeglądaj metadane nagrania"
-
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Edytuj"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Edytuj audycję"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Usuń"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Nie można użyć metody 'przeciągnij i upuść' dla powtórek audycji."
-
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Nie można przenieść audycji archiwalnej"
-
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Nie można przenieść audycji w przeszłość"
-
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Nie można planować nakładających się audycji"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Nagrywana audycja nie może zostać przeniesiona na mniej niż 1h przed jej powtórką."
-
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Audycja została usunięta, ponieważ nagranie nie istnieje!"
-
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Należy odczekać 1 godzinę przed ponownym odtworzeniem."
-
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Tytuł"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Twórca"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Długość"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Gatunek"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Nastrój"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Wydawnictwo"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Kompozytor"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
-
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Prawa autorskie"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Rok"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dyrygent/Pod batutą"
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Język"
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Odtwarzane"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalendarz"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Użytkownicy"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Strumienie"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Status"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Historia odtwarzania"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Statystyki słuchaczy"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Pomoc"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Jak zacząć"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Instrukcja użytkowania"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Nie masz dostępu do tej lokalizacji"
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Nie masz dostępu do tej lokalizacji."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Złe zapytanie. Nie zaakceprtowano parametru 'mode'"
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Złe zapytanie. Parametr 'mode' jest nieprawidłowy"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Nie masz uprawnień do odłączenia żródła"
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Źródło nie jest podłączone do tego wyjścia."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Nie masz uprawnień do przełączenia źródła."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "nie znaleziono %s"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Wystapił błąd"
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Podgląd"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Dodaj do listy odtwarzania"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Dodaj do smartblocku"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Edytuj Metadane."
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Usuń"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Pobierz"
 
@@ -277,81 +891,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Skopiuj listę odtwarzania"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Brak dostepnych czynności"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Nie masz uprawnień do usunięcia wybranych elementów"
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopia %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Webstream bez nazwy"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Zapisano webstream"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Nieprawidłowe wartości formularzy"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Upewnij się, że nazwa użytkownika i hasło są poprawne w System->Strumienie."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Użytkownik został dodany poprawnie!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Odtwrzacz "
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Użytkownik został poprawnie zaktualizowany!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Ustawienia zostały poprawnie zaktualizowane!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Nagrywanie:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Strumień Nadrzędny"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Transmisja na żywo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nic nie zaplanowano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Aktualna audycja:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Aktualny"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Używasz najnowszej wersji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Dostępna jest nowa wersja:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Ta wersja będzie wkrótce przestarzała."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Ta wersja nie jest już obsługiwana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Zaktualizuj na"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Dodaj do bieżącej listy odtwarzania"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Dodaj do bieżącego smart blocku"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Dodawanie 1 elementu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Dodawanie %s elementów"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "do smart blocków mozna dodawać tylko utwory."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Do list odtwarzania można dodawać tylko utwory, smart blocki i webstreamy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Proszę wybrać pozycję kursora na osi czasu."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Edytuj Metadane."
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Dodaj do wybranej audycji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Zaznacz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Zaznacz tę stronę"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Odznacz tę stronę"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Odznacz wszystko"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Czy na pewno chcesz usunąć wybrane elementy?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Tytuł"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Twórca"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bit Rate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Kompozytor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dyrygent/Pod batutą"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Prawa autorskie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Kodowane przez"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Gatunek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Wydawnictwo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Język"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Ostatnio zmodyfikowany"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Ostatnio odtwarzany"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Długość"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Podobne do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Nastrój"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Właściciel"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Normalizacja głośności (Replay Gain)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Wartość próbkowania"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Numer utworu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Przesłano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Strona internetowa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Rok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Ładowanie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Wszystko"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Pliki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Listy odtwarzania"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Blocki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Nieznany typ:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Czy na pewno chcesz usunąć wybrany element?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Wysyłanie w toku..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Pobieranie danych z serwera..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Id SoundCloud dla tego pliku to:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Wystąpił błąd podczas wysyłania na SoundCloud"
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Kod błędu:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Komunikat błędu:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Podana wartość musi być liczbą dodatnią"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Podana wartość musi być liczbą"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Podana wartość musi mieć format yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Podana wartość musi mieć format hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Aktualnie dodajesz pliki. %sPrzejście do innej strony przerwie ten proces. %sCzy na pewno chcesz przejść do innej strony?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "Wprowadź czas w formacie: '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Twoja przeglądarka nie obsługuje odtwarzania plików tego typu:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Podgląd bloku dynamicznego nie jest możliwy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Ograniczenie do:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Lista odtwarzania została zapisana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Playlista została przemieszana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime nie może odczytać statusu pliku. Może się tak zdarzyć, gdy plik znajduje się na zdalnym dysku, do którego aktualnie nie ma dostępu lub znajduje się w katalogu, który nie jest już \"obserwowany\"."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Licznik słuchaczy na %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Przypomnij mi za 1 tydzień"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Nie przypominaj nigdy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Tak, wspieraj Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Obraz musi mieć format jpg, jpeg, png lub gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Statyczny smart block będzie zapisywał kryteria i zawartość bezpośrednio, co umożliwia edycję i wyświetlanie go w bibliotece, przed dodaniem do audycji."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Dynamiczny smart block zapisuje tylko kryteria. Jego zawartość będzie generowana automatycznie po dodaniu go do audycji. Nie będzie można go wyświetlać i edytować w zawartości biblioteki."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Pożądana długość bloku nie zostanie osiągnięta jesli airtime nie znajdzie wystarczającej liczby oryginalnych ścieżek spełniających kryteria wyszukiwania. Włącz tę opcję jesli chcesz, żeby ścieżki zostały wielokrotnie dodane do smart blocku."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart blocku został przemieszany"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Utworzono smartblock i zapisano kryteria"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block został zapisany"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Przetwarzanie..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Wybierz modyfikator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "zawiera"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "nie zawiera"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "to"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "to nie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "zaczyna się od"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "kończy się"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "jest większa niż"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "jest mniejsza niż"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "mieści się w zakresie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Wybierz ścieżkę do katalogu importu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Wybierz katalog do obserwacji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Czy na pewno chcesz zamienić ścieżkę do katalogu importu\n"
+"Wszystkie pliki z biblioteki Airtime zostaną usunięte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Zarządzaj folderami mediów"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Czy na pewno chcesz usunąć katalog z listy katalogów obserwowanych?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Ściezka  jest obecnie niedostepna."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Połączono z serwerem streamingu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Strumień jest odłączony"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Pobieranie informacji z serwera..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Nie można połączyć z serwerem streamującym"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Jesli Airtime korzysta z routera bądź firewalla, może być konieczna konfiguracja przekierowywania portu i informacja w tym polu będzie nieprawidłowa. W takim wypadku należy dokonac ręcznej aktualizacji pola, tak żeby wyświetlił się prawidłowy host/ port/ mount, do którego mógłby podłączyć się prowadzący. Dopuszczalny zakres to 1024 i 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "W celu uzyskania wiecej informacji, należy zapoznać się z %sAirtime Manual%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Zaznacz tę opcję w celu włączenia metadanych dla strumieni OGG (metadane strumieniowe to tytuł ścieżki, artysta i nazwa audycji, ktróre wyświetlają się w odtwarzaczu audio). VLC oraz mplayer mają problem z odtwarzaniem strumienia OGG/Vorbis, których metadane zostały udostępnione- odłączają się one od strumenia po każdej piosence. Jeśli używasz strumeinia OGG, a słuchacze nie żądają mozliwości odtwarzania w tych odtwarzaczach, wówczas można udostepnić tę opcję"
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "To pole służy do automatycznego wyłączenia źródła nadrzędnego/źródła audycji po jego odłączeniu."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "To pole służy automatycznego uruchomienia źródła nadrzędnego/źródła audycji na połączeniu źródłowym"
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Jesli serwer Icecast wymaga nazwy użytkownika \"source\", pole to może zostać puste"
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Jeśli klient nie żąda nazwy uzytkownika, zawartośc tego pola powinna być \"source\""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Nazwa uzytkownika i hasło administartora w programie Icecast/ SHOUTcast w celu uzyskania dostępu do statystyki słuchalności"
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nie znaleziono wyników"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Ta funkcja działa w programach wg tych samych zasad bezpiezeństwa: jedynie użytkownicy przypisani do audcyji mogą się podłączyć."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Ustal własne uwierzytelnienie tylko dla tej audycji."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Instancja audycji już nie istnieje."
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Audycja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Audycja jest pusta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60 min"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Odbieranie danych z serwera"
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Ta audycja nie ma zawartości"
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Brak pełnej zawartości tej audycji."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Styczeń"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Luty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Marzec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Kwiecień"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Maj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Czerwiec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Lipiec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Sierpień"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Wrzesień"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Październik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Listopad"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Grudzień"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Sty"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Lut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Kwi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Cze"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Lip"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Sie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Wrz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Paź"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Lis"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Gru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Niedziela"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Poniedziałek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Wtorek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Środa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Czwartek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Piątek"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Sobota"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Nie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Pon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Wt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Śr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Czw"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Pt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sob"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Audycje o czasie dłuższym niż zaplanowany będą przerywane przez następne ."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Skasować obecną audycję?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Przerwać nagrywanie aktualnej audycji?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Zawartośc audycji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Usunąć całą zawartość?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Skasować wybrane elementy?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Rozpocznij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Zakończ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Czas trwania"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Zgłaśnianie [Fade In]"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Wyciszanie [Fade out]"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Audycja jest pusta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Nagrywaanie z wejścia liniowego"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Podgląd utworu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Nie ma możliwości planowania poza audycją."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Przenoszenie 1 elementu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Przenoszenie %s elementów"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Zapisz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Zaznacz wszystko"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Odznacz wszystkie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Usuń wybrane elementy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Przejdź do obecnie odtwarzanej ściezki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Skasuj obecną audycję"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Otwóz bibliotekę w celu dodania bądź usunięcia zawartości"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Dodaj/usuń zawartość"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "W użyciu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Dysk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Sprawdź"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Otwórz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "Prowadzący"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Menedżer programowy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Gość"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Goście mają mozliwość:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Przeglądanie harmonogramu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Przeglądanie zawartości audycji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Prowadzący ma możliwość:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Zarządzać przypisaną sobie zawartością audycji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Importować pliki mediów"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Tworzyć playlisty, smart blocki i webstreamy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Zarządzać zawartością własnej biblioteki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Zarządzający programowi mają możliwość:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Przeglądać i zarządzać zawartością audycji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Planować audycję"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Zarządzać całą zawartością biblioteki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Administrator ma mozliwość:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Zarządzać preferencjami"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Zarządzać użytkownikami"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Zarządzać przeglądanymi katalogami"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Wyślij informację zwrotną"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Sprawdzać status systemu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Przeglądać historię odtworzeń"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Sprawdzać statystyki słuchaczy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Pokaż/ukryj kolumny"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Od {from} do {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Nd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Pn"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Wt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Śr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Cz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Pt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "So"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Zamknij"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Godzina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Gotowe"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Wybierz pliki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Dodaj pliki do kolejki i wciśnij \"start\""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Dodaj pliki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Zatrzymaj przesyłanie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Rozpocznij przesyłanie"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Dodaj pliki"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Dodano pliki %d%d"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "Nie dotyczy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Przeciągnij pliki tutaj."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Błąd rozszerzenia pliku."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Błąd rozmiaru pliku."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Błąd liczenia plików"
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Błąd inicjalizacji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Błąd HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Błąd zabezpieczeń."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Błąd ogólny."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Błąd I/O"
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Plik: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d plików oczekujących"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Plik: %f, rozmiar %s, maksymalny rozmiar pliku: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "URL nie istnieje bądź jest niewłaściwy"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Błąd: plik jest za duży:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Błąd: nieprawidłowe rozszerzenie pliku:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "Skopiowano %srow%s do schowka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sPrint view%s Użyj j funkcji drukowania na swojej wyszykiwarce. By zakończyć, wciśnij 'escape'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Email nie został wysłany. Sprawdź swoje ustawienia serwera pocztowego i upewnij się, że został skonfigurowany poprawnie."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Błędna nazwa użytkownika lub hasło. Spróbuj ponownie."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -371,11 +2406,6 @@ msgstr "Nie masz pozwolenia na usunięcie wybranych %s(s)"
 msgid "You can only add tracks to smart block."
 msgstr "Utwory mogą być dodane tylko do smartblocku"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Do list odtwarzania można dodawać tylko utwory, smart blocki i webstreamy"
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Lista odtwarzania bez tytułu"
@@ -384,2627 +2414,88 @@ msgstr "Lista odtwarzania bez tytułu"
 msgid "Untitled Smart Block"
 msgstr "Smartblock bez tytułu"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Nieznana playlista"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Nie masz dostępu do tej lokalizacji"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Zaktualizowano preferencje."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Zaktualizowano ustawienia wsparcia."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Informacja zwrotna"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Zaktualizowano ustawienia strumienia"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "należy okreslić ścieżkę"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem z Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Nie masz uprawnień do odłączenia żródła"
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Źródło nie jest podłączone do tego wyjścia."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Nie masz uprawnień do przełączenia źródła."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Błędna nazwa użytkownika lub hasło. Spróbuj ponownie."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Email nie został wysłany. Sprawdź swoje ustawienia serwera pocztowego i upewnij się, że został skonfigurowany poprawnie."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Nie masz dostępu do tej lokalizacji."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Złe zapytanie. Nie zaakceprtowano parametru 'mode'"
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Złe zapytanie. Parametr 'mode' jest nieprawidłowy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Odtwrzacz "
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Nagrywanie:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Strumień Nadrzędny"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Transmisja na żywo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nic nie zaplanowano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Aktualna audycja:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Aktualny"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Używasz najnowszej wersji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Dostępna jest nowa wersja:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Ta wersja będzie wkrótce przestarzała."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Ta wersja nie jest już obsługiwana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Zaktualizuj na"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Dodaj do bieżącej listy odtwarzania"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Dodaj do bieżącego smart blocku"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Dodawanie 1 elementu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Dodawanie %s elementów"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "do smart blocków mozna dodawać tylko utwory."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Proszę wybrać pozycję kursora na osi czasu."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Dodaj do wybranej audycji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Zaznacz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Zaznacz tę stronę"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Odznacz tę stronę"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Odznacz wszystko"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Czy na pewno chcesz usunąć wybrane elementy?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bit Rate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Kodowane przez"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Ostatnio zmodyfikowany"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Ostatnio odtwarzany"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Podobne do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Właściciel"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Normalizacja głośności (Replay Gain)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Wartość próbkowania"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Numer utworu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Przesłano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Strona internetowa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Ładowanie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Wszystko"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Pliki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Listy odtwarzania"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Blocki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Nieznany typ:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Czy na pewno chcesz usunąć wybrany element?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Wysyłanie w toku..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Pobieranie danych z serwera..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Id SoundCloud dla tego pliku to:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Wystąpił błąd podczas wysyłania na SoundCloud"
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Kod błędu:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Komunikat błędu:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Podana wartość musi być liczbą dodatnią"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Podana wartość musi być liczbą"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Podana wartość musi mieć format yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Podana wartość musi mieć format hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Aktualnie dodajesz pliki. %sPrzejście do innej strony przerwie ten proces. %sCzy na pewno chcesz przejść do innej strony?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "Wprowadź czas w formacie: '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "Wprowadź czas w sekundach '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Twoja przeglądarka nie obsługuje odtwarzania plików tego typu:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Podgląd bloku dynamicznego nie jest możliwy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Ograniczenie do:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Lista odtwarzania została zapisana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Playlista została przemieszana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime nie może odczytać statusu pliku. Może się tak zdarzyć, gdy plik znajduje się na zdalnym dysku, do którego aktualnie nie ma dostępu lub znajduje się w katalogu, który nie jest już \"obserwowany\"."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Licznik słuchaczy na %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Przypomnij mi za 1 tydzień"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Nie przypominaj nigdy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Tak, wspieraj Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Obraz musi mieć format jpg, jpeg, png lub gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Statyczny smart block będzie zapisywał kryteria i zawartość bezpośrednio, co umożliwia edycję i wyświetlanie go w bibliotece, przed dodaniem do audycji."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Dynamiczny smart block zapisuje tylko kryteria. Jego zawartość będzie generowana automatycznie po dodaniu go do audycji. Nie będzie można go wyświetlać i edytować w zawartości biblioteki."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Pożądana długość bloku nie zostanie osiągnięta jesli airtime nie znajdzie wystarczającej liczby oryginalnych ścieżek spełniających kryteria wyszukiwania. Włącz tę opcję jesli chcesz, żeby ścieżki zostały wielokrotnie dodane do smart blocku."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart blocku został przemieszany"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Utworzono smartblock i zapisano kryteria"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block został zapisany"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Przetwarzanie..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Wybierz modyfikator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "zawiera"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "nie zawiera"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "to"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "to nie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "zaczyna się od"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "kończy się"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "jest większa niż"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "jest mniejsza niż"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "mieści się w zakresie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Wybierz ścieżkę do katalogu importu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Wybierz katalog do obserwacji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Czy na pewno chcesz zamienić ścieżkę do katalogu importu\nWszystkie pliki z biblioteki Airtime zostaną usunięte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Zarządzaj folderami mediów"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Czy na pewno chcesz usunąć katalog z listy katalogów obserwowanych?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Ściezka  jest obecnie niedostepna."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Połączono z serwerem streamingu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Strumień jest odłączony"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Pobieranie informacji z serwera..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Nie można połączyć z serwerem streamującym"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Jesli Airtime korzysta z routera bądź firewalla, może być konieczna konfiguracja przekierowywania portu i informacja w tym polu będzie nieprawidłowa. W takim wypadku należy dokonac ręcznej aktualizacji pola, tak żeby wyświetlił się prawidłowy host/ port/ mount, do którego mógłby podłączyć się prowadzący. Dopuszczalny zakres to 1024 i 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "W celu uzyskania wiecej informacji, należy zapoznać się z %sAirtime Manual%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Zaznacz tę opcję w celu włączenia metadanych dla strumieni OGG (metadane strumieniowe to tytuł ścieżki, artysta i nazwa audycji, ktróre wyświetlają się w odtwarzaczu audio). VLC oraz mplayer mają problem z odtwarzaniem strumienia OGG/Vorbis, których metadane zostały udostępnione- odłączają się one od strumenia po każdej piosence. Jeśli używasz strumeinia OGG, a słuchacze nie żądają mozliwości odtwarzania w tych odtwarzaczach, wówczas można udostepnić tę opcję"
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "To pole służy do automatycznego wyłączenia źródła nadrzędnego/źródła audycji po jego odłączeniu."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "To pole służy automatycznego uruchomienia źródła nadrzędnego/źródła audycji na połączeniu źródłowym"
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Jesli serwer Icecast wymaga nazwy użytkownika \"source\", pole to może zostać puste"
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Jeśli klient nie żąda nazwy uzytkownika, zawartośc tego pola powinna być \"source\""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Nazwa uzytkownika i hasło administartora w programie Icecast/ SHOUTcast w celu uzyskania dostępu do statystyki słuchalności"
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nie znaleziono wyników"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Ta funkcja działa w programach wg tych samych zasad bezpiezeństwa: jedynie użytkownicy przypisani do audcyji mogą się podłączyć."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Ustal własne uwierzytelnienie tylko dla tej audycji."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Instancja audycji już nie istnieje."
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Audycja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Audycja jest pusta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60 min"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Odbieranie danych z serwera"
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Ta audycja nie ma zawartości"
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Brak pełnej zawartości tej audycji."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Styczeń"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Luty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Marzec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Kwiecień"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Maj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Czerwiec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Lipiec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Sierpień"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Wrzesień"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Październik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Listopad"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Grudzień"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Sty"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Lut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Kwi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Cze"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Lip"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Sie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Wrz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Paź"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Lis"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Gru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Niedziela"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Poniedziałek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Wtorek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Środa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Czwartek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Piątek"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Sobota"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Nie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Pon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Wt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Śr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Czw"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Pt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sob"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Audycje o czasie dłuższym niż zaplanowany będą przerywane przez następne ."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Skasować obecną audycję?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Przerwać nagrywanie aktualnej audycji?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Zawartośc audycji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Usunąć całą zawartość?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Skasować wybrane elementy?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Rozpocznij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Zakończ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Czas trwania"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Zgłaśnianie [Fade In]"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Wyciszanie [Fade out]"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Audycja jest pusta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Nagrywaanie z wejścia liniowego"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Podgląd utworu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Nie ma możliwości planowania poza audycją."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Przenoszenie 1 elementu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Przenoszenie %s elementów"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Zapisz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Anuluj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Zaznacz wszystko"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Odznacz wszystkie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Usuń wybrane elementy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Przejdź do obecnie odtwarzanej ściezki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Skasuj obecną audycję"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Otwóz bibliotekę w celu dodania bądź usunięcia zawartości"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Dodaj/usuń zawartość"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "W użyciu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Dysk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Sprawdź"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Otwórz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "Prowadzący"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Menedżer programowy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Gość"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Goście mają mozliwość:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Przeglądanie harmonogramu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Przeglądanie zawartości audycji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Prowadzący ma możliwość:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Zarządzać przypisaną sobie zawartością audycji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Importować pliki mediów"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Tworzyć playlisty, smart blocki i webstreamy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Zarządzać zawartością własnej biblioteki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Zarządzający programowi mają możliwość:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Przeglądać i zarządzać zawartością audycji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Planować audycję"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Zarządzać całą zawartością biblioteki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Administrator ma mozliwość:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Zarządzać preferencjami"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Zarządzać użytkownikami"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Zarządzać przeglądanymi katalogami"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Wyślij informację zwrotną"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Sprawdzać status systemu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Przeglądać historię odtworzeń"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Sprawdzać statystyki słuchaczy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Pokaż/ukryj kolumny"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Od {from} do {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Nd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Pn"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Wt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Śr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Cz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Pt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "So"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Zamknij"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Godzina"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Gotowe"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Wybierz pliki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Dodaj pliki do kolejki i wciśnij \"start\""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Status"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Dodaj pliki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Zatrzymaj przesyłanie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Rozpocznij przesyłanie"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Dodaj pliki"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Dodano pliki %d%d"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "Nie dotyczy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Przeciągnij pliki tutaj."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Błąd rozszerzenia pliku."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Błąd rozmiaru pliku."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Błąd liczenia plików"
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Błąd inicjalizacji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Błąd HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Błąd zabezpieczeń."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Błąd ogólny."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Błąd I/O"
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Plik: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d plików oczekujących"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Plik: %f, rozmiar %s, maksymalny rozmiar pliku: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "URL nie istnieje bądź jest niewłaściwy"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Błąd: plik jest za duży:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Błąd: nieprawidłowe rozszerzenie pliku:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "Skopiowano %srow%s do schowka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sPrint view%s Użyj j funkcji drukowania na swojej wyszykiwarce. By zakończyć, wciśnij 'escape'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Wybierz kursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Usuń kursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "audycja nie istnieje"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Retransmisja audycji %s z %s o %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Wybierz kursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Usuń kursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "audycja nie istnieje"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Użytkownik został dodany poprawnie!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Użytkownik został poprawnie zaktualizowany!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Ustawienia zostały poprawnie zaktualizowane!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Webstream bez nazwy"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Zapisano webstream"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Nieprawidłowe wartości formularzy"
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Rok %s musi być w przedziale od 1753 do 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s nie jest poprawną datą"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s nie jest prawidłowym czasem"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Transmisja na żywo"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Podziel się"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Wybierz strumień:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "wycisz"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "włącz głos"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Informacje"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "W celu uzyskania szczegółowej pomocy, skorzystaj z %suser manual%s"
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Historia odtwarzania"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Zwiększ bok statyczny"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Zwiększ blok dynamiczny"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Nazwa:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Opis:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Czas trwania:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Wymieszaj listę odtwarzania"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Przemieszaj"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Płynne przenikanie utworów na liście dotwarzania"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Zgłaśnianie [fade in]:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Wyciszanie [fade out]:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Zapisz listę odtwarzania"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Brak otwartej listy odtwarzania"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Zgłaśnianie [Cue in]:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Wyciszanie [Cue out]:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Oryginalna długość:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Ustawienia strumienia"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Zaloguj"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nowe hasło"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Wprowadź i potwierdź swoje hasło w poniższych polach"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Zarządzaj Użytkownikami"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Nowy Użytkownik"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Nazwa użytkownika"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Imię"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Nazwisko"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Typ użytkownika"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Znajdź audycję"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Dni powtarzania:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Usuń"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Dodaj"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Źródło audycji"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Zarejestruj Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Wymagane)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(tylko dla celów weryfikacji, dane nie będą rozpowszechniane)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Uwaga: każdy plik o rozmiarze większym niż 600x600 zostanie zmniejszony"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Pokazuj, co wysyłam"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Zasady i warunki"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Wybierz dni:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "do"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "pliki spełniają kryteria"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtruj Historię"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Aby promowac stację, należy udostepnić funkcję \"wyślij informację zwrotną\")"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Strumień"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Opcje dodatkowe"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "W odtwarzaczu słuchacza wyświetli sie nastepujaca informacja:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Strona internetowa Twojej stacji)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL strumienia:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Wybierz folder"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Ustaw"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktualny folder importu:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Usuń obserwowany katalog."
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Nie obserwujesz w tej chwili żadnych folderów"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Źródło Nadrzędne"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Ustawienia SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Dodaj audycję"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Aktualizuj audycję"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Co"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Kiedy"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Wejście Strumienia \"Na żywo\""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Kto"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Styl"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Miejsce na dysku "
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Importowanie plików w toku..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Zaawansowane opcje wyszukiwania"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Tytuł:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Autor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Utwór:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Długość: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Częstotliwość próbkowania:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Rate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Nastrój:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Rodzaj:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Rok:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Wydawnictwo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Kompozytor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dyrygent/Pod batutą:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Prawa autorskie:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Numer Isrc:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Strona internetowa:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Język:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Ścieżka pliku:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Web Stream"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Smart block dynamiczny"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Smart block statyczny"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Ścieżka audio"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Zawartość listy odtwarzania:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Zawartość statycznego Smart Blocka:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Kryteria dynamicznego Smart Blocku "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Ogranicz(enie) do:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "Adres URL"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Twoja próba wygasa"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dni"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Poprzedni:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Następny:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Strumienie źródłowe"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "Na antenie"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Słuchaj"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Wyloguj"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Nazwa"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Opis"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL strumienia:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Domyślna długość:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Brak webstreamu"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Pomoc"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Nie znaleziono strony!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Wygląda na to, że strona, której szukasz nie istnieje"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "poprzedni"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "play"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pauza"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "następny"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "maksymalna głośność"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Wymagana aktualizacja"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "By odtworzyć medium, należy zaktualizować przeglądarkę do najnowszej wersji bądź zainstalowac aktualizację %sFlash plugin%s"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Data rozpoczęcia:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3014,127 +2505,6 @@ msgstr "Data rozpoczęcia:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Wprowadzony znak jest nieprawidłowy"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Data zakończenia:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Wszystkie moje audycje:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Szukaj Użytkowników:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Prowadzący:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Nazwa stacji"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Strona internetowa stacji:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Kraj:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Miasto:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Opis stacji:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo stacji:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Wymagana jest akceptacja polityki prywatności."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Nagrywać z wejścia liniowego?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Odtwarzać ponownie?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Pole jest wymagane i nie może być puste"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' nie jest poprawnym adresem email w podstawowym formacie local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' nie pasuje do formatu daty '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' zawiera mniej niż %min% znaków"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' zawiera więcej niż %max% znaków"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' nie zawiera się w przedziale od '%min%' do '%max%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Hasła muszą się zgadzać"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3151,675 +2521,55 @@ msgstr "Należy określić czas"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Należy odczekać przynajmniej 1 godzinę przed ponownym odtworzeniem"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Resetuj hasło"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Audycja bez nazwy"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Numer ISRC:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Wyłączone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Włączone"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Tydzień zaczynaj od"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Nazwa użytkownika:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Hasło:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Potwierdź hasło:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Imię:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Nazwisko:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Typ użytkownika:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Nazwa użytkownika musi być unikalna."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Katalog importu:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Katalogi obserwowane:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Nieprawidłowy katalog"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Domyślna licencja:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Wszelkie prawa zastrzeżone"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Utwór w domenie publicznej"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Uznanie autorstwa wg licencji Creative Commons "
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Użycie niekomercyjne wg Creative Commons "
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Uznanie Autorstwa Bez Utworów Zależnych wg Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Uznanie a Na Tych Samych Warunkach  wg Creative Commons "
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Uznanie Autorstwa Bez Utworów Zależnych wg Creative Commons"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Uznanie a Na Tych Samych Warunkach  wg Creative Commons "
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Aktualnie odtwarzane"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Wybierz kryteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Rate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Częstotliwość próbkowania (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "godzin(y)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minut(y)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "elementy"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statyczny"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dynamiczny"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Tworzenie zawartości listy odtwarzania i zapisz kryteria"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Utwórz"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Losowa kolejność odtwarzania"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Limit nie może być pusty oraz mniejszy od 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Limit nie może być większy niż 24 godziny"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Wartość powinna być liczbą całkowitą"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Maksymalna liczba elementów do ustawienia to 500"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Należy wybrać kryteria i modyfikator"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "Długość powinna być wprowadzona w formacie '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Wartość powinna byc zapisana w formacie timestamp (np. 0000-00-00 lub 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Wartość musi być liczbą"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Wartość powinna być mniejsza niż 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Wartość powinna posiadać mniej niż %s znaków"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Wartość nie może być pusta"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Metadane Icecast Vorbis"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Nazwa strumienia:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artysta - Tytuł"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Audycja - Artysta -Tytuł"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Nazwa stacji - Nazwa audycji"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Metadane Off Air"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Włącz normalizację głośności (Replay Gain)"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Modyfikator normalizacji głośności"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Hasło"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Potwierdź nowe hasło"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Hasła muszą się zgadzać."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Włączony:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Typ strumienia:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Typ usługi:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanały:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Serwer"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Możliwe są tylko cyfry."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "adres URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Punkt montowania"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Login Administratora"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Hasło Administratora"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Serwer nie może być pusty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port nie może być pusty."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Punkt montowania nie może być pusty dla serwera Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "%value% nie odpowiada formatowi 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Strefa czasowa:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Powtarzanie?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Nie można utworzyć audycji w przeszłości"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Nie mozna zmienić daty/czasu audycji, która się już rozpoczęła"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Data lub czas zakończenia nie może być z przeszłości."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Czas trwania nie może być mniejszy niż 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Czas trwania nie może wynosić 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Czas trwania nie może być dłuższy niż 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Zastosuj własne uwierzytelnienie:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Nazwa użytkownika"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Hasło"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Pole nazwy użytkownika nie może być puste."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Pole hasła nie może być puste."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Kolor tła:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Kolor tekstu:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Wpisz znaki, które widzisz na obrazku poniżej."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dni"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3865,6 +2615,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Data zakończenia:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Bez czasu końcowego?"
@@ -3877,115 +2633,1174 @@ msgstr "Data końcowa musi występować po dacie początkowej"
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Nagrywać z wejścia liniowego?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Odtwarzać ponownie?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Kolor tła:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Kolor tekstu:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalendarz"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Usuń"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Użytkownicy"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Nazwa:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Strumienie"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Audycja bez nazwy"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "Adres URL"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Rodzaj:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Opis:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Statystyki słuchaczy"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "%value% nie odpowiada formatowi 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Czas trwania:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Strefa czasowa:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Powtarzanie?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Nie można utworzyć audycji w przeszłości"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Nie mozna zmienić daty/czasu audycji, która się już rozpoczęła"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Data lub czas zakończenia nie może być z przeszłości."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Czas trwania nie może być mniejszy niż 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Czas trwania nie może wynosić 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Czas trwania nie może być dłuższy niż 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Nie można planować nakładających się audycji"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Szukaj Użytkowników:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Prowadzący:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Nazwa użytkownika:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Hasło:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Potwierdź hasło:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Imię:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Nazwisko:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Typ użytkownika:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Nazwa użytkownika musi być unikalna."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Jak zacząć"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Instrukcja użytkowania"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Pole jest wymagane i nie może być puste"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Data rozpoczęcia:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Tytuł:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Autor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Rok:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Wydawnictwo:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Kompozytor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dyrygent/Pod batutą:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Nastrój:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Prawa autorskie:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Numer ISRC:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Strona internetowa:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Język:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Nazwa stacji"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo stacji:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Uwaga: każdy plik o rozmiarze większym niż 600x600 zostanie zmniejszony"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Wyłączone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Włączone"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Tydzień zaczynaj od"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' nie jest poprawnym adresem email w podstawowym formacie local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' nie pasuje do formatu daty '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' zawiera mniej niż %min% znaków"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' zawiera więcej niż %max% znaków"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' nie zawiera się w przedziale od '%min%' do '%max%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Hasła muszą się zgadzać"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Możliwe są tylko cyfry."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Zaloguj"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Wpisz znaki, które widzisz na obrazku poniżej."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Hasło"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Potwierdź nowe hasło"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Hasła muszą się zgadzać."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Nazwa użytkownika"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Resetuj hasło"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Aktualnie odtwarzane"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Strona internetowa stacji:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Kraj:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Miasto:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Opis stacji:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Wymagana jest akceptacja polityki prywatności."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Wszystkie moje audycje:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Wybierz kryteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Rate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Opis"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Częstotliwość próbkowania (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "godzin(y)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minut(y)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "elementy"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statyczny"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dynamiczny"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Tworzenie zawartości listy odtwarzania i zapisz kryteria"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Utwórz"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Losowa kolejność odtwarzania"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Przemieszaj"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Limit nie może być pusty oraz mniejszy od 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Limit nie może być większy niż 24 godziny"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Wartość powinna być liczbą całkowitą"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Maksymalna liczba elementów do ustawienia to 500"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Należy wybrać kryteria i modyfikator"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "Długość powinna być wprowadzona w formacie '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Wartość powinna byc zapisana w formacie timestamp (np. 0000-00-00 lub 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Wartość musi być liczbą"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Wartość powinna być mniejsza niż 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Wartość powinna posiadać mniej niż %s znaków"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Wartość nie może być pusta"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Domyślna licencja:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Wszelkie prawa zastrzeżone"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Utwór w domenie publicznej"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Uznanie autorstwa wg licencji Creative Commons "
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Użycie niekomercyjne wg Creative Commons "
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Uznanie Autorstwa Bez Utworów Zależnych wg Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Uznanie a Na Tych Samych Warunkach  wg Creative Commons "
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Uznanie Autorstwa Bez Utworów Zależnych wg Creative Commons"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Uznanie a Na Tych Samych Warunkach  wg Creative Commons "
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Metadane Icecast Vorbis"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Nazwa strumienia:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artysta - Tytuł"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Audycja - Artysta -Tytuł"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Nazwa stacji - Nazwa audycji"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Metadane Off Air"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Włącz normalizację głośności (Replay Gain)"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Modyfikator normalizacji głośności"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Włączony:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Typ strumienia:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Rate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Typ usługi:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanały:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Serwer"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "adres URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Nazwa"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Punkt montowania"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Login Administratora"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Hasło Administratora"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Serwer nie może być pusty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port nie może być pusty."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Punkt montowania nie może być pusty dla serwera Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Katalog importu:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Katalogi obserwowane:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Nieprawidłowy katalog"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Transmisja na żywo"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue-in i cue-out mają wartość zerową."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Wartość cue-out nie może być większa niż długość pliku."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Wartość cue-in nie może być większa niż cue-out."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Wartość cue-out nie może być mniejsza od cue-in."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Retransmisja z %s do %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Wybierz kraj"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4010,14 +3825,12 @@ msgstr "%s nie jest poprawnym katalogiem."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s jest już ustawiony jako katalog główny bądź znajduje się na liście katalogów obserwowanych"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s jest już ustawiony jako katalog główny bądź znajduje się na liście katalogów obserwowanych."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4025,28 +3838,18 @@ msgstr "%s jest już ustawiony jako katalog główny bądź znajduje się na li�
 msgid "%s doesn't exist in the watched list."
 msgstr "%s nie występuje na liście katalogów obserwowanych."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Wybierz kraj"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Audycje mogą mieć maksymalną długość 24 godzin."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Nie można planować audycji nakładających się na siebie.\nUwaga: zmiana audycji powoduje automatyczną zmianę wszystkich jej powtórzeń."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4061,48 +3864,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Harmonogram, który przeglądasz jest nieaktualny! (błędne dopasowanie instancji)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Harmonogram, który przeglądasz jest nieaktualny!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Nie posiadasz uprawnień, aby zaplanować audycję %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Nie można dodawać plików do nagrywanych audycji."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Audycja %s przekracza dopuszczalną długość i nie może zostać zaplanowana."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Audycja %s została zaktualizowana wcześniej!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Wybrany plik nie istnieje!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Audycje mogą mieć maksymalną długość 24 godzin."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Nie można planować audycji nakładających się na siebie.\n"
+"Uwaga: zmiana audycji powoduje automatyczną zmianę wszystkich jej powtórzeń."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Retransmisja z %s do %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4149,8 +3964,1046 @@ msgstr "Nieprawidłowy webstream, prawdopodobnie trwa pobieranie pliku."
 msgid "Unrecognized stream type: %s"
 msgstr "Nie rozpoznano typu strumienia: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Przeglądaj metadane nagrania"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Edytuj"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Edytuj audycję"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Nie można użyć metody 'przeciągnij i upuść' dla powtórek audycji."
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Nie można przenieść audycji archiwalnej"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Nie można przenieść audycji w przeszłość"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Nagrywana audycja nie może zostać przeniesiona na mniej niż 1h przed jej powtórką."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Audycja została usunięta, ponieważ nagranie nie istnieje!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Należy odczekać 1 godzinę przed ponownym odtworzeniem."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Odtwarzane"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "poprzedni"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "play"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pauza"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "następny"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "wycisz"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "włącz głos"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "maksymalna głośność"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Wymagana aktualizacja"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "By odtworzyć medium, należy zaktualizować przeglądarkę do najnowszej wersji bądź zainstalowac aktualizację %sFlash plugin%s"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Informacje"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "W celu uzyskania szczegółowej pomocy, skorzystaj z %suser manual%s"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Podziel się"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Wybierz strumień:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Nie znaleziono strony!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Wygląda na to, że strona, której szukasz nie istnieje"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Źródło audycji"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Wybierz dni:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Dodaj"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Dni powtarzania:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtruj Historię"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Ustawienia SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Źródło Nadrzędne"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Wybierz folder"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Ustaw"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktualny folder importu:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Usuń obserwowany katalog."
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Nie obserwujesz w tej chwili żadnych folderów"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Zarejestruj Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Wymagane)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(tylko dla celów weryfikacji, dane nie będą rozpowszechniane)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Pokazuj, co wysyłam"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Zasady i warunki"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Znajdź audycję"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "do"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "pliki spełniają kryteria"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Strumień"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Opcje dodatkowe"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "W odtwarzaczu słuchacza wyświetli sie nastepujaca informacja:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Strona internetowa Twojej stacji)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL strumienia:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Aby promowac stację, należy udostepnić funkcję \"wyślij informację zwrotną\")"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Utwór:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Długość: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Częstotliwość próbkowania:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Numer Isrc:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Ścieżka pliku:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Web Stream"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Smart block dynamiczny"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Smart block statyczny"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Ścieżka audio"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Zawartość listy odtwarzania:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Zawartość statycznego Smart Blocka:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Kryteria dynamicznego Smart Blocku "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Ogranicz(enie) do:"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Importowanie plików w toku..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Zaawansowane opcje wyszukiwania"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nowe hasło"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Wprowadź i potwierdź swoje hasło w poniższych polach"
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Poprzedni:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Następny:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Strumienie źródłowe"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "Na antenie"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Słuchaj"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Wyloguj"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Twoja próba wygasa"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Wymieszaj listę odtwarzania"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Płynne przenikanie utworów na liście dotwarzania"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Wyciszanie [fade out]:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Zapisz listę odtwarzania"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Brak otwartej listy odtwarzania"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Zgłaśnianie [Cue in]:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Wyciszanie [Cue out]:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Oryginalna długość:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Zgłaśnianie [fade in]:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Zwiększ bok statyczny"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Zwiększ blok dynamiczny"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Ustawienia strumienia"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Dodaj audycję"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Aktualizuj audycję"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Co"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Kiedy"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Wejście Strumienia \"Na żywo\""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Kto"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Styl"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Miejsce na dysku "
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Zarządzaj Użytkownikami"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Nowy Użytkownik"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Imię"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Nazwisko"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Typ użytkownika"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL strumienia:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Domyślna długość:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Brak webstreamu"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "Wprowadź czas w sekundach '00 (.0)'"

--- a/airtime_mvc/locale/pl_PL/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/pl_PL/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/pt_BR/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Felipe Thomaz Pedroni, 2014
 # Pedro Garbellini da Silva <pedrogarbellini@gmail.com>, 2014
@@ -10,266 +10,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/sourcefabric/airtime/language/pt_BR/)\n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "O ano % s deve estar compreendido no intervalo entre 1753 - 9999"
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s não é uma data válida"
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s não é um horário válido"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Visualizar Metadados do Arquivo Gravado"
-
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Editar"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Editar Programa"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Excluir"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Não é possível arrastar e soltar programas repetidos"
-
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Não é possível mover um programa anterior"
-
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Não é possível mover um programa anterior"
-
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Não é permitido agendar programas sobrepostos"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Não é possível mover um programa gravado menos de 1 hora antes de suas retransmissões."
-
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "O programa foi excluído porque a gravação prévia não existe!"
-
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "É necessário aguardar 1 hora antes de retransmitir."
-
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Título"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Criador"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Álbum"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Duração"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Gênero"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Humor"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Legenda"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Compositor"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
-
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Copyright"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Ano"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Maestro"
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Idioma"
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Executado"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Calendário"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Usuários"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Fluxos"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Estado"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Histórico da Programação"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Estatísticas de Ouvintes"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Ajuda"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Iniciando"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Manual do Usuário"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Você não tem permissão para acessar esta funcionalidade."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Você não tem permissão para acessar esta funcionalidade."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Requisição inválida. Parâmetro não informado."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Requisição inválida. Parâmetro informado é inválido."
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Você não tem permissão para desconectar a fonte."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Não há fonte conectada a esta entrada."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Você não tem permissão para alternar entre as fontes."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s não encontrado"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Ocorreu algo errado."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Visualizar"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Adicionar à Lista"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Adicionar ao Bloco"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Editar Metadados"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Excluir"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Download"
 
@@ -278,81 +892,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Duplicar Lista"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Nenhuma ação disponível"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Você não tem permissão para excluir os itens selecionados."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Cópia de %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Fluxo Sem Título"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Fluxo gravado."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Valores do formulário inválidos."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Confirme se o nome de usuário / senha do administrador estão corretos na página Sistema > Fluxos."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Usuário adicionado com sucesso!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Player de Áudio"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Usuário atualizado com sucesso!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Configurações atualizadas com sucesso!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Gravando:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Fluxo Mestre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Fluxo Ao Vivo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Nada Programado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Programa em Exibição:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Agora"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Você está executando a versão mais recente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nova versão disponível:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Esta versão ficará obsoleta em breve."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Esta versão não é mais suportada."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Por favor, atualize para"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Adicionar a esta lista de reprodução"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Adiconar a este bloco"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Adicionando 1 item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Adicionando %s items"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Você pode adicionar somente faixas a um bloco inteligente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Você pode adicionar apenas faixas, blocos e fluxos às listas de reprodução"
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Por favor selecione um posição do cursor na linha do tempo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Editar Metadados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Adicionar ao programa selecionado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Selecionar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Selecionar esta página"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Desmarcar esta página"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Desmarcar todos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Você tem certeza que deseja excluir o(s) item(ns) selecionado(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Título"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Criador"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Álbum"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Bitrate"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Compositor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Maestro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Copyright"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Convertido por"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Gênero"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Legenda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Idioma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Última Ateração"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Última Execução"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Duração"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Humor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Prorietário"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Ganho de Reprodução"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Taxa de Amostragem"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Número de Faixa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Adicionado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Ano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Carregando..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Todos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Arquivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Listas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Blocos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Fluxos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Tipo Desconhecido:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Você tem certeza que deseja excluir o item selecionado?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Upload em andamento..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Obtendo dados do servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "O id no SoundCloud para este arquivo é:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Ocorreu um erro durante o upload para o SoundCloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Código do erro:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Mensagem de erro:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "A entrada deve ser um número positivo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "A entrada deve ser um número"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "A entrada deve estar no formato yyyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "A entrada deve estar no formato hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Você está fazendo upload de arquivos neste momento. %s Ir a outra tela cancelará o processo de upload. %sTem certeza de que deseja sair desta página?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "por favor informe o tempo no formato '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Seu navegador não suporta a execução deste tipo de arquivo:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Não é possível o preview de blocos dinâmicos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Limitar em:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "A lista foi salva"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "A lista foi embaralhada"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "O Airtime não pôde determinar o status do arquivo. Isso pode acontecer quando o arquivo está armazenado em uma unidade remota atualmente inacessível ou está em um diretório que deixou de ser 'monitorado'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Número de Ouvintes em %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Lembrar-me dentro de uma semana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Não me lembrar novamente"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Sim, quero colaborar com o Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "A imagem precisa conter extensão jpg,  jpeg, png ou gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Um bloco estático salvará os critérios e gerará o conteúdo imediatamente. Isso permite que você edite e visualize-o na Biblioteca antes de adicioná-lo a um programa."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Um bloco dinâmico apenas conterá critérios. O conteúdo do bloco será gerado após adicioná-lo a um programa. Você não será capaz de ver ou editar o conteúdo na Biblioteca."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "A duração desejada do bloco não será completada se o Airtime não localizar faixas únicas suficientes que correspondem aos critérios informados. Ative esta opção se você deseja permitir que as mesmas faixas sejam adicionadas várias vezes num bloco inteligente."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "O bloco foi embaralhado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "O bloco foi gerado e o criterio foi salvo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "O bloco foi salvo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Processando..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Selecionar modificador"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "contém"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "não contém"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "é"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "não é"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "começa com"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "termina com"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "é maior que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "é menor que"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "está no intervalo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Selecione o Diretório de Armazenamento"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Selecione o Diretório para Monitoramento"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Tem certeza de que deseja alterar o diretório de armazenamento?  \n"
+"Isto irá remover os arquivos de sua biblioteca Airtime!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Gerenciar Diretórios de Mídia"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Tem certeza que deseja remover o diretório monitorado?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "O caminho está inacessível no momento."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Conectado ao servidor de fluxo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "O fluxo está desabilitado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Obtendo informações do servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Não é possível conectar ao servidor de streaming"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Se o Airtime estiver atrás de um roteador ou firewall, pode ser necessário configurar o redirecionamento de portas e esta informação de campo ficará incorreta. Neste caso, você terá de atualizar manualmente este campo para que ele exiba o corretamente o host / porta / ponto de montagem necessários para seu DJ para se conectar. O intervalo permitido é entre 1024 e 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Para mais informações, leia o %sManual do Airtime%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Marque esta opção para habilitar metadados para fluxos OGG (metadados fluxo são o título da faixa, artista e nome doprograma que é exibido em um player de áudio). VLC e MPlayer tem um bug sério quando executam fluxos Ogg / Vorbis, que possuem o recurso de metadados habilitado: eles vão desconectar do fluxo depois de cada faixa. Se você estiver transmitindo um fluxo no formato OGG e seus ouvintes não precisem de suporte para esses players de áudio, sinta-se à vontade para ativar essa opção."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Marque esta caixa para desligar automaticamente as fontes Mestre / Programa, após a desconexão de uma fonte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Marque esta caixa para ligar automaticamente as fontes Mestre / Programa, após a conexão de uma fonte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Se o servidor Icecast esperar por um usuário 'source', este campo poderá permanecer em branco."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Se o cliente de fluxo ao vivo não solicitar um usuário, este campo deve ser \"source\"."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Este é o usuário e senha de servidores Icecast / SHOUTcast, para obter estatísticas de ouvintes."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nenhum resultado encontrado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Este segue o mesmo padrão de segurança para os programas: apenas usuários designados para o programa poderão se conectar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Defina uma autenticação personalizada que funcionará apenas neste programa."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "A instância deste programa não existe mais!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "O programa está vazio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Obtendo dados do servidor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Este programa não possui conteúdo agendado."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Este programa não possui duração completa de conteúdos."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Janeiro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Fevereiro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Março"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Abril"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Maio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Junho"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Julho"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Agosto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Setembro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Outubro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Novembro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Dezembro"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Fev"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Abr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Ago"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Set"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dez"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Domingo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Segunda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Terça"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Quarta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Quinta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Sexta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Sábado"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Dom"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Seg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Ter"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Qua"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Qui"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Sex"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sab"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Um programa com tempo maior que a duração programada será cortado pelo programa seguinte."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Cancelar Programa em Execução?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Parar gravação do programa em execução?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Conteúdos do Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Remover todos os conteúdos?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Excluir item(ns) selecionado(s)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Início"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Fim"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Duração"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue Entrada"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Saída"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade Entrada"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Saída"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Programa vazio"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Gravando a partir do Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Prévia da faixa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Não é possível realizar agendamento fora de um programa."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Movendo 1 item"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Movendo %s itens"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Salvar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Selecionar todos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Selecionar nenhum"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Remover seleção de itens agendados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Saltar para faixa em execução"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Cancelar programa atual"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Abrir biblioteca para adicionar ou remover conteúdo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Adicionar / Remover Conteúdo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "em uso"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disco"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Explorar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Abrir"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrador"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Gerente de Programação"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Visitante"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Visitantes podem fazer o seguinte:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Visualizar agendamentos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Visualizar conteúdo dos programas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJs podem fazer o seguinte:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Gerenciar o conteúdo de programas delegados a ele"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Importar arquivos de mídia"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Criar listas de reprodução, blocos inteligentes e fluxos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Gerenciar sua própria blblioteca de conteúdos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Gerentes de Programação podem fazer o seguinte:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Visualizar e gerenciar o conteúdo dos programas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Agendar programas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Gerenciar bibliotecas de conteúdo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Administradores podem fazer o seguinte:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Gerenciar configurações"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Gerenciar usuários"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Gerenciar diretórios monitorados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Enviar informações de suporte"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Visualizar estado do sistema"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Acessar o histórico da programação"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Ver estado dos ouvintes"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Exibir / ocultar colunas"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "De {from} até {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "yyy-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "khz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Do"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Se"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Te"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Qu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Qu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Se"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Fechar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Hora"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Concluído"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Selecionar arquivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Adicione arquivos para a fila de upload e pressione o botão iniciar "
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Adicionar Arquivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Parar Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Iniciar Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Adicionar arquivos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "%d/%d arquivos importados"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Arraste arquivos nesta área."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Erro na extensão do arquivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Erro no tamanho do arquivo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Erro na contagem dos arquivos."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Erro de inicialização."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Erro HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Erro de segurança."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Erro genérico."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Erro de I/O."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Arquivos: %s."
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d arquivos adicionados à fila."
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Arquivo: %f, tamanho: %s, tamanho máximo: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "URL de upload pode estar incorreta ou inexiste."
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Erro: Arquivo muito grande:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Erro: Extensão de arquivo inválida."
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s linhas%s copiadas para a área de transferência"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sVisualizar impressão%sUse a função de impressão do navegador para imprimir esta tabela. Pressione ESC quando terminar."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "O email não pôde ser enviado. Verifique as definições do servidor de email e certifique-se de que esteja corretamente configurado."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Usuário ou senha inválidos. Tente novamente."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -372,11 +2407,6 @@ msgstr "Você não tem permissão para excluir os %s(s) selecionados."
 msgid "You can only add tracks to smart block."
 msgstr "Você pode somente adicionar faixas um bloco inteligente."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Você pode adicionar apenas faixas, blocos e fluxos às listas de reprodução"
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Lista Sem Título"
@@ -385,2627 +2415,88 @@ msgstr "Lista Sem Título"
 msgid "Untitled Smart Block"
 msgstr "Bloco Sem Título"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Lista Desconhecida"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Você não tem permissão para acessar esta funcionalidade."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Preferências atualizadas."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Configurações de suporte atualizadas."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Informações de Suporte"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Preferências de fluxo atualizadas."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "o caminho precisa ser informado"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problemas com o Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Você não tem permissão para desconectar a fonte."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Não há fonte conectada a esta entrada."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Você não tem permissão para alternar entre as fontes."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Usuário ou senha inválidos. Tente novamente."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "O email não pôde ser enviado. Verifique as definições do servidor de email e certifique-se de que esteja corretamente configurado."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Você não tem permissão para acessar esta funcionalidade."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Requisição inválida. Parâmetro não informado."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Requisição inválida. Parâmetro informado é inválido."
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Player de Áudio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Gravando:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Fluxo Mestre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Fluxo Ao Vivo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Nada Programado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Programa em Exibição:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Agora"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Você está executando a versão mais recente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nova versão disponível:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Esta versão ficará obsoleta em breve."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Esta versão não é mais suportada."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Por favor, atualize para"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Adicionar a esta lista de reprodução"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Adiconar a este bloco"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Adicionando 1 item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Adicionando %s items"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Você pode adicionar somente faixas a um bloco inteligente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Por favor selecione um posição do cursor na linha do tempo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Adicionar ao programa selecionado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Selecionar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Selecionar esta página"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Desmarcar esta página"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Desmarcar todos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Você tem certeza que deseja excluir o(s) item(ns) selecionado(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Bitrate"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Convertido por"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Última Ateração"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Última Execução"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Prorietário"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Ganho de Reprodução"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Taxa de Amostragem"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Número de Faixa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Adicionado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Carregando..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Todos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Arquivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Listas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Blocos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Fluxos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Tipo Desconhecido:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Você tem certeza que deseja excluir o item selecionado?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Upload em andamento..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Obtendo dados do servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "O id no SoundCloud para este arquivo é:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Ocorreu um erro durante o upload para o SoundCloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Código do erro:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Mensagem de erro:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "A entrada deve ser um número positivo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "A entrada deve ser um número"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "A entrada deve estar no formato yyyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "A entrada deve estar no formato hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Você está fazendo upload de arquivos neste momento. %s Ir a outra tela cancelará o processo de upload. %sTem certeza de que deseja sair desta página?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "por favor informe o tempo no formato '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "por favor informe o tempo em segundos '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Seu navegador não suporta a execução deste tipo de arquivo:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Não é possível o preview de blocos dinâmicos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Limitar em:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "A lista foi salva"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "A lista foi embaralhada"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "O Airtime não pôde determinar o status do arquivo. Isso pode acontecer quando o arquivo está armazenado em uma unidade remota atualmente inacessível ou está em um diretório que deixou de ser 'monitorado'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Número de Ouvintes em %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Lembrar-me dentro de uma semana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Não me lembrar novamente"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Sim, quero colaborar com o Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "A imagem precisa conter extensão jpg,  jpeg, png ou gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Um bloco estático salvará os critérios e gerará o conteúdo imediatamente. Isso permite que você edite e visualize-o na Biblioteca antes de adicioná-lo a um programa."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Um bloco dinâmico apenas conterá critérios. O conteúdo do bloco será gerado após adicioná-lo a um programa. Você não será capaz de ver ou editar o conteúdo na Biblioteca."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "A duração desejada do bloco não será completada se o Airtime não localizar faixas únicas suficientes que correspondem aos critérios informados. Ative esta opção se você deseja permitir que as mesmas faixas sejam adicionadas várias vezes num bloco inteligente."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "O bloco foi embaralhado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "O bloco foi gerado e o criterio foi salvo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "O bloco foi salvo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Processando..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Selecionar modificador"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "contém"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "não contém"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "é"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "não é"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "começa com"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "termina com"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "é maior que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "é menor que"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "está no intervalo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Selecione o Diretório de Armazenamento"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Selecione o Diretório para Monitoramento"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Tem certeza de que deseja alterar o diretório de armazenamento?  \nIsto irá remover os arquivos de sua biblioteca Airtime!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Gerenciar Diretórios de Mídia"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Tem certeza que deseja remover o diretório monitorado?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "O caminho está inacessível no momento."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Conectado ao servidor de fluxo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "O fluxo está desabilitado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Obtendo informações do servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Não é possível conectar ao servidor de streaming"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Se o Airtime estiver atrás de um roteador ou firewall, pode ser necessário configurar o redirecionamento de portas e esta informação de campo ficará incorreta. Neste caso, você terá de atualizar manualmente este campo para que ele exiba o corretamente o host / porta / ponto de montagem necessários para seu DJ para se conectar. O intervalo permitido é entre 1024 e 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Para mais informações, leia o %sManual do Airtime%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Marque esta opção para habilitar metadados para fluxos OGG (metadados fluxo são o título da faixa, artista e nome doprograma que é exibido em um player de áudio). VLC e MPlayer tem um bug sério quando executam fluxos Ogg / Vorbis, que possuem o recurso de metadados habilitado: eles vão desconectar do fluxo depois de cada faixa. Se você estiver transmitindo um fluxo no formato OGG e seus ouvintes não precisem de suporte para esses players de áudio, sinta-se à vontade para ativar essa opção."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Marque esta caixa para desligar automaticamente as fontes Mestre / Programa, após a desconexão de uma fonte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Marque esta caixa para ligar automaticamente as fontes Mestre / Programa, após a conexão de uma fonte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Se o servidor Icecast esperar por um usuário 'source', este campo poderá permanecer em branco."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Se o cliente de fluxo ao vivo não solicitar um usuário, este campo deve ser \"source\"."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Este é o usuário e senha de servidores Icecast / SHOUTcast, para obter estatísticas de ouvintes."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nenhum resultado encontrado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Este segue o mesmo padrão de segurança para os programas: apenas usuários designados para o programa poderão se conectar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Defina uma autenticação personalizada que funcionará apenas neste programa."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "A instância deste programa não existe mais!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "O programa está vazio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Obtendo dados do servidor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Este programa não possui conteúdo agendado."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Este programa não possui duração completa de conteúdos."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Janeiro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Fevereiro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Março"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Abril"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Maio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Junho"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Julho"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Agosto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Setembro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Outubro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Novembro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Dezembro"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Fev"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Abr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Ago"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Set"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dez"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Domingo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Segunda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Terça"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Quarta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Quinta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Sexta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Sábado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Dom"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Seg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Ter"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Qua"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Qui"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Sex"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sab"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Um programa com tempo maior que a duração programada será cortado pelo programa seguinte."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Cancelar Programa em Execução?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Parar gravação do programa em execução?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Conteúdos do Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Remover todos os conteúdos?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Excluir item(ns) selecionado(s)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Início"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Fim"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Duração"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue Entrada"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Saída"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade Entrada"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Saída"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Programa vazio"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Gravando a partir do Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Prévia da faixa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Não é possível realizar agendamento fora de um programa."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Movendo 1 item"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Movendo %s itens"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Salvar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Cancelar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Selecionar todos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Selecionar nenhum"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Remover seleção de itens agendados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Saltar para faixa em execução"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Cancelar programa atual"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Abrir biblioteca para adicionar ou remover conteúdo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Adicionar / Remover Conteúdo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "em uso"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disco"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Explorar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Abrir"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrador"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Gerente de Programação"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Visitante"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Visitantes podem fazer o seguinte:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Visualizar agendamentos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Visualizar conteúdo dos programas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJs podem fazer o seguinte:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Gerenciar o conteúdo de programas delegados a ele"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Importar arquivos de mídia"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Criar listas de reprodução, blocos inteligentes e fluxos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Gerenciar sua própria blblioteca de conteúdos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Gerentes de Programação podem fazer o seguinte:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Visualizar e gerenciar o conteúdo dos programas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Agendar programas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Gerenciar bibliotecas de conteúdo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Administradores podem fazer o seguinte:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Gerenciar configurações"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Gerenciar usuários"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Gerenciar diretórios monitorados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Enviar informações de suporte"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Visualizar estado do sistema"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Acessar o histórico da programação"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Ver estado dos ouvintes"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Exibir / ocultar colunas"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "De {from} até {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "yyy-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "khz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Do"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Se"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Te"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Qu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Qu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Se"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Fechar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Hora"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Concluído"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Selecionar arquivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Adicione arquivos para a fila de upload e pressione o botão iniciar "
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Estado"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Adicionar Arquivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Parar Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Iniciar Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Adicionar arquivos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "%d/%d arquivos importados"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Arraste arquivos nesta área."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Erro na extensão do arquivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Erro no tamanho do arquivo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Erro na contagem dos arquivos."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Erro de inicialização."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Erro HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Erro de segurança."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Erro genérico."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Erro de I/O."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Arquivos: %s."
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d arquivos adicionados à fila."
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Arquivo: %f, tamanho: %s, tamanho máximo: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "URL de upload pode estar incorreta ou inexiste."
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Erro: Arquivo muito grande:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Erro: Extensão de arquivo inválida."
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s linhas%s copiadas para a área de transferência"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sVisualizar impressão%sUse a função de impressão do navegador para imprimir esta tabela. Pressione ESC quando terminar."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Selecione o cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Remover o cursor"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "programa inexistente"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Retransmissão do programa %s de %s as %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Selecione o cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Remover o cursor"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "programa inexistente"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Usuário adicionado com sucesso!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Usuário atualizado com sucesso!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Configurações atualizadas com sucesso!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Fluxo Sem Título"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Fluxo gravado."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Valores do formulário inválidos."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "O ano % s deve estar compreendido no intervalo entre 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s não é uma data válida"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s não é um horário válido"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Fluxo ao vivo"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Compartilhar"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Selecionar fluxo:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "Mudo"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "retirar mudo"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "Sobre"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Para obter ajuda mais detalhada, leia o %smanual do usuário%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Histórico da Programação"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Expandir Bloco Estático"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Expandir Bloco Dinâmico"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Nome:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Descrição:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Duração:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Embaralhar Lista"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Embaralhar"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Crossfade da Lista"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Fade de entrada"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Fade de saída"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Salvar Lista"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Nenhuma lista aberta"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss,t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue entrada:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Saída:"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Duração Original:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Configurações de Fluxo"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Acessar"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nova senha"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Por favor informe e confirme sua nova senha nos campos abaixo."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Gerenciar Usuários"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Novo Usuário"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Usuário"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Primeiro Nome"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Último Nome"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Tipo de Usuário"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Encontrar Programas"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Dias para reexibir:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Remover"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Adicionar"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Programa"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Registrar Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Obrigatório)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(somente para efeito de verificação, não será publicado)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Nota: qualquer arquivo maior que 600x600 será redimensionado"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Mostrar quais informações estou enviando"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Termos e Condições"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Selecione os Dias:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "para"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "arquivos correspondem ao critério"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Histórico de Filtros"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(para divulgação de sua estação, a opção 'Enviar Informações de Suporte\" precisa estar habilitada)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Fluxo"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Opções Adicionais"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "A informação a seguir será exibida para os ouvintes em seu player de mídia:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(O website de sua estação de rádio)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL do Fluxo:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Selecione o diretório"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Definir"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Diretório de Importação Atual:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Remover diretório monitorado"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Você não está monitorando nenhum diretório."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Master"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Configurações do SoundCloud"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Adicionar este programa"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Atualizar programa"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "O que"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Quando"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Fluxo de entrada ao vivo"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Quem"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Aparência"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Espaço em Disco"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Importação de arquivo em progresso..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Opções da Busca Avançada"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Título:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Criador:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Álbum:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Faixa:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Duração:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Taxa de Amostragem:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bitrate:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Humor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Gênero:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Ano:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Legenda:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Compositor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Maestro:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Copyright:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Número Isrc:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Website:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Idioma:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Caminho do Arquivo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Fluxo Web"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Bloco Inteligente Dinâmico"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Bloco Inteligente Estático"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Faixa de Áudio"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Conteúdos da Lista de Reprodução:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Conteúdo do Bloco Inteligente Estático:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Critério para Bloco Inteligente Dinâmico:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Limitar em"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Seu período de teste termina em"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dias"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Anterior:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Próximo:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Fontes de Fluxo"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "NO AR"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Ouvir"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Sair"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Nome"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Descrição"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL do Fluxo:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Duração Padrão:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Nenhum fluxo web"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Ajuda"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Página não encontrada!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "A página que você procura não existe!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "anterior"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "play"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pause"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "próximo"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "stop"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "volume máximo"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Atualização Necessária"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Para reproduzir a mídia que você terá que quer atualizar seu navegador para uma versão recente ou atualizar seu %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Data de Início:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3015,127 +2506,6 @@ msgstr "Data de Início:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Caracter inválido informado"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Data de Fim:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Meus Programas:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Procurar Usuários:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJs:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Nome da Estação"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Fone:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Website da Estação:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "País:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Cidade:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Descrição da Estação:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo da Estação:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Você precisa concordar com a política de privacidade."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Gravar a partir do Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Retransmitir?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Valor é obrigatório e não poder estar em branco."
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "%value%' não é um enderçeo de email válido"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' não corresponde a uma data válida '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' is menor que comprimento mínimo %min% de caracteres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' is maior que o número máximo %max% de caracteres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' não está compreendido entre '%min%' e '%max%', inclusive"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Senhas não conferem"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3152,675 +2522,55 @@ msgstr "O horário deve ser especificado"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "É preciso aguardar uma hora para retransmitir"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Redefinir senha"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Programa Sem Título"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "Número ISRC:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Inativo"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Ativo"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Semana Inicia Em"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Usuário:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Senha:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Confirmar Senha:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Primeiro nome:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Último nome:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Celular:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Perfil do Usuário:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Usuário já existe."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Diretório de Importação:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Diretórios Monitorados: "
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Não é um diretório válido"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Licença Padrão:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Todos os direitos são reservados"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "O trabalho é de domínio público"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Attribution Noncommercial"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution No Derivative Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution Noncommercial Share Alike"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Tocando agora"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Selecione um critério"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bitrate (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Taxa de Amostragem (khz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "horas"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minutos"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "itens"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Estático"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinâmico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Gerar conteúdo da lista e salvar critério"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Gerar"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Embaralhar conteúdo da lista"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "O limite não pode ser vazio ou menor que 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "O limite não pode ser maior que 24 horas"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "O valor deve ser um número inteiro"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "O número máximo de itens é 500"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Você precisa selecionar Critério e Modificador "
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "A duração deve ser informada no formato '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "O valor deve estar no formato timestamp (ex. 0000-00-00 ou 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "O valor deve ser numérico"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "O valor precisa ser menor que 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "O valor deve conter no máximo %s caracteres"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "O valor não pode estar em branco"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Metadados Icecast Vorbis"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Legenda do Fluxo:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Artista - Título"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Programa - Artista - Título"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Nome da Estação - Nome do Programa"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Metadados Off Air"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Habilitar Ganho de Reprodução"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Modificador de Ganho de Reprodução"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Senha"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Confirmar nova senha"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "A senha de confirmação não confere."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Habilitado:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Tipo de Fluxo:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Tipo de Serviço:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Canais:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stéreo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Servidor"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Porta"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Somente números são permitidos."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Ponto de Montagem"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Usuário Administrador"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Senha do Administrador"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Servidor não pode estar em branco."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Porta não pode estar em branco."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Ponto de montagem deve ser informada em servidor Icecast."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' não corresponde ao formato 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Fuso Horário:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Reexibir?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Não é possível criar um programa no passado."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Não é possível alterar o início de um programa que está em execução"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Data e horário finais não podem ser definidos no passado."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Não pode ter duração < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Não pode ter duração 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Não pode ter duração maior que 24 horas"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Usar Autenticação Personalizada:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Definir Usuário:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Definir Senha:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "O usuário não pode estar em branco."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "A senha não pode estar em branco."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Cor de Fundo:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Cor da Fonte:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Digite os caracteres que você vê na imagem abaixo."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dias"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3866,6 +2616,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Data de Fim:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Sem fim?"
@@ -3878,115 +2634,1174 @@ msgstr "A data de fim deve ser posterior à data de início"
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Gravar a partir do Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Retransmitir?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Cor de Fundo:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Cor da Fonte:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Calendário"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Remover"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Usuários"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Nome:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Fluxos"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Programa Sem Título"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Gênero:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Descrição:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Estatísticas de Ouvintes"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' não corresponde ao formato 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Duração:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Fuso Horário:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Reexibir?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Não é possível criar um programa no passado."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Não é possível alterar o início de um programa que está em execução"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Data e horário finais não podem ser definidos no passado."
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Não pode ter duração < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Não pode ter duração 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Não pode ter duração maior que 24 horas"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Não é permitido agendar programas sobrepostos"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Procurar Usuários:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJs:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Usuário:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Senha:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Confirmar Senha:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Primeiro nome:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Último nome:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Celular:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Perfil do Usuário:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Usuário já existe."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Iniciando"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Manual do Usuário"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Valor é obrigatório e não poder estar em branco."
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Data de Início:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Título:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Criador:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Álbum:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Ano:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Legenda:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Compositor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Maestro:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Humor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Copyright:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "Número ISRC:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Website:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Idioma:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Nome da Estação"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo da Estação:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Nota: qualquer arquivo maior que 600x600 será redimensionado"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Inativo"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Ativo"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Semana Inicia Em"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "%value%' não é um enderçeo de email válido"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' não corresponde a uma data válida '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' is menor que comprimento mínimo %min% de caracteres"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' is maior que o número máximo %max% de caracteres"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' não está compreendido entre '%min%' e '%max%', inclusive"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Senhas não conferem"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Somente números são permitidos."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Acessar"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Digite os caracteres que você vê na imagem abaixo."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Senha"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Confirmar nova senha"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "A senha de confirmação não confere."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Usuário"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Redefinir senha"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Tocando agora"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Fone:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Website da Estação:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "País:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Cidade:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Descrição da Estação:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Você precisa concordar com a política de privacidade."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Meus Programas:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Selecione um critério"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bitrate (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Descrição"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Taxa de Amostragem (khz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "horas"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minutos"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "itens"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Estático"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinâmico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Gerar conteúdo da lista e salvar critério"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Gerar"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Embaralhar conteúdo da lista"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Embaralhar"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "O limite não pode ser vazio ou menor que 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "O limite não pode ser maior que 24 horas"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "O valor deve ser um número inteiro"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "O número máximo de itens é 500"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Você precisa selecionar Critério e Modificador "
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "A duração deve ser informada no formato '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "O valor deve estar no formato timestamp (ex. 0000-00-00 ou 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "O valor deve ser numérico"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "O valor precisa ser menor que 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "O valor deve conter no máximo %s caracteres"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "O valor não pode estar em branco"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Licença Padrão:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Todos os direitos são reservados"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "O trabalho é de domínio público"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Attribution Noncommercial"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution No Derivative Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Noncommercial Non Derivate Works"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution Noncommercial Share Alike"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Metadados Icecast Vorbis"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Legenda do Fluxo:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Artista - Título"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Programa - Artista - Título"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Nome da Estação - Nome do Programa"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Metadados Off Air"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Habilitar Ganho de Reprodução"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Modificador de Ganho de Reprodução"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Habilitado:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Tipo de Fluxo:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bitrate:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Tipo de Serviço:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Canais:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stéreo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Servidor"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Porta"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Nome"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Ponto de Montagem"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Usuário Administrador"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Senha do Administrador"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Servidor não pode estar em branco."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Porta não pode estar em branco."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Ponto de montagem deve ser informada em servidor Icecast."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Diretório de Importação:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Diretórios Monitorados: "
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Não é um diretório válido"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Fluxo ao vivo"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Cue de entrada e saída são nulos."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "O ponto de saída não pode ser maior que a duração do arquivo"
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "A duração do ponto de entrada não pode ser maior que a do ponto de saída."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "A duração do ponto de saída não pode ser menor que a do ponto de entrada."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Retransmissão de %s a partir de %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Selecione o País"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4011,14 +3826,12 @@ msgstr "%s não é um diretório válido."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s já está definido como armazenamento atual ou está na lista de diretórios monitorados"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s já está definido como armazenamento atual ou está  na lista de diretórios monitorados."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4026,28 +3839,18 @@ msgstr "%s já está definido como armazenamento atual ou está  na lista de dir
 msgid "%s doesn't exist in the watched list."
 msgstr "%s não existe na lista de diretórios monitorados."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Selecione o País"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Os programas podem ter duração máxima de 24 horas."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Não é possível agendar programas sobrepostos.\nNota: Redimensionar um programa repetitivo afeta todas as suas repetições."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4062,48 +3865,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "A programação que você está vendo está desatualizada! (instância incompatível)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "A programação que você está vendo está desatualizada!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Você não tem permissão para agendar programa %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Você não pode adicionar arquivos para gravação de programas."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "O programa %s terminou e não pode ser agendado."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "O programa %s foi previamente atualizado!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Um dos arquivos selecionados não existe!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Os programas podem ter duração máxima de 24 horas."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Não é possível agendar programas sobrepostos.\n"
+"Nota: Redimensionar um programa repetitivo afeta todas as suas repetições."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Retransmissão de %s a partir de %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4150,8 +3965,1046 @@ msgstr "Fluxo web inválido. A URL parece tratar-se de download de arquivo."
 msgid "Unrecognized stream type: %s"
 msgstr "Tipo de fluxo não reconhecido: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Visualizar Metadados do Arquivo Gravado"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Editar"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Editar Programa"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Não é possível arrastar e soltar programas repetidos"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Não é possível mover um programa anterior"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Não é possível mover um programa anterior"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Não é possível mover um programa gravado menos de 1 hora antes de suas retransmissões."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "O programa foi excluído porque a gravação prévia não existe!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "É necessário aguardar 1 hora antes de retransmitir."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Executado"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "anterior"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "play"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pause"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "próximo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "stop"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "Mudo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "retirar mudo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "volume máximo"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Atualização Necessária"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Para reproduzir a mídia que você terá que quer atualizar seu navegador para uma versão recente ou atualizar seu %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "Sobre"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Para obter ajuda mais detalhada, leia o %smanual do usuário%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Compartilhar"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Selecionar fluxo:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Página não encontrada!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "A página que você procura não existe!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Programa"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Selecione os Dias:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Adicionar"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Dias para reexibir:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Histórico de Filtros"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Configurações do SoundCloud"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Master"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Selecione o diretório"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Definir"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Diretório de Importação Atual:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Remover diretório monitorado"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Você não está monitorando nenhum diretório."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Registrar Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Obrigatório)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(somente para efeito de verificação, não será publicado)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Mostrar quais informações estou enviando"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Termos e Condições"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Encontrar Programas"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "para"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "arquivos correspondem ao critério"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Fluxo"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Opções Adicionais"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "A informação a seguir será exibida para os ouvintes em seu player de mídia:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(O website de sua estação de rádio)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL do Fluxo:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(para divulgação de sua estação, a opção 'Enviar Informações de Suporte\" precisa estar habilitada)"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Faixa:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Duração:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Taxa de Amostragem:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Número Isrc:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Caminho do Arquivo:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Fluxo Web"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Bloco Inteligente Dinâmico"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Bloco Inteligente Estático"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Faixa de Áudio"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Conteúdos da Lista de Reprodução:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Conteúdo do Bloco Inteligente Estático:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Critério para Bloco Inteligente Dinâmico:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Limitar em"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Importação de arquivo em progresso..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Opções da Busca Avançada"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nova senha"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Por favor informe e confirme sua nova senha nos campos abaixo."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Anterior:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Próximo:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Fontes de Fluxo"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "NO AR"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Ouvir"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Sair"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Seu período de teste termina em"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Embaralhar Lista"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Crossfade da Lista"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Fade de saída"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Salvar Lista"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Nenhuma lista aberta"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue entrada:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Saída:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Duração Original:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss,t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Fade de entrada"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Expandir Bloco Estático"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Expandir Bloco Dinâmico"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Configurações de Fluxo"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Adicionar este programa"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Atualizar programa"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "O que"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Quando"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Fluxo de entrada ao vivo"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Quem"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Aparência"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Espaço em Disco"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Gerenciar Usuários"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Novo Usuário"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Primeiro Nome"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Último Nome"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Tipo de Usuário"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL do Fluxo:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Duração Padrão:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Nenhum fluxo web"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "por favor informe o tempo em segundos '00 (.0)'"

--- a/airtime_mvc/locale/pt_BR/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/pt_BR/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ro_RO/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Romanian (Romania) (http://www.transifex.com/sourcefabric/airtime/language/ro_RO/)\n"
+"Language: ro_RO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ro_RO\n"
 "Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/ru_RU/LC_MESSAGES/airtime.po
@@ -1,7 +1,7 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Andrey Podshivalov, 2014-2015
 # Andrey Podshivalov, 2014
@@ -12,266 +12,880 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Russian (Russia) (http://www.transifex.com/sourcefabric/airtime/language/ru_RU/)\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru_RU\n"
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Записанный файл не найден"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Год %s должен быть в пределах 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Просмотр метаданных записанного файла"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s - %s - %s не является допустимой датой"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s : %s : %s не является допустимым временем"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Редактировать"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Редактировать программу"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Удалить"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Нет доступа"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Невозможно перетащить повторяющиеся программы"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Невозможно переместить прошлую программу"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Невозможно переместить программу в прошедший период"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Невозможно поставить в расписание пересекающиеся программы"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Невозможно переместить записанную программу менее, чем за 1 час до ее ретрансляции."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Программа была удалена, потому что записанная программа не существует!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "До ретрансляции необходимо ожидать 1 час."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Заголовок"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Создатель"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Альбом"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Длина"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Жанр"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Настроение"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Ярлык "
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Композитор"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Авторское право"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Год"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Трек"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Исполнитель"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Язык"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Время старта"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Время окончания"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Проиграно"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Календарь"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Пользователи"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Потоки"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Статус"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "История воспроизведения"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Шаблоны истории"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Статистика слушателей"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Справка"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "С чего начать"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Руководство пользователя"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Вы не имеете доступа к этому ресурсу."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Вы не имеете доступа к этому ресурсу."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Неверный запрос. параметр 'режим' не прошел."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Неверный запрос. параметр 'режим' является недопустимым"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "У вас нет разрешения отсоединить источник."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Нет источника, подключенного к этому входу."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "У вас нет разрешения для переключения источника."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s не найден"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Что-то пошло не так."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Добавить в плейлист"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Добавить в умный блок"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Редактировать метаданные"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Удалить"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Загрузить"
 
@@ -280,81 +894,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Дублировать плейлист"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Нет доступных действий"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "У вас нет разрешения на удаление выбранных элементов."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Копия %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Веб-поток без названия"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Веб-поток сохранен."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Недопустимые значения формы."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Пользователь успешно добавлен!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Аудио-плейер"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Пользователь успешно обновлен!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Изменения в настройках сохранены!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Запись:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Поток Master"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Потоковый режим"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Ничего не запланировано"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Текущая программа:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Текущий"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Вы используете последнюю версию"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Доступна новая версия:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Эта версия скоро устареет."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Эта версия больше не поддерживается."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Пожалуйста, обновите до"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Добавить в текущий плейлист"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Добавить в текущем умный блок"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Добавление 1 элемента"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Добавление %s элементов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Вы можете добавить треки только в умные блоки."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Вы можете добавить только треки, умные блоки и веб-потоки к плейлистам."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Редактировать метаданные"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Добавить в избранную программу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Выбрать"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Выбрать эту страницу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Отменить выбор страницы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Отменить все выделения"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Вы действительно хотите удалить выделенное?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Запланировано"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Заголовок"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Создатель"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Альбом"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Скорость передачи данных"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Композитор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Исполнитель"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Авторское право"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Закодировано в"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Жанр"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Ярлык "
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Язык"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Последние изменения"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Последнее проигрывание"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Длина"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Настроение"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Владелец"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Выравнивание громкости"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Частота дискретизации"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Номер дорожки"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Загружено"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Вебсайт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Год"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Загрузка..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Все"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Файлы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Плейлисты"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Умные блоки"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Веб-потоки"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Неизвестный тип:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Вы действительно хотите удалить выбранный элемент?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Загрузка продолжается ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Получение данных с сервера ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "Soundcloud идентификатор для этого файла: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Произошла ошибка при загрузке на Soundcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Код ошибки: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Сообщение об ошибке: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Вход должен быть положительным числом"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Вход должен быть числом"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Вход должен быть в формате: гггг-мм-дд"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Вход должен быть в формате: чч: мм: сс"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Вы загружаете файлы. %sПереход на другой экран отменит процесс загрузки. %sВы уверены, что хотите покинуть страницу?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Открыть медиа-построитель"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "пожалуйста, поставьте во время '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Ваш браузер не поддерживает воспроизведения данного типа файлов: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Динамический блок не подлежит предпросмотру"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Ограничить до: "
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Playlist сохранен"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime не уверен в статусе этого файла. Это возможно, если файл находится на удаленном недоступном диске или в папке, которая более не \"просматривается\"."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Слушатель считает на %s : %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Напомнить мне через 1 неделю"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Не напоминать никогда"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Да, помочь Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Изображение должно быть в любом из следующих форматов: jpg, jpeg, png или gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Статический умный блок сохранит критерии и немедленно создаст контент блока. Это позволяет редактировать и просматривать его в библиотеке, прежде чем добавить его в программу."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Динамический умный блок сохранит только критерии. Содержания блока будете сгенерировано после добавления его в программу. Вы не сможете просматривать и редактировать содержимое в библиотеке."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Желаемая длина блока не будет достигнута, если Airtime не найдет уникальных треков, соответствующих вашим критериям. Активируйте эту опцию, если хотите неоднократного добавления треков в умный блок."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Умный блок перемешан"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Умный блок создан и критерии сохранены"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Умный блок сохранен"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Обработка ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Выберите модификатор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "содержит"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "не содержит:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "является"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "не является"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "начинается с"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "заканчивается"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "больше, чем"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "меньше, чем"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "находится в диапазоне"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "выберите папку для хранения"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Выберите папку для просмотра"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Вы уверены, что хотите изменить папку хранения? \n"
+" Файлы из вашей библиотеки будут удалены!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Управление папками медиа-файлов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Вы уверены, что хотите удалить просмотренную папку?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Этот путь в настоящий момент недоступен."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Подключено к потоковому серверу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Поток отключен"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Получение информации с сервера ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Не удается подключиться к потоковому серверу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Если Airtime находится за маршрутизатором или брандмауэром, вам может потребоваться настроить переадресацию портов, и информация в этом поле будет неверной. В этом случае вам нужно будет вручную обновлять это поле так, чтобы оно показывало верный хост / порт / сборку, к которым должен подключиться ваш диджей. Допустимый диапазон: от 1024 до 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Для более подробной информации, пожалуйста, прочитайте %sРуководство Airtime %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Отметьте эту опцию для активации метаданных OGG потока (метаданные потока это название композиции, имя исполнителя и название шоу, которое отображается в аудио-плейере). В VLC и mplayer   наблюдается серьезная ошибка при воспроизведении потоков OGG/VORBIS, в которых метаданные включены: они будут отключаться от потока после каждой песни. Если вы используете поток OGG и ваши слушатели не требуют поддержки этих аудиоплееров, то не стесняйтесь включить эту опцию."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Выберите эту опцию для автоматического выключения источника Master / Show после отключения источника."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Выберите эту опцию для автоматического включения источника Master / Show после соединения с источником."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Если ваш сервер Icecast ожидает имя пользователя \"источника\", это поле можно оставить пустым."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Если ваш клиент потокового режима не запросит имя пользователя, то это поле должно быть 'источником'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Результатов не найдено"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "Действует та же схема безопасности программы: только пользователи, назначенные для программы, могут подключиться."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Укажите пользовательскую идентификацию, которая будет работать только для этой программы."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Выпуска программы больше не существует!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Программа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Программа не заполнена"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60мин"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Retreiving данных с сервера ..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Эта программа не имеет запланированного содержания."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "января"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "февраля"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "марта"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "апреля"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "мая"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "июня"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "июля"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "августа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "сентября"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "октября"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "ноября"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "декабря"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "янв"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "фев"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "март"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "апр"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "июн"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "июл"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "авг"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "сент"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "окт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "нояб"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "дек"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Воскресенье"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Понедельник"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Вторник"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Среда"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Четверг"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Пятница"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Суббота"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Вс"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Пн"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Вт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Ср"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Чт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Пт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Сб"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Программы, превышающие время, запланированное в расписании, будут обрезаны следующей программой."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Отменить текущую программу?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Остановить запись текущей программы?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "ОК"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Содержание программы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Удалить все содержание?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Удалить выбранный элемент(ы)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Начало"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Конец"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Продолжительность"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Начало звучания"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Окончание звучания"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Усиление"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Затухание"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Программа не заполнена"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Запись с линейного входа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Предпросмотр треков"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Нельзя планировать вне рамок программы."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Перемещение 1 элемента"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Перемещение %s элементов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Сохранить"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Отменить"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Редактор затухания"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Выделить все"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Снять выделения"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Удалить выбранные запланированные элементы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Перейти к текущей проигрываемой дорожке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Отмена текущей программы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Открыть библиотеку, чтобы добавить или удалить содержимое"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Добавить / удалить содержимое"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "используется"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Диск"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Заглянуть"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Открыть"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Администратор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "Диджей"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Менеджер программы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Гость"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Показать календарь"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Показать программу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "DJ-ю доступно:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Импорт медиа-файлов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Редактировать программу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Планировать программу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Администраторы могут:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Настроить предпочтения"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Отправить отзыв о поддержке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Системный статус"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Доступ к истории плейлиста"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Статистика слушателей"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Показать / скрыть столбцы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "С {с} до {до}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "кбит"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "гггг-мм-дд"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "чч: мм: сс"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "кГц"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Вс"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Пн"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Вт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Ср"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Чт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Пт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Сб"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Закрыть"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Часов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Минут"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Сделано"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Выбрать файлы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Добавить файлы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Остановить загрузку"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Начать загрузку"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Добавить файлы"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Загружено файлов: %d/%d "
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "н/о"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Перетащите сюда файлы."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Неверное расширение файла."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Невереный размер файла."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Ошибка инициализации."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "Ошибка HTTP."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Ошибка безопасности."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Общая ошибка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "Ошибка записи/чтения."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Ошибка: Файл слишком большой:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Установить по умолчанию"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Создать"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Редактировать историю"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Нет Show"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-mail не может быть отправлен. Проверьте настройки почтового сервера и убедитесь, что он был настроен должным образом."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Неверное имя пользователя или пароль. Пожалуйста, попробуйте еще раз."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -374,11 +2409,6 @@ msgstr "У вас нет разрешения на удаление выбран
 msgid "You can only add tracks to smart block."
 msgstr "Вы можете добавить треки только в умный блок."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Вы можете добавить только треки, умные блоки и веб-потоки к плейлистам."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Плейлист без названия"
@@ -387,2627 +2417,88 @@ msgstr "Плейлист без названия"
 msgid "Untitled Smart Block"
 msgstr "Умный блок без названия"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Неизвестный плейлист"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Вы не имеете доступа к этому ресурсу."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Установки пользователя обновлены."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Настройка поддержки обновлена."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Отзывы о поддержке"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Настройки потока обновлены."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "Путь должен быть указан"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Проблема с Liquidsoap ..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "У вас нет разрешения отсоединить источник."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Нет источника, подключенного к этому входу."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "У вас нет разрешения для переключения источника."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Неверное имя пользователя или пароль. Пожалуйста, попробуйте еще раз."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-mail не может быть отправлен. Проверьте настройки почтового сервера и убедитесь, что он был настроен должным образом."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Вы не имеете доступа к этому ресурсу."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Неверный запрос. параметр 'режим' не прошел."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Неверный запрос. параметр 'режим' является недопустимым"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Аудио-плейер"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Запись:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Поток Master"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Потоковый режим"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Ничего не запланировано"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Текущая программа:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Текущий"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Вы используете последнюю версию"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Доступна новая версия:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Эта версия скоро устареет."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Эта версия больше не поддерживается."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Пожалуйста, обновите до"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Добавить в текущий плейлист"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Добавить в текущем умный блок"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Добавление 1 элемента"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Добавление %s элементов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Вы можете добавить треки только в умные блоки."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Добавить в избранную программу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Выбрать"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Выбрать эту страницу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Отменить выбор страницы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Отменить все выделения"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Вы действительно хотите удалить выделенное?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Запланировано"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Скорость передачи данных"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Закодировано в"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Последние изменения"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Последнее проигрывание"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Владелец"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Выравнивание громкости"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Частота дискретизации"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Номер дорожки"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Загружено"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Вебсайт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Загрузка..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Все"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Файлы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Плейлисты"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Умные блоки"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Веб-потоки"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Неизвестный тип:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Вы действительно хотите удалить выбранный элемент?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Загрузка продолжается ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Получение данных с сервера ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "Soundcloud идентификатор для этого файла: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Произошла ошибка при загрузке на Soundcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Код ошибки: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Сообщение об ошибке: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Вход должен быть положительным числом"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Вход должен быть числом"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Вход должен быть в формате: гггг-мм-дд"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Вход должен быть в формате: чч: мм: сс"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Вы загружаете файлы. %sПереход на другой экран отменит процесс загрузки. %sВы уверены, что хотите покинуть страницу?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Открыть медиа-построитель"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "пожалуйста, поставьте во время '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "пожалуйста, поставьте во время в секундах '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Ваш браузер не поддерживает воспроизведения данного типа файлов: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Динамический блок не подлежит предпросмотру"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Ограничить до: "
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Playlist сохранен"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime не уверен в статусе этого файла. Это возможно, если файл находится на удаленном недоступном диске или в папке, которая более не \"просматривается\"."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Слушатель считает на %s : %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Напомнить мне через 1 неделю"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Не напоминать никогда"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Да, помочь Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Изображение должно быть в любом из следующих форматов: jpg, jpeg, png или gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Статический умный блок сохранит критерии и немедленно создаст контент блока. Это позволяет редактировать и просматривать его в библиотеке, прежде чем добавить его в программу."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Динамический умный блок сохранит только критерии. Содержания блока будете сгенерировано после добавления его в программу. Вы не сможете просматривать и редактировать содержимое в библиотеке."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Желаемая длина блока не будет достигнута, если Airtime не найдет уникальных треков, соответствующих вашим критериям. Активируйте эту опцию, если хотите неоднократного добавления треков в умный блок."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Умный блок перемешан"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Умный блок создан и критерии сохранены"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Умный блок сохранен"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Обработка ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Выберите модификатор"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "содержит"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "не содержит:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "является"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "не является"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "начинается с"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "заканчивается"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "больше, чем"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "меньше, чем"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "находится в диапазоне"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "выберите папку для хранения"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Выберите папку для просмотра"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Вы уверены, что хотите изменить папку хранения? \n Файлы из вашей библиотеки будут удалены!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Управление папками медиа-файлов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Вы уверены, что хотите удалить просмотренную папку?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Этот путь в настоящий момент недоступен."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Подключено к потоковому серверу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Поток отключен"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Получение информации с сервера ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Не удается подключиться к потоковому серверу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Если Airtime находится за маршрутизатором или брандмауэром, вам может потребоваться настроить переадресацию портов, и информация в этом поле будет неверной. В этом случае вам нужно будет вручную обновлять это поле так, чтобы оно показывало верный хост / порт / сборку, к которым должен подключиться ваш диджей. Допустимый диапазон: от 1024 до 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Для более подробной информации, пожалуйста, прочитайте %sРуководство Airtime %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Отметьте эту опцию для активации метаданных OGG потока (метаданные потока это название композиции, имя исполнителя и название шоу, которое отображается в аудио-плейере). В VLC и mplayer   наблюдается серьезная ошибка при воспроизведении потоков OGG/VORBIS, в которых метаданные включены: они будут отключаться от потока после каждой песни. Если вы используете поток OGG и ваши слушатели не требуют поддержки этих аудиоплееров, то не стесняйтесь включить эту опцию."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Выберите эту опцию для автоматического выключения источника Master / Show после отключения источника."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Выберите эту опцию для автоматического включения источника Master / Show после соединения с источником."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Если ваш сервер Icecast ожидает имя пользователя \"источника\", это поле можно оставить пустым."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Если ваш клиент потокового режима не запросит имя пользователя, то это поле должно быть 'источником'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Результатов не найдено"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "Действует та же схема безопасности программы: только пользователи, назначенные для программы, могут подключиться."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Укажите пользовательскую идентификацию, которая будет работать только для этой программы."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Выпуска программы больше не существует!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Программа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Программа не заполнена"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60мин"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Retreiving данных с сервера ..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Эта программа не имеет запланированного содержания."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "января"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "февраля"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "марта"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "апреля"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "мая"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "июня"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "июля"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "августа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "сентября"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "октября"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "ноября"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "декабря"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "янв"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "фев"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "март"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "апр"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "июн"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "июл"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "авг"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "сент"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "окт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "нояб"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "дек"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Воскресенье"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Понедельник"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Вторник"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Среда"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Четверг"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Пятница"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Суббота"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Вс"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Пн"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Вт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Ср"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Чт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Пт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Сб"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Программы, превышающие время, запланированное в расписании, будут обрезаны следующей программой."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Отменить текущую программу?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Остановить запись текущей программы?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "ОК"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Содержание программы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Удалить все содержание?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Удалить выбранный элемент(ы)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Начало"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Конец"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Продолжительность"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Начало звучания"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Окончание звучания"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Усиление"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Затухание"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Программа не заполнена"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Запись с линейного входа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Предпросмотр треков"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Нельзя планировать вне рамок программы."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Перемещение 1 элемента"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Перемещение %s элементов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Сохранить"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Отменить"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Редактор затухания"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Выделить все"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Снять выделения"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Удалить выбранные запланированные элементы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Перейти к текущей проигрываемой дорожке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Отмена текущей программы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Открыть библиотеку, чтобы добавить или удалить содержимое"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Добавить / удалить содержимое"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "используется"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Диск"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Заглянуть"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Открыть"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Администратор"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "Диджей"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Менеджер программы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Гость"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Показать календарь"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Показать программу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "DJ-ю доступно:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Импорт медиа-файлов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Редактировать программу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Планировать программу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Администраторы могут:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Настроить предпочтения"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Отправить отзыв о поддержке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Системный статус"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Доступ к истории плейлиста"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Статистика слушателей"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Показать / скрыть столбцы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "С {с} до {до}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "кбит"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "гггг-мм-дд"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "чч: мм: сс"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "кГц"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Вс"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Пн"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Вт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Ср"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Чт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Пт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Сб"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Закрыть"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Часов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Минут"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Сделано"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Выбрать файлы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Статус"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Добавить файлы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Остановить загрузку"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Начать загрузку"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Добавить файлы"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Загружено файлов: %d/%d "
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "н/о"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Перетащите сюда файлы."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Неверное расширение файла."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Невереный размер файла."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Ошибка инициализации."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "Ошибка HTTP."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Ошибка безопасности."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Общая ошибка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "Ошибка записи/чтения."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Ошибка: Файл слишком большой:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Установить по умолчанию"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Создать"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Редактировать историю"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Нет Show"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Выбрать курсор"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Удалить курсор"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "Программа не существует"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Ретрансляция программы %s от %s в %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Выбрать курсор"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Удалить курсор"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "Программа не существует"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Пользователь успешно добавлен!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Пользователь успешно обновлен!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Изменения в настройках сохранены!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Веб-поток без названия"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Веб-поток сохранен."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Недопустимые значения формы."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Год %s должен быть в пределах 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s - %s - %s не является допустимой датой"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s : %s : %s не является допустимым временем"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Потоковый режим"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Проигр."
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Стоп"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Установить начало звучания"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Установить окончание звучания"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Курсор"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Поделиться"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Выбор потока:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "отключить звук"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "включить звук"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "О программе"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Для более подробной справки читать %sруководство пользователя%s ."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "История воспроизведения"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Данные по прграмме"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Развернуть статический блок"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Развернуть динамический блок"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Имя:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Описание:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Длительность:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Перемешать плейлист"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Перемешать"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Перекрестное затухание композиций плейлиста"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Очистить плейлист"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Очистить"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Усиление: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Затухание: "
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Сохранить плейлист"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Нет открытых плейлистов"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Показать трек"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(сс)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Начало звучания: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(чч: мм: сс)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Окончание звучания: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Исходная длина:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Настройки потоковой передачи "
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "дБ"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Войти"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Новый пароль"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Пожалуйста, введите и подтвердите новый пароль ниже."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Управление пользователями"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Новый пользователь"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Имя пользователя"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Имя"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Фамилия"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Тип пользователя"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Найти программы"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Выберите программу"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Найти"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Повторить дні:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Удалить"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Добавить"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Источник Show"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Регистрация Airtime "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Обязательно)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(Только для проверки, не будет опубликовано)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Примечание: все, что превысит размеры 600x600, будет изменено."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Покажите мне, что я посылаю "
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Постановления и условия"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Выберите дни:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "или"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "и"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr " к "
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "Файлы отвечают критериям"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Фильтровать историю"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(В целях продвижения вашей станции, опция 'Отправить отзывы о поддержке' должна быть включена)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Поток "
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Дополнительные параметры"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Следующая информация будет отображаться для слушателей в их медиа-плейере:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Веб-сайт вашей радиостанции)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL потока: "
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Выбрать"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Установка"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Текущая папка импорта:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Удалить просмотренную папку"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Вы не просматриваете никакие папки медиа-файлов."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Источник Master "
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "Настройки SoundCloud "
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Добавить эту программу"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Обновить программу"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Что"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Когда"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Потоковый ввод"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Кто"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Стиль"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Дисковое пространство"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Импорт файлов в процессе ..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Дополнительные параметры поиска"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Заголовок:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Создатель:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Альбом:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Дорожка"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Длина:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Частота дискретизации:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Битовая скорость:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Настроение:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Жанр:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Год:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Метка:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Композитор:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Исполнитель:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Авторское право:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC номер:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Вебсайт:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Язык: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Веб-поток"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Динамический умный блок"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Статический умный блок"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Аудио-дорожка"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Содержание плейлиста: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Содержание статического умного блока: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Критерии динамического умного блока: "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Ограничение до "
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "лизензия истекает через"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "дней"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Предыдущая:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Следующая:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Исходные потоки"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "В эфире"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Слушать"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Выход"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Шаблоны лога"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Нет шаблона лога"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Создание шаблона по файлам"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Создание шаблона лога"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Имя"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Добавить еще элементы"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Добавить поле"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Установить шаблон по умолчанию"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Описание"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL потока:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Длина по умолчанию:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Нет веб-потока"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Справка"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Страница не найдена!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Похоже, что страница, которую вы ищете, не существует!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "предыдущая"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "играть"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "пауза"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "следующая"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "стоп"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "максимальная громкость"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Требуется обновление"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Для проигрывания медиа-файла необходимо либо обновить браузер до последней версии или обновить %sфлэш-плагина%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Дата начала:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3017,127 +2508,6 @@ msgstr "Дата начала:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Неверно введенный символ"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Дата окончания:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Все мои программы:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Поиск пользователей:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Диджеи:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Название станции"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Телефон:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Email:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Вебсайт станции:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Страна:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Город"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Описание станции:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Логотип станции:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Вы должны согласиться с политикой конфиденциальности."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Запись с линейного входа?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Ретрансляция?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Значение является обязательным и не может быть пустым"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'% значение%' не является действительным адресом электронной почты в формате local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%значение%' не соответствует формату даты '%формат%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%значение%' имеет менее %min% символов"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%значение%' имеет более %max% символов"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%значение%' не входит в промежуток '%min%' и '%maxс% включительно"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Пароли не совпадают"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3154,675 +2524,55 @@ msgstr "Время должно быть указано"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Должны ждать по крайней мере 1 час до ретрансляции"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Сменить пароль"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Программа без названия"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC номер:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Возрастание по умолчанию:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Затухание по умолчанию:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Отключено"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Активировано"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Временная зона станции"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Начало недели"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Логин:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Пароль:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Повторите пароль:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Имя"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Фамилия"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Тел:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Тип пользователя:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Имя пользователя не является уникальным."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Импорт папки:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Просматриваемые папки:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Не является допустимой папкой"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Лицензия по умолчанию:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Все права защищены"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Работа находится в публичном домене"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Лицензия Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Некоммерческая Creative Commons Attribution"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Attribution без производных продуктов"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Attribution в равных долях"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Attribution Non Некоммерческое производных работ"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Attribution некоммерческая в равных долях"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Временная зона (броузер)"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Сейчас в эфире"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Выбрать критерии"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Битовая скорость (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Частота дискретизации (кГц)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "часов"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "минут"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "элементы"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Статический"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Динамический"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Создать содержание плейлиста и сохранить критерии"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Создать"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Перемешать содержание плейлиста"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Ограничение не может быть пустым или менее 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Ограничение не может быть более 24 часов"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Значение должно быть целым числом"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 является максимально допустимым значением элемента"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Вы должны выбрать критерии и модификаторы"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "\"Длина\" должна быть в формате '00:00:00'"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Значение должно быть в формате временной метки (например, 0000-00-00 или 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Значение должно быть числом"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Значение должно быть меньше, чем 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Значение должно быть меньше, чем %s символов"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Значение не может быть пустым"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Метаданные Icecast Vorbis "
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Метка потока:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Исполнитель - Название"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Программа - Исполнитель - Название"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Название станции - Название программы"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Отключить мета-данные"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Пароль"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Подтвердить новый пароль"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Подтверждение пароля не совпадает с вашим паролем."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Активировано:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Тип потока:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Тип услуги:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Каналы:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Моно"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Стерео"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Сервер"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Порт"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Разрешены только числа."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Точка монтирования"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Администратор"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Пароль администратора"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Сервер не может быть пустым"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Порт не может быть пустым."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Монтирование не может быть пустым с Icecast сервер."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%значение%' не соответствует формату времени 'ЧЧ:мм'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Временная зона:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Повторы?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Невозможно создать программу в прошедшем периоде"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Невозможно изменить дату/время начала программы, которая уже началась"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Дата/время окончания не могут быть прошедшими"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Не может иметь длительность <0м"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Не может иметь длительность 00ч 00м"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Не может иметь длительность более 24 часов"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Использование пользовательской идентификации:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Пользовательские имя пользователя"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Пользовательский пароль"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Имя пользователя не может быть пустым."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Пароль не может быть пустым."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Цвет фона:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Цвет текста:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Введите символы, которые вы видите на картинке ниже."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "дней"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3868,6 +2618,12 @@ msgstr "день месяца"
 msgid "day of the week"
 msgstr "день недели"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Дата окончания:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Нет окончания?"
@@ -3880,115 +2636,1174 @@ msgstr "Дата окончания должна быть после даты н
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Запись с линейного входа?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Ретрансляция?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Цвет фона:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Цвет текста:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Календарь"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Удалить"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Пользователи"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Имя:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Потоки"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Программа без названия"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Жанр:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Описание:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Статистика слушателей"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%значение%' не соответствует формату времени 'ЧЧ:мм'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Шаблоны истории"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Длительность:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Временная зона:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Повторы?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Невозможно создать программу в прошедшем периоде"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Невозможно изменить дату/время начала программы, которая уже началась"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Дата/время окончания не могут быть прошедшими"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Не может иметь длительность <0м"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Не может иметь длительность 00ч 00м"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Не может иметь длительность более 24 часов"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Невозможно поставить в расписание пересекающиеся программы"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Поиск пользователей:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Диджеи:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Логин:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Пароль:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Повторите пароль:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Имя"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Фамилия"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Email:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Тел:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Тип пользователя:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Имя пользователя не является уникальным."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "С чего начать"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Руководство пользователя"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Значение является обязательным и не может быть пустым"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Дата начала:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Заголовок:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Создатель:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Альбом:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Год:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Метка:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Композитор:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Исполнитель:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Настроение:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Авторское право:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC номер:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Вебсайт:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Язык: "
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Время старта"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Время окончания"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Временная зона (броузер)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Название станции"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Логотип станции:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Примечание: все, что превысит размеры 600x600, будет изменено."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Возрастание по умолчанию:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Затухание по умолчанию:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Отключено"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Активировано"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Временная зона станции"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Начало недели"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'% значение%' не является действительным адресом электронной почты в формате local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%значение%' не соответствует формату даты '%формат%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%значение%' имеет менее %min% символов"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%значение%' имеет более %max% символов"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%значение%' не входит в промежуток '%min%' и '%maxс% включительно"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Пароли не совпадают"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Разрешены только числа."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Войти"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Введите символы, которые вы видите на картинке ниже."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Пароль"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Подтвердить новый пароль"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Подтверждение пароля не совпадает с вашим паролем."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Имя пользователя"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Сменить пароль"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Сейчас в эфире"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Телефон:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Вебсайт станции:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Страна:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Город"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Описание станции:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Вы должны согласиться с политикой конфиденциальности."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Все мои программы:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Выбрать критерии"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Битовая скорость (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Описание"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Частота дискретизации (кГц)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "часов"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "минут"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "элементы"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Статический"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Динамический"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Создать содержание плейлиста и сохранить критерии"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Создать"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Перемешать содержание плейлиста"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Перемешать"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Ограничение не может быть пустым или менее 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Ограничение не может быть более 24 часов"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Значение должно быть целым числом"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 является максимально допустимым значением элемента"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Вы должны выбрать критерии и модификаторы"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "\"Длина\" должна быть в формате '00:00:00'"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Значение должно быть в формате временной метки (например, 0000-00-00 или 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Значение должно быть числом"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Значение должно быть меньше, чем 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Значение должно быть меньше, чем %s символов"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Значение не может быть пустым"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Лицензия по умолчанию:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Все права защищены"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Работа находится в публичном домене"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Лицензия Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Некоммерческая Creative Commons Attribution"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Attribution без производных продуктов"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Attribution в равных долях"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Attribution Non Некоммерческое производных работ"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Attribution некоммерческая в равных долях"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Метаданные Icecast Vorbis "
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Метка потока:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Исполнитель - Название"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Программа - Исполнитель - Название"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Название станции - Название программы"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Отключить мета-данные"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Активировано:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Тип потока:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Битовая скорость:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Тип услуги:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Каналы:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Моно"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Стерео"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Сервер"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Порт"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Имя"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Точка монтирования"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Администратор"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Пароль администратора"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Сервер не может быть пустым"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Порт не может быть пустым."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Монтирование не может быть пустым с Icecast сервер."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Импорт папки:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Просматриваемые папки:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Не является допустимой папкой"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Проигр."
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Стоп"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Установить начало звучания"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Установить окончание звучания"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Курсор"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Потоковый режим"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "Время начала и окончания звучания трека не заполнены."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Время окончания звучания не может превышать длину трека."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Время начала звучания не может быть больше времени окончания. "
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Время окончания звучания не может быть меньше времени начала."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Ретрансляция %s из %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Выберите страну"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4013,14 +3828,12 @@ msgstr "%s не является допустимой папкой."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s уже установлена в качестве текущей папки хранения или в списке просматриваемых папок"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s уже установлен в качестве текущей папки хранения или в списке просматриваемых папок."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4028,28 +3841,18 @@ msgstr "%s уже установлен в качестве текущей пап
 msgid "%s doesn't exist in the watched list."
 msgstr "%s не существует в просматриваемом списке"
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Выберите страну"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Максимальная продолжительность программы 24 часа."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Нельзя планировать пересекающиеся программы.\nПримечание: изменение размера повторяющейся программы влияет на все ее повторы."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4064,48 +3867,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Расписание, которое вы просматриваете, устарело! (несоответствие выпусков)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Расписание, которое вы просматриваете, устарело!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "У вас нет прав планирования программы %s ."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Вы не можете добавлять файлы в записываемую программу"
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Программа %s окончилась и не может быть поставлена в расписание."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Программа %s была обновлена ранее!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Выбранный файл не существует!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Максимальная продолжительность программы 24 часа."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Нельзя планировать пересекающиеся программы.\n"
+"Примечание: изменение размера повторяющейся программы влияет на все ее повторы."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Ретрансляция %s из %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4152,8 +3967,1046 @@ msgstr "Неверный вебпоток - это загрузка файла."
 msgid "Unrecognized stream type: %s"
 msgstr "Неизвестный тип потока: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Записанный файл не найден"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Просмотр метаданных записанного файла"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Редактировать"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Редактировать программу"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Нет доступа"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Невозможно перетащить повторяющиеся программы"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Невозможно переместить прошлую программу"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Невозможно переместить программу в прошедший период"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Невозможно переместить записанную программу менее, чем за 1 час до ее ретрансляции."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Программа была удалена, потому что записанная программа не существует!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "До ретрансляции необходимо ожидать 1 час."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Трек"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Проиграно"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "предыдущая"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "играть"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "пауза"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "следующая"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "стоп"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "отключить звук"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "включить звук"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "максимальная громкость"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Требуется обновление"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Для проигрывания медиа-файла необходимо либо обновить браузер до последней версии или обновить %sфлэш-плагина%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "О программе"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Для более подробной справки читать %sруководство пользователя%s ."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Поделиться"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Выбор потока:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Страница не найдена!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Похоже, что страница, которую вы ищете, не существует!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Источник Show"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Выберите дни:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Добавить"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Повторить дні:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Фильтровать историю"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Выберите программу"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Найти"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "Настройки SoundCloud "
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Источник Master "
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Выбрать"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Установка"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Текущая папка импорта:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Удалить просмотренную папку"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Вы не просматриваете никакие папки медиа-файлов."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Регистрация Airtime "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Обязательно)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(Только для проверки, не будет опубликовано)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Покажите мне, что я посылаю "
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Постановления и условия"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Найти программы"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "или"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "и"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr " к "
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "Файлы отвечают критериям"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Поток "
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Дополнительные параметры"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Следующая информация будет отображаться для слушателей в их медиа-плейере:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Веб-сайт вашей радиостанции)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL потока: "
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(В целях продвижения вашей станции, опция 'Отправить отзывы о поддержке' должна быть включена)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Дорожка"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Длина:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Частота дискретизации:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC номер:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Веб-поток"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Динамический умный блок"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Статический умный блок"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Аудио-дорожка"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Содержание плейлиста: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Содержание статического умного блока: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Критерии динамического умного блока: "
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Ограничение до "
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Импорт файлов в процессе ..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Дополнительные параметры поиска"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Новый пароль"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Пожалуйста, введите и подтвердите новый пароль ниже."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Предыдущая:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Следующая:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Исходные потоки"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "В эфире"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Слушать"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Выход"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "лизензия истекает через"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Перемешать плейлист"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Перекрестное затухание композиций плейлиста"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Очистить плейлист"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Очистить"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Затухание: "
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Сохранить плейлист"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Нет открытых плейлистов"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Показать трек"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Начало звучания: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(чч: мм: сс)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Окончание звучания: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Исходная длина:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(сс)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Усиление: "
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Развернуть статический блок"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Развернуть динамический блок"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Данные по прграмме"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Шаблоны лога"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Нет шаблона лога"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Создание шаблона по файлам"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Создание шаблона лога"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Добавить еще элементы"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Добавить поле"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Установить шаблон по умолчанию"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Настройки потоковой передачи "
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "дБ"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Добавить эту программу"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Обновить программу"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Что"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Когда"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Потоковый ввод"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Кто"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Стиль"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Дисковое пространство"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Управление пользователями"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Новый пользователь"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Имя"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Фамилия"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Тип пользователя"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL потока:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Длина по умолчанию:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Нет веб-потока"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "пожалуйста, поставьте во время в секундах '00 (.0)'"

--- a/airtime_mvc/locale/ru_RU/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/ru_RU/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/si/LC_MESSAGES/airtime.po
@@ -1,272 +1,886 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Sinhala (http://www.transifex.com/sourcefabric/airtime/language/si/)\n"
+"Language: si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: si\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -275,80 +889,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -369,11 +2402,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -382,2627 +2410,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3011,127 +2500,6 @@ msgstr ""
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:177
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
@@ -3149,674 +2517,54 @@ msgstr ""
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
 msgstr ""
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
@@ -3863,6 +2611,12 @@ msgstr ""
 msgid "day of the week"
 msgstr ""
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr ""
@@ -3875,114 +2629,1173 @@ msgstr ""
 msgid "Please select a repeat day"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4008,14 +3821,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4023,27 +3834,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4059,47 +3860,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4147,8 +3958,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/si/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/si/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Sourcefabric <contact@sourcefabric.org>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Serbian (Serbia) (http://www.transifex.com/sourcefabric/airtime/language/sr_RS/)\n"
+"Language: sr_RS\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr_RS\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Снимљена датотека не постоји"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Година %s мора да буде у распону између 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Метаподаци снимљеног фајла"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s није исправан датум"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s није исправан датум"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Уређивање"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Уређивање Програма"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Обриши"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Дозвола одбијена"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Не можеш повући и испустити понављајуће емисије"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Не можеш преместити догађане емисије"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Не можеш преместити емисију у прошлости"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Не можеш заказати преклапајуће емисије"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Не можеш преместити снимљене емисије раније од 1 сат времена пре њених реемитовања."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Емисија је избрисана јер је снимљена емисија не постоји!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Мораш причекати 1 сат за ре-емитовање."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Назив"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Творац"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Албум"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Дужина"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Жанр"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Расположење"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Налепница"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Композитор"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Ауторско право"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Година"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Песма"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Диригент"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Језик"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Време Почетка"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Време Завршетка"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Пуштена"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Календар"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Корисници"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Преноси"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Стање"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Историја Пуштених Песама"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Историјски Шаблони"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Слушатељска Статистика"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Помоћ"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Почетак Коришћења"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Упутство"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Не смеш да приступиш овог извора."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Не смеш да приступите овог извора."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Неисправан захтев."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Неисправан захтев"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Немаш допуштење да искључиш извор."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Нема спојеног извора на овај улаз."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Немаш дозволу за промену извора."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s није пронађен"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Нешто је пошло по криву."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Преглед"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Додај на Списак Песама"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Додај у Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Уреди Метаподатке"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Обриши"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Преузимање"
 
@@ -276,81 +890,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Удвостручавање"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Нема доступних акција"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Немаш допуштење за брисање одабране ставке."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Копирање од %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Неименовани Пренос"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Пренос је сачуван."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Неважећи вредности обрасца."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Молимо, провери да ли је исправан/на админ корисник/лозинка на страници Систем->Преноси."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Корисник је успешно додат!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Аудио Уређај"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Корисник је успешно ажуриран!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Подешавања су успешно ажуриране!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Снимање:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Мајсторски Пренос"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Пренос Уживо"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Ништа по распореду"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Садашња Емисија:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Тренутна"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Ти имаш инсталирану најновију верзију"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Нова верзија је доступна:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Ова верзија ускоро ће да буде застарео."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Ова верзија више није подржана."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Молимо надогради на"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Додај у тренутни списак песама"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Додај у тренутни smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Додавање 1 Ставке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Додавање %s Ставке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Можеш да додаш само песме код паметних блокова."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Можеш само да додаш песме, паметне блокова, и преносе код листе нумера."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Молимо одабери место показивача на временској црти."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Уреди Метаподатке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Додај у одабраној емисији"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Одабери"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Одабери ову страницу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Одзначи ову страницу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Одзначи све"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Јеси ли сигуран да желиш да избришеш одабрану (е) ставу (е)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Заказана"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Назив"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Творац"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Албум"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Пренос Бита"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Композитор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Диригент"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Ауторско право"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Кодирано је по"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Жанр"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Налепница"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Језик"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Последња Измена"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Задњи Пут Одиграна"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Дужина"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Расположење"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Власник"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Узорак Стопа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Број Песма"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Додата"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Веб страница"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Година"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Учитавање..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Све"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Датотеке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Листе песама"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Block-ови"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Преноси"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Непознати тип:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Јеси ли сигуран да желиш да обришеш изабрану ставку?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Пренос је у току..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Преузимање података са сервера..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "SoundCloud id за ову датотеку је:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Дошло је до грешке приликом преноса на soundcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Шифра грешке:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Порука о грешци:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Мора да буде позитиван број"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Мора да буде број"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Мора да буде у облику: гггг-мм-дд"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Мора да буде у облику: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Тренутно је пренос датотеке. %sОдлазак на другом екрану ће да откаже процес слања. %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Отвори Медијског Градитеља"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "молимо стави у време '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Твој претраживач не подржава ову врсту аудио фајл:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Динамички блок није доступан за преглед"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Ограничити се на:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Списак песама је спремљена"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Списак песама је измешан"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime је несигуран о статусу ове датотеке. То такође може да се деси када је датотека на удаљеном диску или је датотека у некој директоријуми, која се више није 'праћена односно надзирана'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Број Слушалаца %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Подсети ме за 1 недељу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Никад ме више не подсети"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Да, помажем Airtime-у"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Слика мора да буде jpg, jpeg, png, или gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Статички паметни блокови спремају критеријуме и одмах генеришу блок садржаја. То ти омогућава да уредиш и видиш га у библиотеци пре него што га додаш на емисију."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Динамички паметни блокови само критеријуме спремају. Блок садржаја ће се генерише након што га додамо на емисију. Нећеш моћи да прегледаш и уређиваш садржај у библиотеци."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Жељена дужина блока неће да буде постигнут јер Airtime не могу да пронађе довољно јединствене песме које одговарају твојим критеријумима. Омогући ову опцију ако желиш да допустиш да неке песме могу да се више пута понављају."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block је измешан"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block је генерисан и критеријуме су спремне"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block је сачуван"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Обрада..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Одабери модификатор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "садржи"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "не садржи"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "је"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "није"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "почиње се са"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "завршава се са"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "је већи од"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "је мањи од"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "је у опсегу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Одабери Мапу за Складиштење"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Одабери Мапу за Праћење"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Јеси ли сигуран да желиш да промениш мапу за складиштење?\n"
+"То ће да уклони датотеке из твоје библиотеке!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Управљање Медијске Мапе"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Јеси ли сигуран да желиш да уклониш надзорску мапу?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Овај пут није тренутно доступан."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Неке врсте емитовање захтевају додатну конфигурацију. Детаљи око омогућавања %sAAC+ Подршке%s или %sOpus Подршке%s су овде доступни."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Прикључен је на серверу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Пренос је онемогућен"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Добијање информација са сервера..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Не може да се повеже на серверу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Ако је иза Airtime-а рутер или заштитни зид, можда мораш да конфигуришеш поље порта прослеђивање и ово информационо поље ће да буде нетачан. У том случају мораћеш ручно да ажурираш ово поље, да би показао тачноhost/port/mount да се могу да повеже твоји диск-џокеји. Допуштени опсег је између 1024 и 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "За више детаља, прочитај %sУпутству за употребу%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Провери ову опцију како би се омогућило метаподатака за OGG потоке."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Провери ову кућицу за аутоматско искључење Мајстор/Емисија извора, након престанка рада извора."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Провери ову кућицу за аутоматско пребацивање на Мајстор/Емисија извора, након што је спојен извор."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Ако твој Icecast сервер очекује корисничко име из 'извора', ово поље може да остане празно."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Ако твој 'live streaming' клијент не пита за корисничко име, ово поље требало да буде 'извор'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Ово је админ корисничко име и лозинка за Icecast/SHOUTcast да би добио слушатељску статистику."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Упозорење: Не можеш променити садржај поља, док се садашња емисија не завршава"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Нема пронађених резултата"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "То следи исти образац безбедности за емисије: само додељени корисници могу да се повеже на емисију."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Одреди прилагођене аутентификације које ће да се уважи само за ову емисију."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Емисија у овом случају више не постоји!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Упозорење: Емисије не може поново да се повеже"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Повезивањем своје понављајуће емисије свака заказана медијска става у свакој понављајућим емисијама добиће исти распоред такође и у другим понављајућим емисијама"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Временска зона је постављена по станичну зону према задатим. Емисије у календару ће се да прикаже по твојим локалном времену која је дефинисана у интерфејса временске зоне у твојим корисничким поставци."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Емисија"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Емисија је празна"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Добијање података са сервера..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Ова емисија нема заказаног садржаја."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Ова емисија није у потпуности испуњена са садржајем."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Јануар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Фебруар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Март"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "Април"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Мај"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Јун"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Јул"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Август"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Септембар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Октобар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Новембар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Децембар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Јан"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Феб"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Мар"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Апр"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Јун"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Јул"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Авг"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Сеп"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Окт"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Нов"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Дец"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Недеља"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Понедељак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Уторак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Среда"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Четвртак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Петак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Субота"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Нед"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Пон"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Уто"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Сре"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Чет"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Пет"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Суб"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Емисија дуже од предвиђеног времена ће да буде одсечен."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Откажи Тренутног Програма?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Заустављање снимање емисије?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ок"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Садржај Емисије"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Уклониш све садржаје?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Обришеш ли одабрану (е) ставу (е)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Почетак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Завршетак"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Трајање"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Одтамњење"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Затамњење"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Празна Емисија"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Снимање са Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Преглед песма"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Не може да се заказује ван емисије."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Премештање 1 Ставка"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Премештање %s Ставке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Сачувај"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Одустани"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Уређивач за (Од-/За-)тамњивање"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Уређивач"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Таласни облик функције су доступне у споредну Web Audio API прегледачу"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Одабери све"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Не одабери ништа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Уклони одабране заказане ставке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Скочи на тренутну свирану песму"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Поништи тренутну емисију"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Отвори библиотеку за додавање или уклањање садржаја"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Додај / Уклони Садржај"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "у употреби"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Диск"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Погледај унутра"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Отвори"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Администратор"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "Диск-џокеј"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Водитељ Програма"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Гост"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Гости могу да уради следеће:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Преглед распореда"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Преглед садржај емисије"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Диск-џокеји могу да уради следеће:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Управљање додељен садржај емисије"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Увоз медијске фајлове"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Изради листе песама, паметне блокове, и преносе"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Управљање своје библиотечког садржаја"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Менаџер програма могу да уради следеће:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Приказ и управљање садржај емисије"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Распоредне емисије"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Управљање све садржаје библиотека"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Администратори могу да уради следеће:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Управљање подешавања"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Управљање кориснике"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Управљање надзираних датотеке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Пошаљи повратне информације"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Преглед стања система"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Приступ за историју пуштених песама"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Погледај статистику слушаоце"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Покажи/сакриј колоне"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Од {from} до {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "гггг-мм-дд"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Не"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "По"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Ут"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Ср"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Че"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Пе"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Су"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Затвори"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Сат"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Минута"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Готово"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Изабери датотеке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Додај датотеке и кликни на 'Покрени Upload' дугме."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Додај Датотеке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Заустави Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Покрени upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Додај датотеке"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Послата %d/%d датотека"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Повуци датотеке овде."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Грешка (ознаку типа датотеке)."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Грешка величине датотеке."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Грешка број датотеке."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init грешка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Грешка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Безбедносна грешка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Генеричка грешка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO грешка."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Фајл: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d датотека на чекању"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Датотека: %f, величина: %s, макс величина датотеке: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Преносни URL може да буде у криву или не постоји"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Грешка: Датотека је превелика:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Грешка: Неважећи ознак типа датотека:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Постави Подразумевано"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Стварање Уноса"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Уреди Историјат Уписа"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Нема Програма"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s ред%s је копиран у међумеморију"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sИспис поглед%sМолимо, користи прегледача штампање функцију за штампање ову табелу. Кад завршиш, притисни Escape."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "Е-маил није могао да буде послат. Провери своје поставке сервера поште и провери се да је исправно подешен."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Погрешно корисничко име или лозинка. Молимо покушај поново."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -370,11 +2405,6 @@ msgstr "Немаш допуштење за брисање одабраног (е
 msgid "You can only add tracks to smart block."
 msgstr "Можеш само песме да додаш за паметног блока."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Можеш само да додаш песме, паметне блокова, и преносе код листе нумера."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Неименовани Списак Песама"
@@ -383,2627 +2413,88 @@ msgstr "Неименовани Списак Песама"
 msgid "Untitled Smart Block"
 msgstr "Неименовани Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Непознати Списак Песама"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Не смеш да приступиш овог извора."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Подешавања су ажуриране."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Подршка подешавања је ажурирана."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Повратне Информације"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Пренос Подешавање је Ажурирано."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "пут би требао да буде специфициран"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Проблем са Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Немаш допуштење да искључиш извор."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Нема спојеног извора на овај улаз."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Немаш дозволу за промену извора."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Погрешно корисничко име или лозинка. Молимо покушај поново."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "Е-маил није могао да буде послат. Провери своје поставке сервера поште и провери се да је исправно подешен."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Не смеш да приступите овог извора."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Неисправан захтев."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Неисправан захтев"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Аудио Уређај"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Снимање:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Мајсторски Пренос"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Пренос Уживо"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Ништа по распореду"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Садашња Емисија:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Тренутна"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Ти имаш инсталирану најновију верзију"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Нова верзија је доступна:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Ова верзија ускоро ће да буде застарео."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Ова верзија више није подржана."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Молимо надогради на"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Додај у тренутни списак песама"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Додај у тренутни smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Додавање 1 Ставке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Додавање %s Ставке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Можеш да додаш само песме код паметних блокова."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Молимо одабери место показивача на временској црти."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Додај у одабраној емисији"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Одабери"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Одабери ову страницу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Одзначи ову страницу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Одзначи све"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Јеси ли сигуран да желиш да избришеш одабрану (е) ставу (е)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Заказана"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Пренос Бита"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Кодирано је по"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Последња Измена"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Задњи Пут Одиграна"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Власник"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Узорак Стопа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Број Песма"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Додата"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Веб страница"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Учитавање..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Све"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Датотеке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Листе песама"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Block-ови"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Преноси"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Непознати тип:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Јеси ли сигуран да желиш да обришеш изабрану ставку?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Пренос је у току..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Преузимање података са сервера..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "SoundCloud id за ову датотеку је:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Дошло је до грешке приликом преноса на soundcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Шифра грешке:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Порука о грешци:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Мора да буде позитиван број"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Мора да буде број"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Мора да буде у облику: гггг-мм-дд"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Мора да буде у облику: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Тренутно је пренос датотеке. %sОдлазак на другом екрану ће да откаже процес слања. %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Отвори Медијског Градитеља"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "молимо стави у време '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "молимо стави у време у секундама '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Твој претраживач не подржава ову врсту аудио фајл:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Динамички блок није доступан за преглед"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Ограничити се на:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Списак песама је спремљена"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Списак песама је измешан"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime је несигуран о статусу ове датотеке. То такође може да се деси када је датотека на удаљеном диску или је датотека у некој директоријуми, која се више није 'праћена односно надзирана'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Број Слушалаца %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Подсети ме за 1 недељу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Никад ме више не подсети"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Да, помажем Airtime-у"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Слика мора да буде jpg, jpeg, png, или gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Статички паметни блокови спремају критеријуме и одмах генеришу блок садржаја. То ти омогућава да уредиш и видиш га у библиотеци пре него што га додаш на емисију."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Динамички паметни блокови само критеријуме спремају. Блок садржаја ће се генерише након што га додамо на емисију. Нећеш моћи да прегледаш и уређиваш садржај у библиотеци."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Жељена дужина блока неће да буде постигнут јер Airtime не могу да пронађе довољно јединствене песме које одговарају твојим критеријумима. Омогући ову опцију ако желиш да допустиш да неке песме могу да се више пута понављају."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block је измешан"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block је генерисан и критеријуме су спремне"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block је сачуван"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Обрада..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Одабери модификатор"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "садржи"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "не садржи"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "је"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "није"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "почиње се са"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "завршава се са"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "је већи од"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "је мањи од"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "је у опсегу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Одабери Мапу за Складиштење"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Одабери Мапу за Праћење"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Јеси ли сигуран да желиш да промениш мапу за складиштење?\nТо ће да уклони датотеке из твоје библиотеке!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Управљање Медијске Мапе"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Јеси ли сигуран да желиш да уклониш надзорску мапу?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Овај пут није тренутно доступан."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Неке врсте емитовање захтевају додатну конфигурацију. Детаљи око омогућавања %sAAC+ Подршке%s или %sOpus Подршке%s су овде доступни."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Прикључен је на серверу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Пренос је онемогућен"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Добијање информација са сервера..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Не може да се повеже на серверу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Ако је иза Airtime-а рутер или заштитни зид, можда мораш да конфигуришеш поље порта прослеђивање и ово информационо поље ће да буде нетачан. У том случају мораћеш ручно да ажурираш ово поље, да би показао тачноhost/port/mount да се могу да повеже твоји диск-џокеји. Допуштени опсег је између 1024 и 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "За више детаља, прочитај %sУпутству за употребу%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Провери ову опцију како би се омогућило метаподатака за OGG потоке."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Провери ову кућицу за аутоматско искључење Мајстор/Емисија извора, након престанка рада извора."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Провери ову кућицу за аутоматско пребацивање на Мајстор/Емисија извора, након што је спојен извор."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Ако твој Icecast сервер очекује корисничко име из 'извора', ово поље може да остане празно."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Ако твој 'live streaming' клијент не пита за корисничко име, ово поље требало да буде 'извор'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Ово је админ корисничко име и лозинка за Icecast/SHOUTcast да би добио слушатељску статистику."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Упозорење: Не можеш променити садржај поља, док се садашња емисија не завршава"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Нема пронађених резултата"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "То следи исти образац безбедности за емисије: само додељени корисници могу да се повеже на емисију."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Одреди прилагођене аутентификације које ће да се уважи само за ову емисију."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Емисија у овом случају више не постоји!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Упозорење: Емисије не може поново да се повеже"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Повезивањем своје понављајуће емисије свака заказана медијска става у свакој понављајућим емисијама добиће исти распоред такође и у другим понављајућим емисијама"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Временска зона је постављена по станичну зону према задатим. Емисије у календару ће се да прикаже по твојим локалном времену која је дефинисана у интерфејса временске зоне у твојим корисничким поставци."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Емисија"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Емисија је празна"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Добијање података са сервера..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Ова емисија нема заказаног садржаја."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Ова емисија није у потпуности испуњена са садржајем."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Јануар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Фебруар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Март"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "Април"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Мај"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Јун"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Јул"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Август"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Септембар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Октобар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Новембар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Децембар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Јан"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Феб"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Мар"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Апр"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Јун"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Јул"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Авг"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Сеп"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Окт"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Нов"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Дец"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Недеља"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Понедељак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Уторак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Среда"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Четвртак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Петак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Субота"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Нед"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Пон"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Уто"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Сре"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Чет"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Пет"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Суб"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Емисија дуже од предвиђеног времена ће да буде одсечен."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Откажи Тренутног Програма?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Заустављање снимање емисије?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ок"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Садржај Емисије"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Уклониш све садржаје?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Обришеш ли одабрану (е) ставу (е)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Почетак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Завршетак"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Трајање"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Одтамњење"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Затамњење"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Празна Емисија"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Снимање са Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Преглед песма"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Не може да се заказује ван емисије."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Премештање 1 Ставка"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Премештање %s Ставке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Сачувај"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Одустани"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Уређивач за (Од-/За-)тамњивање"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Уређивач"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Таласни облик функције су доступне у споредну Web Audio API прегледачу"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Одабери све"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Не одабери ништа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Уклони одабране заказане ставке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Скочи на тренутну свирану песму"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Поништи тренутну емисију"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Отвори библиотеку за додавање или уклањање садржаја"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Додај / Уклони Садржај"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "у употреби"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Диск"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Погледај унутра"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Отвори"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Администратор"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "Диск-џокеј"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Водитељ Програма"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Гост"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Гости могу да уради следеће:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Преглед распореда"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Преглед садржај емисије"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Диск-џокеји могу да уради следеће:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Управљање додељен садржај емисије"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Увоз медијске фајлове"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Изради листе песама, паметне блокове, и преносе"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Управљање своје библиотечког садржаја"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Менаџер програма могу да уради следеће:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Приказ и управљање садржај емисије"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Распоредне емисије"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Управљање све садржаје библиотека"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Администратори могу да уради следеће:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Управљање подешавања"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Управљање кориснике"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Управљање надзираних датотеке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Пошаљи повратне информације"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Преглед стања система"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Приступ за историју пуштених песама"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Погледај статистику слушаоце"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Покажи/сакриј колоне"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Од {from} до {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "гггг-мм-дд"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Не"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "По"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Ут"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Ср"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Че"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Пе"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Су"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Затвори"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Сат"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Минута"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Готово"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Изабери датотеке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Додај датотеке и кликни на 'Покрени Upload' дугме."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Стање"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Додај Датотеке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Заустави Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Покрени upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Додај датотеке"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Послата %d/%d датотека"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Повуци датотеке овде."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Грешка (ознаку типа датотеке)."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Грешка величине датотеке."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Грешка број датотеке."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init грешка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Грешка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Безбедносна грешка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Генеричка грешка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO грешка."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Фајл: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d датотека на чекању"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Датотека: %f, величина: %s, макс величина датотеке: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Преносни URL може да буде у криву или не постоји"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Грешка: Датотека је превелика:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Грешка: Неважећи ознак типа датотека:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Постави Подразумевано"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Стварање Уноса"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Уреди Историјат Уписа"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Нема Програма"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s ред%s је копиран у међумеморију"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sИспис поглед%sМолимо, користи прегледача штампање функцију за штампање ову табелу. Кад завршиш, притисни Escape."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Одабери показивач"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Уклони показивач"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "емисија не постоји"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Реемитовање емисија %s од %s на %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Одабери показивач"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Уклони показивач"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "емисија не постоји"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Корисник је успешно додат!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Корисник је успешно ажуриран!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Подешавања су успешно ажуриране!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Неименовани Пренос"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Пренос је сачуван."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Неважећи вредности обрасца."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Година %s мора да буде у распону између 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s није исправан датум"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s није исправан датум"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Пренос уживо"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Покрени"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Стани"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Подеси Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Подеси Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Показивач"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Подели"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Преноси:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "mute"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "укључи"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "О пројекту"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "За детаљну помоћ, прочитај %sупутство за коришћење%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Историја Пуштених Песама"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Списак Пријава"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Датотечни Извештај"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Програмски Извештај"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Проширење Статичког Bloка"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Проширење Динамичког Блока"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Назив:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Опис:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Трајање:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Случајни избор списак песама"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Мешање"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Крижно утишавање списак песама"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Празан садржај списак песама"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Очисти"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Одтамњење:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Затамњење:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Сачувај списак песама"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Нема отворених списак песама"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Емисијски звучни таласни облик"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Оригинална Дужина:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Преносна Подешавања"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Пријава"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Нова лозинка"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Унеси и потврди своју нову лозинку у поља доле."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Управљање Кориснике"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Нови Корисник"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Корисничко име"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Име"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Презиме"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Врста Корисника"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Пронађи Емисије"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Одабери Емисијску Степену"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Пронађи"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Поновљени Дани:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Уклони"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Додај"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Emisijski Izvor"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime Регистар"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Обавезно)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(служи само за проверу, неће да буде објављена)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Напомена: Све већа од 600к600 ће да се мењају."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Покажи ми шта шаљем"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Услови и Одредбе"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Одабери Дане:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "или"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "и"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "до"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "датотеке задовољавају критеријуме"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Филтрирај Историје"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Како би се промовисао своју станицу, 'Пошаљи повратне информације' мора да буде омогућена)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Пренос"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Додатне Опције"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Следеће информације ће да буде приказане слушаоцима у медијском плејерима:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Твоја радијска станица веб странице)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL Преноса:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Одабери фолдер"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Подеси"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Актуална Увозна Мапа:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Уклони надзорану директоријуму"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Не пратиш ниједне медијске мапе."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Мајсторски Извор"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Подешавање"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Додај ову емисију"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Ажурирање емисије"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Шта"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Када"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Улаз Уживног Преноса"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Ко"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Стил"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Дисковни Простор"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Увоз датотеке је у току..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Напредне Опције Претраживања"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Назив:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Творац:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Aлбум:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Песма:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Дужина:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Узорак Стопа:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Брзина у Битовима:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Расположење:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Жанр:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Година:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Налепница:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Композитор:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Диригент:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Ауторско право:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Број:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Веб страница:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Језик:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Стажа Датотека:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Пренос"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Динамички Паметан Блок"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Статички Паметан Блок"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Звучни Запис"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Садржаји Списак Песама:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Статички Паметан Блок Садржаји:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Динамички Паметан Блок Критеријуми:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Ограничено за"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Ваш налог истиче у"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "дани"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Претходна:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Следећа:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Преносни Извори"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "ПРЕНОС"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Слушај"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Одјава"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Шаблони Списак Пријаве"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Нови Листу шаблона"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Нема Листу Шаблона"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Шаблони за Датотечни Сажеци"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Нови Шаблон за Датотечни Сажеци"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Нема Шаблона за Датотечни Сажеци"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Стварање Шаблона за Датотечни Сажеци"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Стварање Листу Шаблона"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Назив"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Додај више елемената"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Додај Ново Поље"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Подеси Подразумевано Шаблону"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Опис"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL Преноса:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Задата Дужина:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Нема преноса"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Помоћ"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Страница није пронађена!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Изгледа страница коју си тражио не постоји!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "претходна"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "покрени"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "пауза"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "следећа"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "заустави"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "макс гласноћа"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Потребно Ажурирање"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Медија је потребна за репродукцију, и мораш да ажурираш свој претраживач на новију верзију, или да ажурираш свој %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Датум Почетка:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2504,6 @@ msgstr "Датум Почетка:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Унесени су неважећи знакови"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Датум Завршетка:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Све Моје Емисије:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Тражи Кориснике:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Диск-џокеји:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Назив Станице"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Телефон:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Е-маил:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Веб Страница:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Држава:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Град:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Опис:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Лого:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Мораш да пристанеш на правила о приватности."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Снимање са Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Поново да емитује?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Вредност је потребна и не може да буде празан"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' није ваљана е-маил адреса у основном облику local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' не одговара по облику датума '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' је мањи од %min% дугачко знакова"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' је више од %max% дугачко знакова"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' није између '%min%' и '%max%', укључиво"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Лозинке се не подударају"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2520,55 @@ msgstr "Време мора да буде наведено"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Мораш да чекаш најмање 1 сат за ре-емитовање"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Ресетуј лозинку"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Неименована Емисија"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Број:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "ОК"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Подразумевано Трајање Укрштено Стишавање (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Подразумевано Одтамњење (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Подразумевано Затамњење (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Онемогућено"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Омогућено"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Станична Временска Зона"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Први Дан у Недељи"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Корисничко име:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Лозинка:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Потврди Лозинку:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Име:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Презиме:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Мобилни Телефон:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Типова Корисника:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Име пријаве није јединствено."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Увозна Мапа:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Мапе Под Надзором:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Не важећи Директоријум"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Задата Дозвола:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Сва права задржана"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Рад је у јавном домену"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Именовање"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Именовање Некомерцијално"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Именовање Без Изведених Дела"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Дели Под Истим Условима"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Именовање Некомерцијално Без Изведених Дела"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Именовање Некомерцијално Дијели Под Истим Условима"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Временска Зона Интерфејси:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Тренутно Извођена"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Одабери критеријуме"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Брзина у Битовима (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Узорак Стопа (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "сати"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "минути"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "елементи"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Статички"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Динамички"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Генерисање листе песама и чување садржаја критеријуме"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Генериши"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Садржај случајни избор списак песама"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Ограничење не може да буде празан или мањи од 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Ограничење не може да буде више од 24 сати"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Вредност мора да буде цео број"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 је макс ставу граничну вредност могуће је да подесиш"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Мораш да изабереш Критерију и Модификацију"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Дужина' требала да буде у '00:00:00' облику"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Вредност мора да буде у облику временске ознаке (нпр. 0000-00-00 или 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Вредност мора да буде нумеричка"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Вредност би требала да буде мања од 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Вредност мора да буде мања од %s знакова"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Вредност не може да буде празна"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Метаподаци"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Видљиви Подаци:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Аутор - Назив"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Емисија - Аутор - Назив"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Назив станице - Назив емисије"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Метаподаци"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Укључи Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Модификатор"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Лозинка"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Потврди нову лозинку"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Лозинке које сте унели не подударају се."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Омогућено:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Пренос Типа:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Тип Услуге:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Канали:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Сервер"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Порт"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Допуштени су само бројеви."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Тачка Монтирања"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Админ Корисник"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Aдминска Лозинка"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Сервер не може да буде празан."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port не може да буде празан."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Монтирање не може да буде празна са Icecast сервером."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' се не уклапа у временском формату 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Временска Зона:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Понављање?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Не може да се створи емисију у прошлости"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Не можеш да мењаш датум/време почетак емисије, ако је већ почела"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Датум завршетка и време не може да буде у прошлости"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Не може да траје < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Не може да траје 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Не може да траје више од 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Користи Прилагођено потврду идентитета:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Прилагођено Корисничко Име"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Прилагођена Лозинка"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "'Корисничко Име' поља не сме да остане празно."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "'Лозинка' поља не сме да остане празно."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Боја Позадине:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Боја Текста:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Упиши знаке које видиш на слици у наставку."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "дани"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2614,12 @@ msgstr "дан у месецу"
 msgid "day of the week"
 msgstr "дан у недељи"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Датум Завршетка:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Нема Краја?"
@@ -3876,115 +2632,1174 @@ msgstr "Датум завршетка мора да буде после дату
 msgid "Please select a repeat day"
 msgstr "Молимо, одабери којег дана"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Снимање са Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Поново да емитује?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Боја Позадине:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Боја Текста:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Календар"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Уклони"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Корисници"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Назив:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Преноси"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Неименована Емисија"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Жанр:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Опис:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Слушатељска Статистика"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' се не уклапа у временском формату 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Историјски Шаблони"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Трајање:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Временска Зона:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Понављање?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Не може да се створи емисију у прошлости"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Не можеш да мењаш датум/време почетак емисије, ако је већ почела"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Датум завршетка и време не може да буде у прошлости"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Не може да траје < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Не може да траје 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Не може да траје више од 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Не можеш заказати преклапајуће емисије"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Тражи Кориснике:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Диск-џокеји:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Корисничко име:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Лозинка:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Потврди Лозинку:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Име:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Презиме:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Е-маил:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Мобилни Телефон:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Типова Корисника:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Име пријаве није јединствено."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Почетак Коришћења"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Упутство"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Вредност је потребна и не може да буде празан"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Датум Почетка:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Назив:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Творац:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Aлбум:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Година:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Налепница:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Композитор:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Диригент:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Расположење:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Ауторско право:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Број:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Веб страница:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Језик:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Време Почетка"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Време Завршетка"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Временска Зона Интерфејси:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Назив Станице"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Лого:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Напомена: Све већа од 600к600 ће да се мењају."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Подразумевано Трајање Укрштено Стишавање (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Подразумевано Одтамњење (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Подразумевано Затамњење (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Онемогућено"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Омогућено"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Станична Временска Зона"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Први Дан у Недељи"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' није ваљана е-маил адреса у основном облику local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' не одговара по облику датума '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' је мањи од %min% дугачко знакова"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' је више од %max% дугачко знакова"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' није између '%min%' и '%max%', укључиво"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Лозинке се не подударају"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Допуштени су само бројеви."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Пријава"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Упиши знаке које видиш на слици у наставку."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Лозинка"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Потврди нову лозинку"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Лозинке које сте унели не подударају се."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Корисничко име"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Ресетуј лозинку"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Тренутно Извођена"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Телефон:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Веб Страница:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Држава:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Град:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Опис:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Мораш да пристанеш на правила о приватности."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Све Моје Емисије:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Одабери критеријуме"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Брзина у Битовима (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Опис"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Узорак Стопа (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "сати"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "минути"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "елементи"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Статички"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Динамички"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Генерисање листе песама и чување садржаја критеријуме"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Генериши"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Садржај случајни избор списак песама"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Мешање"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Ограничење не може да буде празан или мањи од 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Ограничење не може да буде више од 24 сати"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Вредност мора да буде цео број"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 је макс ставу граничну вредност могуће је да подесиш"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Мораш да изабереш Критерију и Модификацију"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Дужина' требала да буде у '00:00:00' облику"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Вредност мора да буде у облику временске ознаке (нпр. 0000-00-00 или 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Вредност мора да буде нумеричка"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Вредност би требала да буде мања од 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Вредност мора да буде мања од %s знакова"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Вредност не може да буде празна"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Задата Дозвола:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Сва права задржана"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Рад је у јавном домену"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Именовање"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Именовање Некомерцијално"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Именовање Без Изведених Дела"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Дели Под Истим Условима"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Именовање Некомерцијално Без Изведених Дела"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Именовање Некомерцијално Дијели Под Истим Условима"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Метаподаци"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Видљиви Подаци:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Аутор - Назив"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Емисија - Аутор - Назив"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Назив станице - Назив емисије"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Метаподаци"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Укључи Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Модификатор"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Омогућено:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Пренос Типа:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Брзина у Битовима:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Тип Услуге:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Канали:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Сервер"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Порт"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Назив"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Тачка Монтирања"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Админ Корисник"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Aдминска Лозинка"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Сервер не може да буде празан."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port не може да буде празан."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Монтирање не може да буде празна са Icecast сервером."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Увозна Мапа:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Мапе Под Надзором:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Не важећи Директоријум"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Покрени"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Стани"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Подеси Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Подеси Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Показивач"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Пренос уживо"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "'Cue in' и 'cue out' су нуле."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Не можеш да подесиш да 'cue out' буде веће од дужине фајла."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Не можеш да подесиш да 'cue in' буде веће него 'cue out'."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Не можеш да подесиш да 'cue out' буде мање него 'cue in'."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Реемитовање од %s од %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Одабери Државу"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4009,14 +3824,12 @@ msgstr "%s није ваљан директоријум."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s је већ постављена као мапа за складиштење или је између пописа праћених фолдера"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s је већ постављена као мапа за складиштење или је између пописа праћених фолдера."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,28 +3837,18 @@ msgstr "%s је већ постављена као мапа за складиш�
 msgid "%s doesn't exist in the watched list."
 msgstr "%s не постоји у листи надзираних локације."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Одабери Државу"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Емисије могу да имају највећу дужину 24 сата."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Не може да се закаже преклапајуће емисије.\nНапомена: Промена величине понављане емисије утиче на све њене понављање."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4060,48 +3863,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Застарео се прегледан распоред! (пример неусклађеност)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Застарео се прегледан распоред!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Не смеш да закажеш распоредну емисију %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Не можеш да додаш датотеке за снимљене емисије."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Емисија %s је готова и не могу да буде заказана."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Раније је %s емисија већ била ажурирана!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Садржај у повезаним емисијама мора да буде заказан пре или после било које емисије"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Изабрани Фајл не постоји!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Емисије могу да имају највећу дужину 24 сата."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Не може да се закаже преклапајуће емисије.\n"
+"Напомена: Промена величине понављане емисије утиче на све њене понављање."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Реемитовање од %s од %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4148,8 +3963,1049 @@ msgstr "Неважећи пренос - Чини се да је ово преу�
 msgid "Unrecognized stream type: %s"
 msgstr "Непознати преносни тип: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Снимљена датотека не постоји"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Метаподаци снимљеног фајла"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Уређивање"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Уређивање Програма"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Дозвола одбијена"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Не можеш повући и испустити понављајуће емисије"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Не можеш преместити догађане емисије"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Не можеш преместити емисију у прошлости"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Не можеш преместити снимљене емисије раније од 1 сат времена пре њених реемитовања."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Емисија је избрисана јер је снимљена емисија не постоји!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Мораш причекати 1 сат за ре-емитовање."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Песма"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Пуштена"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "претходна"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "покрени"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "пауза"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "следећа"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "заустави"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "mute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "укључи"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "макс гласноћа"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Потребно Ажурирање"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Медија је потребна за репродукцију, и мораш да ажурираш свој претраживач на новију верзију, или да ажурираш свој %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "О пројекту"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "За детаљну помоћ, прочитај %sупутство за коришћење%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Подели"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Преноси:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Страница није пронађена!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Изгледа страница коју си тражио не постоји!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Emisijski Izvor"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Одабери Дане:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Додај"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Поновљени Дани:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Филтрирај Историје"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Одабери Емисијску Степену"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Пронађи"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Подешавање"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Мајсторски Извор"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "ОК"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Одабери фолдер"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Подеси"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Актуална Увозна Мапа:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Уклони надзорану директоријуму"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Не пратиш ниједне медијске мапе."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime Регистар"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Обавезно)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(служи само за проверу, неће да буде објављена)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Покажи ми шта шаљем"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Услови и Одредбе"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Пронађи Емисије"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "или"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "и"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "до"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "датотеке задовољавају критеријуме"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Пренос"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Додатне Опције"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Следеће информације ће да буде приказане слушаоцима у медијском плејерима:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Твоја радијска станица веб странице)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL Преноса:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Како би се промовисао своју станицу, 'Пошаљи повратне информације' мора да буде омогућена)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Песма:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Дужина:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Узорак Стопа:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Број:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Стажа Датотека:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Пренос"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Динамички Паметан Блок"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Статички Паметан Блок"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Звучни Запис"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Садржаји Списак Песама:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Статички Паметан Блок Садржаји:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Динамички Паметан Блок Критеријуми:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Ограничено за"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Увоз датотеке је у току..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Напредне Опције Претраживања"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Нова лозинка"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Унеси и потврди своју нову лозинку у поља доле."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Претходна:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Следећа:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Преносни Извори"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "ПРЕНОС"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Слушај"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Одјава"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Ваш налог истиче у"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Случајни избор списак песама"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Крижно утишавање списак песама"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Празан садржај списак песама"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Очисти"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Затамњење:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Сачувај списак песама"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Нема отворених списак песама"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Емисијски звучни таласни облик"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Оригинална Дужина:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Одтамњење:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Проширење Статичког Bloка"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Проширење Динамичког Блока"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Списак Пријава"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Датотечни Извештај"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Програмски Извештај"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Шаблони Списак Пријаве"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Нови Листу шаблона"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Нема Листу Шаблона"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Шаблони за Датотечни Сажеци"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Нови Шаблон за Датотечни Сажеци"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Нема Шаблона за Датотечни Сажеци"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Стварање Шаблона за Датотечни Сажеци"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Стварање Листу Шаблона"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Додај више елемената"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Додај Ново Поље"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Подеси Подразумевано Шаблону"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Преносна Подешавања"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Додај ову емисију"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Ажурирање емисије"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Шта"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Када"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Улаз Уживног Преноса"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Ко"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Стил"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Дисковни Простор"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Управљање Кориснике"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Нови Корисник"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Име"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Презиме"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Врста Корисника"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL Преноса:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Задата Дужина:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Нема преноса"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "молимо стави у време у секундама '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Садржај у повезаним емисијама мора да буде заказан пре или после било које емисије"

--- a/airtime_mvc/locale/sr_RS/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/sr_RS/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Sourcefabric <contact@sourcefabric.org>, 2013
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Serbian (Latin) (Serbia) (http://www.transifex.com/sourcefabric/airtime/language/sr_RS@latin/)\n"
+"Language: sr_RS@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sr_RS@latin\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "Snimljena datoteka ne postoji"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "Godina %s mora da bude u rasponu između 1753 - 9999"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "Metapodaci snimljenog fajla"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s nije ispravan datum"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s nije ispravan datum"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Uređivanje"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "Uređivanje Programa"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Obriši"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "Dozvola odbijena"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "Ne možeš povući i ispustiti ponavljajuće emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "Ne možeš premestiti događane emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "Ne možeš premestiti emisiju u prošlosti"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Ne možeš zakazati preklapajuće emisije"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "Ne možeš premestiti snimljene emisije ranije od 1 sat vremena pre njenih reemitovanja."
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "Emisija je izbrisana jer je snimljena emisija ne postoji!"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "Moraš pričekati 1 sat za re-emitovanje."
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Naziv"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Tvorac"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Album"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Dužina"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Žanr"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Raspoloženje"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Nalepnica"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Kompozitor"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Autorsko pravo"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Godina"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "Pesma"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Dirigent"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Jezik"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Vreme Početka"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Vreme Završetka"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "Puštena"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "Kalendar"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "Korisnici"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "Prenosi"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "Stanje"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "Istorija Puštenih Pesama"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "Istorijski Šabloni"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "Slušateljska Statistika"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "Pomoć"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "Početak Korišćenja"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "Uputstvo"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "Ne smeš da pristupiš ovog izvora."
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "Ne smeš da pristupite ovog izvora."
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "Neispravan zahtev."
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "Neispravan zahtev"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "Nemaš dopuštenje da isključiš izvor."
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "Nema spojenog izvora na ovaj ulaz."
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "Nemaš dozvolu za promenu izvora."
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s nije pronađen"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "Nešto je pošlo po krivu."
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Pregled"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "Dodaj na Spisak Pesama"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "Dodaj u Smart Block"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "Uredi Metapodatke"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Obriši"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "Preuzimanje"
 
@@ -276,81 +890,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "Udvostručavanje"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "Nema dostupnih akcija"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "Nemaš dopuštenje za brisanje odabrane stavke."
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "Kopiranje od %s"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "Neimenovani Prenos"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "Prenos je sačuvan."
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "Nevažeći vrednosti obrasca."
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "Molimo, proveri da li je ispravan/na admin korisnik/lozinka na stranici Sistem->Prenosi."
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "Korisnik je uspešno dodat!"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Uređaj"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "Korisnik je uspešno ažuriran!"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "Podešavanja su uspešno ažurirane!"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "Snimanje:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "Majstorski Prenos"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Prenos Uživo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "Ništa po rasporedu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "Sadašnja Emisija:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "Trenutna"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "Ti imaš instaliranu najnoviju verziju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "Nova verzija je dostupna:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "Ova verzija uskoro će da bude zastareo."
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "Ova verzija više nije podržana."
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "Molimo nadogradi na"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "Dodaj u trenutni spisak pesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "Dodaj u trenutni smart block"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "Dodavanje 1 Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "Dodavanje %s Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "Možeš da dodaš samo pesme kod pametnih blokova."
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "Možeš samo da dodaš pesme, pametne blokova, i prenose kod liste numera."
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "Molimo odaberi mesto pokazivača na vremenskoj crti."
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "Uredi Metapodatke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "Dodaj u odabranoj emisiji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "Odaberi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "Odaberi ovu stranicu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "Odznači ovu stranicu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "Odznači sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "Jesi li siguran da želiš da izbrišeš odabranu (e) stavu (e)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "Zakazana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Naziv"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Tvorac"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Album"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "Prenos Bita"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Kompozitor"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Dirigent"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Autorsko pravo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Kodirano je po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Žanr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Nalepnica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Jezik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Poslednja Izmena"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Zadnji Put Odigrana"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Dužina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Raspoloženje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Vlasnik"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "Uzorak Stopa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Broj Pesma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Dodata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Veb stranica"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Godina"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Učitavanje..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "Datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "Liste pesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "Smart Block-ovi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "Prenosi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "Nepoznati tip:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "Jesi li siguran da želiš da obrišeš izabranu stavku?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "Prenos je u toku..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "Preuzimanje podataka sa servera..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "SoundCloud id za ovu datoteku je:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "Došlo je do greške prilikom prenosa na soundcloud."
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "Šifra greške:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "Poruka o grešci:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "Mora da bude pozitivan broj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "Mora da bude broj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "Mora da bude u obliku: gggg-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "Mora da bude u obliku: hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "Trenutno je prenos datoteke. %sOdlazak na drugom ekranu će da otkaže proces slanja. %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "Otvori Medijskog Graditelja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "molimo stavi u vreme '00:00:00 (.0)'"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "Tvoj pretraživač ne podržava ovu vrstu audio fajl:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "Dinamički blok nije dostupan za pregled"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "Ograničiti se na:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "Spisak pesama je spremljena"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "Spisak pesama je izmešan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "Airtime je nesiguran o statusu ove datoteke. To takođe može da se desi kada je datoteka na udaljenom disku ili je datoteka u nekoj direktorijumi, koja se više nije 'praćena odnosno nadzirana'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "Broj Slušalaca %s: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "Podseti me za 1 nedelju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "Nikad me više ne podseti"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "Da, pomažem Airtime-u"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "Slika mora da bude jpg, jpeg, png, ili gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "Statički pametni blokovi spremaju kriterijume i odmah generišu blok sadržaja. To ti omogućava da urediš i vidiš ga u biblioteci pre nego što ga dodaš na emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "Dinamički pametni blokovi samo kriterijume spremaju. Blok sadržaja će se generiše nakon što ga dodamo na emisiju. Nećeš moći da pregledaš i uređivaš sadržaj u biblioteci."
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "Željena dužina bloka neće da bude postignut jer Airtime ne mogu da pronađe dovoljno jedinstvene pesme koje odgovaraju tvojim kriterijumima. Omogući ovu opciju ako želiš da dopustiš da neke pesme mogu da se više puta ponavljaju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "Smart block je izmešan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "Smart block je generisan i kriterijume su spremne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "Smart block je sačuvan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "Obrada..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Odaberi modifikator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "sadrži"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "ne sadrži"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "je"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "nije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "počinje se sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "završava se sa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "je veći od"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "je manji od"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "je u opsegu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "Odaberi Mapu za Skladištenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "Odaberi Mapu za Praćenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"Jesi li siguran da želiš da promeniš mapu za skladištenje?\n"
+"To će da ukloni datoteke iz tvoje biblioteke!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "Upravljanje Medijske Mape"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "Jesi li siguran da želiš da ukloniš nadzorsku mapu?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "Ovaj put nije trenutno dostupan."
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "Neke vrste emitovanje zahtevaju dodatnu konfiguraciju. Detalji oko omogućavanja %sAAC+ Podrške%s ili %sOpus Podrške%s su ovde dostupni."
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "Priključen je na serveru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "Prenos je onemogućen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Dobijanje informacija sa servera..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "Ne može da se poveže na serveru"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "Ako je iza Airtime-a ruter ili zaštitni zid, možda moraš da konfigurišeš polje porta prosleđivanje i ovo informaciono polje će da bude netačan. U tom slučaju moraćeš ručno da ažuriraš ovo polje, da bi pokazao tačnohost/port/mount da se mogu da poveže tvoji disk-džokeji. Dopušteni opseg je između 1024 i 49151."
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "Za više detalja, pročitaj %sUputstvu za upotrebu%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "Proveri ovu opciju kako bi se omogućilo metapodataka za OGG potoke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "Proveri ovu kućicu za automatsko isključenje Majstor/Emisija izvora, nakon prestanka rada izvora."
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "Proveri ovu kućicu za automatsko prebacivanje na Majstor/Emisija izvora, nakon što je spojen izvor."
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "Ako tvoj Icecast server očekuje korisničko ime iz 'izvora', ovo polje može da ostane prazno."
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "Ako tvoj 'live streaming' klijent ne pita za korisničko ime, ovo polje trebalo da bude 'izvor'."
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "Ovo je admin korisničko ime i lozinka za Icecast/SHOUTcast da bi dobio slušateljsku statistiku."
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr "Upozorenje: Ne možeš promeniti sadržaj polja, dok se sadašnja emisija ne završava"
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "Nema pronađenih rezultata"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "To sledi isti obrazac bezbednosti za emisije: samo dodeljeni korisnici mogu da se poveže na emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "Odredi prilagođene autentifikacije koje će da se uvaži samo za ovu emisiju."
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "Emisija u ovom slučaju više ne postoji!"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "Upozorenje: Emisije ne može ponovo da se poveže"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "Povezivanjem svoje ponavljajuće emisije svaka zakazana medijska stava u svakoj ponavljajućim emisijama dobiće isti raspored takođe i u drugim ponavljajućim emisijama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "Vremenska zona je postavljena po staničnu zonu prema zadatim. Emisije u kalendaru će se da prikaže po tvojim lokalnom vremenu koja je definisana u interfejsa vremenske zone u tvojim korisničkim postavci."
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "Emisija"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "Emisija je prazna"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "Dobijanje podataka sa servera..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "Ova emisija nema zakazanog sadržaja."
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "Ova emisija nije u potpunosti ispunjena sa sadržajem."
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "Januar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "Februar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "Mart"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "April"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "Maj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "Avgust"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "Septembar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "Oktobar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "Novembar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "Decembar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "Jan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "Feb"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "Mar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "Apr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "Jun"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "Jul"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "Avg"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "Sep"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "Okt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "Nov"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "Dec"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Nedelja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Ponedeljak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Utorak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Sreda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Četvrtak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Petak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Subota"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Ned"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Pon"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Uto"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Sre"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Čet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Pet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Sub"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "Emisija duže od predviđenog vremena će da bude odsečen."
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "Otkaži Trenutnog Programa?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "Zaustavljanje snimanje emisije?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "Ok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "Sadržaj Emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "Ukloniš sve sadržaje?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "Obrišeš li odabranu (e) stavu (e)?"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "Početak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "Završetak"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "Trajanje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Odtamnjenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Zatamnjenje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "Prazna Emisija"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "Snimanje sa Line In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "Pregled pesma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "Ne može da se zakazuje van emisije."
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "Premeštanje 1 Stavka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "Premeštanje %s Stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Sačuvaj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "Odustani"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "Uređivač za (Od-/Za-)tamnjivanje"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "Cue Uređivač"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "Talasni oblik funkcije su dostupne u sporednu Web Audio API pregledaču"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "Odaberi sve"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "Ne odaberi ništa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "Ukloni odabrane zakazane stavke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "Skoči na trenutnu sviranu pesmu"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "Poništi trenutnu emisiju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "Otvori biblioteku za dodavanje ili uklanjanje sadržaja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "Dodaj / Ukloni Sadržaj"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "u upotrebi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "Disk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "Pogledaj unutra"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "Otvori"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Administrator"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "Disk-džokej"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Voditelj Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Gost"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "Gosti mogu da uradi sledeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "Pregled rasporeda"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "Pregled sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "Disk-džokeji mogu da uradi sledeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "Upravljanje dodeljen sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "Uvoz medijske fajlove"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "Izradi liste pesama, pametne blokove, i prenose"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "Upravljanje svoje bibliotečkog sadržaja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "Menadžer programa mogu da uradi sledeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "Prikaz i upravljanje sadržaj emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "Rasporedne emisije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "Upravljanje sve sadržaje biblioteka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "Administratori mogu da uradi sledeće:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "Upravljanje podešavanja"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "Upravljanje korisnike"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "Upravljanje nadziranih datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Pošalji povratne informacije"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "Pregled stanja sistema"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "Pristup za istoriju puštenih pesama"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "Pogledaj statistiku slušaoce"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "Pokaži/sakrij kolone"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "Od {from} do {to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "kbps"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "gggg-mm-dd"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "hh:mm:ss.t"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "kHz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "Ne"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "Po"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "Ut"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "Sr"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "Če"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "Pe"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "Su"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Zatvori"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Sat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "Minuta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "Gotovo"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "Izaberi datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "Dodaj datoteke i klikni na 'Pokreni Upload' dugme."
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "Dodaj Datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "Zaustavi Upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "Pokreni upload"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "Dodaj datoteke"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "Poslata %d/%d datoteka"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "N/A"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "Povuci datoteke ovde."
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "Greška (oznaku tipa datoteke)."
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "Greška veličine datoteke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "Greška broj datoteke."
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "Init greška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "HTTP Greška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "Bezbednosna greška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "Generička greška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "IO greška."
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "Fajl: %s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "%d datoteka na čekanju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "Datoteka: %f, veličina: %s, maks veličina datoteke: %m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "Prenosni URL može da bude u krivu ili ne postoji"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "Greška: Datoteka je prevelika:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "Greška: Nevažeći oznak tipa datoteka:"
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "Postavi Podrazumevano"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "Stvaranje Unosa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "Uredi Istorijat Upisa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Nema Programa"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "%s red%s je kopiran u međumemoriju"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%sIspis pogled%sMolimo, koristi pregledača štampanje funkciju za štampanje ovu tabelu. Kad završiš, pritisni Escape."
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "E-mail nije mogao da bude poslat. Proveri svoje postavke servera pošte i proveri se da je ispravno podešen."
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "Pogrešno korisničko ime ili lozinka. Molimo pokušaj ponovo."
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -370,11 +2405,6 @@ msgstr "Nemaš dopuštenje za brisanje odabranog (e) %s."
 msgid "You can only add tracks to smart block."
 msgstr "Možeš samo pesme da dodaš za pametnog bloka."
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "Možeš samo da dodaš pesme, pametne blokova, i prenose kod liste numera."
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "Neimenovani Spisak Pesama"
@@ -383,2627 +2413,88 @@ msgstr "Neimenovani Spisak Pesama"
 msgid "Untitled Smart Block"
 msgstr "Neimenovani Smart Block"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "Nepoznati Spisak Pesama"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "Ne smeš da pristupiš ovog izvora."
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "Podešavanja su ažurirane."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "Podrška podešavanja je ažurirana."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "Povratne Informacije"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "Prenos Podešavanje je Ažurirano."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "put bi trebao da bude specificiran"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Problem sa Liquidsoap..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "Nemaš dopuštenje da isključiš izvor."
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "Nema spojenog izvora na ovaj ulaz."
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "Nemaš dozvolu za promenu izvora."
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "Pogrešno korisničko ime ili lozinka. Molimo pokušaj ponovo."
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "E-mail nije mogao da bude poslat. Proveri svoje postavke servera pošte i proveri se da je ispravno podešen."
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "Ne smeš da pristupite ovog izvora."
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "Neispravan zahtev."
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "Neispravan zahtev"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Uređaj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "Snimanje:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "Majstorski Prenos"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Prenos Uživo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "Ništa po rasporedu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "Sadašnja Emisija:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "Trenutna"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "Ti imaš instaliranu najnoviju verziju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "Nova verzija je dostupna:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "Ova verzija uskoro će da bude zastareo."
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "Ova verzija više nije podržana."
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "Molimo nadogradi na"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "Dodaj u trenutni spisak pesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "Dodaj u trenutni smart block"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "Dodavanje 1 Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "Dodavanje %s Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "Možeš da dodaš samo pesme kod pametnih blokova."
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "Molimo odaberi mesto pokazivača na vremenskoj crti."
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "Dodaj u odabranoj emisiji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "Odaberi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "Odaberi ovu stranicu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "Odznači ovu stranicu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "Odznači sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "Jesi li siguran da želiš da izbrišeš odabranu (e) stavu (e)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "Zakazana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "Prenos Bita"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Kodirano je po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Poslednja Izmena"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Zadnji Put Odigrana"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Vlasnik"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "Uzorak Stopa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Broj Pesma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Dodata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Veb stranica"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Učitavanje..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "Datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "Liste pesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "Smart Block-ovi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "Prenosi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "Nepoznati tip:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "Jesi li siguran da želiš da obrišeš izabranu stavku?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "Prenos je u toku..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "Preuzimanje podataka sa servera..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "SoundCloud id za ovu datoteku je:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "Došlo je do greške prilikom prenosa na soundcloud."
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "Šifra greške:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "Poruka o grešci:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "Mora da bude pozitivan broj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "Mora da bude broj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "Mora da bude u obliku: gggg-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "Mora da bude u obliku: hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "Trenutno je prenos datoteke. %sOdlazak na drugom ekranu će da otkaže proces slanja. %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "Otvori Medijskog Graditelja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "molimo stavi u vreme '00:00:00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "molimo stavi u vreme u sekundama '00 (.0)'"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "Tvoj pretraživač ne podržava ovu vrstu audio fajl:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "Dinamički blok nije dostupan za pregled"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "Ograničiti se na:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "Spisak pesama je spremljena"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "Spisak pesama je izmešan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "Airtime je nesiguran o statusu ove datoteke. To takođe može da se desi kada je datoteka na udaljenom disku ili je datoteka u nekoj direktorijumi, koja se više nije 'praćena odnosno nadzirana'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "Broj Slušalaca %s: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "Podseti me za 1 nedelju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "Nikad me više ne podseti"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "Da, pomažem Airtime-u"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "Slika mora da bude jpg, jpeg, png, ili gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "Statički pametni blokovi spremaju kriterijume i odmah generišu blok sadržaja. To ti omogućava da urediš i vidiš ga u biblioteci pre nego što ga dodaš na emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "Dinamički pametni blokovi samo kriterijume spremaju. Blok sadržaja će se generiše nakon što ga dodamo na emisiju. Nećeš moći da pregledaš i uređivaš sadržaj u biblioteci."
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "Željena dužina bloka neće da bude postignut jer Airtime ne mogu da pronađe dovoljno jedinstvene pesme koje odgovaraju tvojim kriterijumima. Omogući ovu opciju ako želiš da dopustiš da neke pesme mogu da se više puta ponavljaju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "Smart block je izmešan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "Smart block je generisan i kriterijume su spremne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "Smart block je sačuvan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "Obrada..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Odaberi modifikator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "sadrži"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "ne sadrži"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "je"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "nije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "počinje se sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "završava se sa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "je veći od"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "je manji od"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "je u opsegu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "Odaberi Mapu za Skladištenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "Odaberi Mapu za Praćenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "Jesi li siguran da želiš da promeniš mapu za skladištenje?\nTo će da ukloni datoteke iz tvoje biblioteke!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "Upravljanje Medijske Mape"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "Jesi li siguran da želiš da ukloniš nadzorsku mapu?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "Ovaj put nije trenutno dostupan."
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "Neke vrste emitovanje zahtevaju dodatnu konfiguraciju. Detalji oko omogućavanja %sAAC+ Podrške%s ili %sOpus Podrške%s su ovde dostupni."
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "Priključen je na serveru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "Prenos je onemogućen"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Dobijanje informacija sa servera..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "Ne može da se poveže na serveru"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "Ako je iza Airtime-a ruter ili zaštitni zid, možda moraš da konfigurišeš polje porta prosleđivanje i ovo informaciono polje će da bude netačan. U tom slučaju moraćeš ručno da ažuriraš ovo polje, da bi pokazao tačnohost/port/mount da se mogu da poveže tvoji disk-džokeji. Dopušteni opseg je između 1024 i 49151."
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "Za više detalja, pročitaj %sUputstvu za upotrebu%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "Proveri ovu opciju kako bi se omogućilo metapodataka za OGG potoke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "Proveri ovu kućicu za automatsko isključenje Majstor/Emisija izvora, nakon prestanka rada izvora."
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "Proveri ovu kućicu za automatsko prebacivanje na Majstor/Emisija izvora, nakon što je spojen izvor."
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "Ako tvoj Icecast server očekuje korisničko ime iz 'izvora', ovo polje može da ostane prazno."
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "Ako tvoj 'live streaming' klijent ne pita za korisničko ime, ovo polje trebalo da bude 'izvor'."
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "Ovo je admin korisničko ime i lozinka za Icecast/SHOUTcast da bi dobio slušateljsku statistiku."
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr "Upozorenje: Ne možeš promeniti sadržaj polja, dok se sadašnja emisija ne završava"
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "Nema pronađenih rezultata"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "To sledi isti obrazac bezbednosti za emisije: samo dodeljeni korisnici mogu da se poveže na emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "Odredi prilagođene autentifikacije koje će da se uvaži samo za ovu emisiju."
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "Emisija u ovom slučaju više ne postoji!"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "Upozorenje: Emisije ne može ponovo da se poveže"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "Povezivanjem svoje ponavljajuće emisije svaka zakazana medijska stava u svakoj ponavljajućim emisijama dobiće isti raspored takođe i u drugim ponavljajućim emisijama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "Vremenska zona je postavljena po staničnu zonu prema zadatim. Emisije u kalendaru će se da prikaže po tvojim lokalnom vremenu koja je definisana u interfejsa vremenske zone u tvojim korisničkim postavci."
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "Emisija"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "Emisija je prazna"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "Dobijanje podataka sa servera..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "Ova emisija nema zakazanog sadržaja."
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "Ova emisija nije u potpunosti ispunjena sa sadržajem."
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "Januar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "Februar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "Mart"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "April"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "Maj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "Avgust"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "Septembar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "Oktobar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "Novembar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "Decembar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "Jan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "Feb"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "Mar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "Apr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "Jun"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "Jul"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "Avg"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "Sep"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "Okt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "Nov"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "Dec"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Nedelja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Ponedeljak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Utorak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Sreda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Četvrtak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Petak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Subota"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Ned"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Pon"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Uto"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Sre"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Čet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Pet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Sub"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "Emisija duže od predviđenog vremena će da bude odsečen."
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "Otkaži Trenutnog Programa?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "Zaustavljanje snimanje emisije?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "Ok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "Sadržaj Emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "Ukloniš sve sadržaje?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "Obrišeš li odabranu (e) stavu (e)?"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "Početak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "Završetak"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "Trajanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Odtamnjenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Zatamnjenje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "Prazna Emisija"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "Snimanje sa Line In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "Pregled pesma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "Ne može da se zakazuje van emisije."
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "Premeštanje 1 Stavka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "Premeštanje %s Stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Sačuvaj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "Odustani"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "Uređivač za (Od-/Za-)tamnjivanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "Cue Uređivač"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "Talasni oblik funkcije su dostupne u sporednu Web Audio API pregledaču"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "Odaberi sve"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "Ne odaberi ništa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "Ukloni odabrane zakazane stavke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "Skoči na trenutnu sviranu pesmu"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "Poništi trenutnu emisiju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "Otvori biblioteku za dodavanje ili uklanjanje sadržaja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "Dodaj / Ukloni Sadržaj"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "u upotrebi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "Disk"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "Pogledaj unutra"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "Otvori"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Administrator"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "Disk-džokej"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Voditelj Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Gost"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "Gosti mogu da uradi sledeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "Pregled rasporeda"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "Pregled sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "Disk-džokeji mogu da uradi sledeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "Upravljanje dodeljen sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "Uvoz medijske fajlove"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "Izradi liste pesama, pametne blokove, i prenose"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "Upravljanje svoje bibliotečkog sadržaja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "Menadžer programa mogu da uradi sledeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "Prikaz i upravljanje sadržaj emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "Rasporedne emisije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "Upravljanje sve sadržaje biblioteka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "Administratori mogu da uradi sledeće:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "Upravljanje podešavanja"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "Upravljanje korisnike"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "Upravljanje nadziranih datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Pošalji povratne informacije"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "Pregled stanja sistema"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "Pristup za istoriju puštenih pesama"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "Pogledaj statistiku slušaoce"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "Pokaži/sakrij kolone"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "Od {from} do {to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "kbps"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "gggg-mm-dd"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "hh:mm:ss.t"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "kHz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "Ne"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "Po"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "Ut"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "Sr"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "Če"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "Pe"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "Su"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Zatvori"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Sat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "Minuta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "Gotovo"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "Izaberi datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "Dodaj datoteke i klikni na 'Pokreni Upload' dugme."
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "Stanje"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "Dodaj Datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "Zaustavi Upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "Pokreni upload"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "Dodaj datoteke"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "Poslata %d/%d datoteka"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "N/A"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "Povuci datoteke ovde."
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "Greška (oznaku tipa datoteke)."
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "Greška veličine datoteke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "Greška broj datoteke."
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "Init greška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "HTTP Greška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "Bezbednosna greška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "Generička greška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "IO greška."
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "Fajl: %s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "%d datoteka na čekanju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "Datoteka: %f, veličina: %s, maks veličina datoteke: %m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "Prenosni URL može da bude u krivu ili ne postoji"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "Greška: Datoteka je prevelika:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "Greška: Nevažeći oznak tipa datoteka:"
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "Postavi Podrazumevano"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "Stvaranje Unosa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "Uredi Istorijat Upisa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Nema Programa"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "%s red%s je kopiran u međumemoriju"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%sIspis pogled%sMolimo, koristi pregledača štampanje funkciju za štampanje ovu tabelu. Kad završiš, pritisni Escape."
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "Odaberi pokazivač"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "Ukloni pokazivač"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "emisija ne postoji"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "Reemitovanje emisija %s od %s na %s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "Odaberi pokazivač"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "Ukloni pokazivač"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "emisija ne postoji"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "Korisnik je uspešno dodat!"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "Korisnik je uspešno ažuriran!"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "Podešavanja su uspešno ažurirane!"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "Neimenovani Prenos"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "Prenos je sačuvan."
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "Nevažeći vrednosti obrasca."
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "Godina %s mora da bude u rasponu između 1753 - 9999"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s nije ispravan datum"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s nije ispravan datum"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Prenos uživo"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Pokreni"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Stani"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Podesi Cue In"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Podesi Cue Out"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Pokazivač"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Podeli"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "Prenosi:"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "mute"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "uključi"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "O projektu"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "Za detaljnu pomoć, pročitaj %suputstvo za korišćenje%s."
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "Istorija Puštenih Pesama"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "Spisak Prijava"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "Datotečni Izveštaj"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "Programski Izveštaj"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "Proširenje Statičkog Bloka"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "Proširenje Dinamičkog Bloka"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "Naziv:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Opis:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Trajanje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "Slučajni izbor spisak pesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Mešanje"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "Križno utišavanje spisak pesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "Prazan sadržaj spisak pesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "Očisti"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "Odtamnjenje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "Zatamnjenje:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "Sačuvaj spisak pesama"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "Nema otvorenih spisak pesama"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "Emisijski zvučni talasni oblik"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "(ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "Cue In: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "(hh:mm:ss.t)"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "Cue Out: "
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "Originalna Dužina:"
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "Prenosna Podešavanja"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "dB"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Prijava"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "Nova lozinka"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "Unesi i potvrdi svoju novu lozinku u polja dole."
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "Upravljanje Korisnike"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "Novi Korisnik"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "id"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Korisničko ime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "Ime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Prezime"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "Vrsta Korisnika"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "Pronađi Emisije"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "Odaberi Emisijsku Stepenu"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "Pronađi"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "Ponovljeni Dani:"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Ukloni"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Dodaj"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "Emisijski Izvor"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "Airtime Registar"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "(Obavezno)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "(služi samo za proveru, neće da bude objavljena)"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "Napomena: Sve veća od 600k600 će da se menjaju."
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "Pokaži mi šta šaljem"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "Uslovi i Odredbe"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "Odaberi Dane:"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "ili"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "i"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "do"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "datoteke zadovoljavaju kriterijume"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "Filtriraj Istorije"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "(Kako bi se promovisao svoju stanicu, 'Pošalji povratne informacije' mora da bude omogućena)."
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "Prenos"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "Dodatne Opcije"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "Sledeće informacije će da bude prikazane slušaocima u medijskom plejerima:"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "(Tvoja radijska stanica veb stranice)"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "URL Prenosa:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "Odaberi folder"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "Podesi"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "Aktualna Uvozna Mapa:"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "Ukloni nadzoranu direktorijumu"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "Ne pratiš nijedne medijske mape."
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "Majstorski Izvor"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud Podešavanje"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "Dodaj ovu emisiju"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "Ažuriranje emisije"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "Šta"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "Kada"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "Ulaz Uživnog Prenosa"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "Ko"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stil"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "Diskovni Prostor"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "Uvoz datoteke je u toku..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "Napredne Opcije Pretraživanja"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Naziv:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Tvorac:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Album:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Pesma:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "Dužina:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "Uzorak Stopa:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Brzina u Bitovima:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Raspoloženje:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Žanr:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Godina:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Nalepnica:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Kompozitor:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Dirigent:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Autorsko pravo:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "Isrc Broj:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Veb stranica:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Jezik:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "Staža Datoteka:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "Prenos"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "Dinamički Pametan Blok"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "Statički Pametan Blok"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "Zvučni Zapis"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "Sadržaji Spisak Pesama:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "Statički Pametan Blok Sadržaji:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "Dinamički Pametan Blok Kriterijumi:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "Ograničeno za"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL:"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "Vaš nalog ističe u"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "dani"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "Prethodna:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "Sledeća:"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "Prenosni Izvori"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "PRENOS"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "Slušaj"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Odjava"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "Šabloni Spisak Prijave"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "Novi Listu šablona"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "Nema Listu Šablona"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "Šabloni za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "Novi Šablon za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "Nema Šablona za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "Stvaranje Šablona za Datotečni Sažeci"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "Stvaranje Listu Šablona"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "Naziv"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "Dodaj više elemenata"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "Dodaj Novo Polje"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "Podesi Podrazumevano Šablonu"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Opis"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "URL Prenosa:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "Zadata Dužina:"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "Nema prenosa"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "Pomoć"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "Stranica nije pronađena!"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "Izgleda stranica koju si tražio ne postoji!"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "prethodna"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "pokreni"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "pauza"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "sledeća"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "zaustavi"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "maks glasnoća"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "Potrebno Ažuriranje"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "Medija je potrebna za reprodukciju, i moraš da ažuriraš svoj pretraživač na noviju verziju, ili da ažuriraš svoj %sFlash plugin%s."
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Datum Početka:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2504,6 @@ msgstr "Datum Početka:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Uneseni su nevažeći znakovi"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Datum Završetka:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Sve Moje Emisije:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Traži Korisnike:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "Disk-džokeji:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Naziv Stanice"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "E-mail:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Veb Stranica:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Država:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Grad:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Opis:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Logo:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Moraš da pristaneš na pravila o privatnosti."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Snimanje sa Line In?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Ponovo da emituje?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Vrednost je potrebna i ne može da bude prazan"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' nije valjana e-mail adresa u osnovnom obliku local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' ne odgovara po obliku datuma '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' je manji od %min% dugačko znakova"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' je više od %max% dugačko znakova"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' nije između '%min%' i '%max%', uključivo"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Lozinke se ne podudaraju"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2520,55 @@ msgstr "Vreme mora da bude navedeno"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Moraš da čekaš najmanje 1 sat za re-emitovanje"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Resetuj lozinku"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "Neimenovana Emisija"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC Broj:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Podrazumevano Trajanje Ukršteno Stišavanje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Podrazumevano Odtamnjenje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Podrazumevano Zatamnjenje (s):"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Onemogućeno"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Omogućeno"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Stanična Vremenska Zona"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Prvi Dan u Nedelji"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Korisničko ime:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Lozinka:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Potvrdi Lozinku:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "Ime:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Prezime:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Mobilni Telefon:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Tipova Korisnika:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Ime prijave nije jedinstveno."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "Uvozna Mapa:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "Mape Pod Nadzorom:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Ne važeći Direktorijum"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Zadata Dozvola:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Sva prava zadržana"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Rad je u javnom domenu"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "Creative Commons Imenovanje"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "Creative Commons Imenovanje Nekomercijalno"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "Creative Commons Imenovanje Bez Izvedenih Dela"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "Creative Commons Deli Pod Istim Uslovima"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "Creative Commons Imenovanje Nekomercijalno Bez Izvedenih Dela"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "Creative Commons Imenovanje Nekomercijalno Dijeli Pod Istim Uslovima"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Vremenska Zona Interfejsi:"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "Trenutno Izvođena"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Odaberi kriterijume"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Brzina u Bitovima (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Uzorak Stopa (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "sati"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "minuti"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "elementi"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Statički"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinamički"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Generisanje liste pesama i čuvanje sadržaja kriterijume"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Generiši"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Sadržaj slučajni izbor spisak pesama"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Ograničenje ne može da bude prazan ili manji od 0"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Ograničenje ne može da bude više od 24 sati"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Vrednost mora da bude ceo broj"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "500 je maks stavu graničnu vrednost moguće je da podesiš"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Moraš da izabereš Kriteriju i Modifikaciju"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "'Dužina' trebala da bude u '00:00:00' obliku"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Vrednost mora da bude u obliku vremenske oznake (npr. 0000-00-00 ili 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Vrednost mora da bude numerička"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Vrednost bi trebala da bude manja od 2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Vrednost mora da bude manja od %s znakova"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Vrednost ne može da bude prazna"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metapodaci"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Vidljivi Podaci:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Autor - Naziv"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Emisija - Autor - Naziv"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Naziv stanice - Naziv emisije"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Off Air Metapodaci"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "Uključi Replay Gain"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "Replay Gain Modifikator"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Lozinka"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Potvrdi novu lozinku"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Lozinke koje ste uneli ne podudaraju se."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Omogućeno:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Prenos Tipa:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Tip Usluge:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanali:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Server"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Dopušteni su samo brojevi."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Tačka Montiranja"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Admin Korisnik"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Adminska Lozinka"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Server ne može da bude prazan."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port ne može da bude prazan."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Montiranje ne može da bude prazna sa Icecast serverom."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' se ne uklapa u vremenskom formatu 'HH:mm'"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Vremenska Zona:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Ponavljanje?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Ne može da se stvori emisiju u prošlosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Ne možeš da menjaš datum/vreme početak emisije, ako je već počela"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Datum završetka i vreme ne može da bude u prošlosti"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Ne može da traje < 0m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "Ne može da traje 00h 00m"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Ne može da traje više od 24h"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Koristi Prilagođeno potvrdu identiteta:"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Prilagođeno Korisničko Ime"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Prilagođena Lozinka"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "'Korisničko Ime' polja ne sme da ostane prazno."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "'Lozinka' polja ne sme da ostane prazno."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Boja Pozadine:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Boja Teksta:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Upiši znake koje vidiš na slici u nastavku."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "dani"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2614,12 @@ msgstr "dan u mesecu"
 msgid "day of the week"
 msgstr "dan u nedelji"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Datum Završetka:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Nema Kraja?"
@@ -3876,115 +2632,1174 @@ msgstr "Datum završetka mora da bude posle datuma početka"
 msgid "Please select a repeat day"
 msgstr "Molimo, odaberi kojeg dana"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Snimanje sa Line In?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Ponovo da emituje?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Boja Pozadine:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Boja Teksta:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "Kalendar"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Ukloni"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "Korisnici"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "Naziv:"
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "Prenosi"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "Neimenovana Emisija"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Žanr:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Opis:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "Slušateljska Statistika"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' se ne uklapa u vremenskom formatu 'HH:mm'"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "Istorijski Šabloni"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Trajanje:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Vremenska Zona:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Ponavljanje?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Ne može da se stvori emisiju u prošlosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Ne možeš da menjaš datum/vreme početak emisije, ako je već počela"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Datum završetka i vreme ne može da bude u prošlosti"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Ne može da traje < 0m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "Ne može da traje 00h 00m"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Ne može da traje više od 24h"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Ne možeš zakazati preklapajuće emisije"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Traži Korisnike:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "Disk-džokeji:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Korisničko ime:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Lozinka:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Potvrdi Lozinku:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "Ime:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Prezime:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "E-mail:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Mobilni Telefon:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Tipova Korisnika:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Ime prijave nije jedinstveno."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "Početak Korišćenja"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "Uputstvo"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Vrednost je potrebna i ne može da bude prazan"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Datum Početka:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Naziv:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Tvorac:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Album:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Godina:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Nalepnica:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Kompozitor:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Dirigent:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Raspoloženje:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Autorsko pravo:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC Broj:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Veb stranica:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Jezik:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Vreme Početka"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Vreme Završetka"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Vremenska Zona Interfejsi:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Naziv Stanice"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Logo:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "Napomena: Sve veća od 600k600 će da se menjaju."
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Podrazumevano Trajanje Ukršteno Stišavanje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Podrazumevano Odtamnjenje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Podrazumevano Zatamnjenje (s):"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Onemogućeno"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Omogućeno"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Stanična Vremenska Zona"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Prvi Dan u Nedelji"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' nije valjana e-mail adresa u osnovnom obliku local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' ne odgovara po obliku datuma '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' je manji od %min% dugačko znakova"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' je više od %max% dugačko znakova"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' nije između '%min%' i '%max%', uključivo"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Lozinke se ne podudaraju"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Dopušteni su samo brojevi."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Prijava"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Upiši znake koje vidiš na slici u nastavku."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Lozinka"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Potvrdi novu lozinku"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Lozinke koje ste uneli ne podudaraju se."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Korisničko ime"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Resetuj lozinku"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "Trenutno Izvođena"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Veb Stranica:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Država:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Grad:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Opis:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Moraš da pristaneš na pravila o privatnosti."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Sve Moje Emisije:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Odaberi kriterijume"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Brzina u Bitovima (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Opis"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Uzorak Stopa (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "sati"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "minuti"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "elementi"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Statički"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinamički"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Generisanje liste pesama i čuvanje sadržaja kriterijume"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Generiši"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Sadržaj slučajni izbor spisak pesama"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Mešanje"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Ograničenje ne može da bude prazan ili manji od 0"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Ograničenje ne može da bude više od 24 sati"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Vrednost mora da bude ceo broj"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "500 je maks stavu graničnu vrednost moguće je da podesiš"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Moraš da izabereš Kriteriju i Modifikaciju"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "'Dužina' trebala da bude u '00:00:00' obliku"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Vrednost mora da bude u obliku vremenske oznake (npr. 0000-00-00 ili 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Vrednost mora da bude numerička"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Vrednost bi trebala da bude manja od 2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Vrednost mora da bude manja od %s znakova"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Vrednost ne može da bude prazna"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Zadata Dozvola:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Sva prava zadržana"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Rad je u javnom domenu"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "Creative Commons Imenovanje"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "Creative Commons Imenovanje Nekomercijalno"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "Creative Commons Imenovanje Bez Izvedenih Dela"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "Creative Commons Deli Pod Istim Uslovima"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "Creative Commons Imenovanje Nekomercijalno Bez Izvedenih Dela"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "Creative Commons Imenovanje Nekomercijalno Dijeli Pod Istim Uslovima"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metapodaci"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Vidljivi Podaci:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Autor - Naziv"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Emisija - Autor - Naziv"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Naziv stanice - Naziv emisije"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Off Air Metapodaci"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "Uključi Replay Gain"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "Replay Gain Modifikator"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Omogućeno:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Prenos Tipa:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Brzina u Bitovima:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Tip Usluge:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanali:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Server"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "Naziv"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Tačka Montiranja"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Admin Korisnik"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Adminska Lozinka"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Server ne može da bude prazan."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port ne može da bude prazan."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Montiranje ne može da bude prazna sa Icecast serverom."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "Uvozna Mapa:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "Mape Pod Nadzorom:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Ne važeći Direktorijum"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Pokreni"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Stani"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Podesi Cue In"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Podesi Cue Out"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Pokazivač"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Prenos uživo"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "'Cue in' i 'cue out' su nule."
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "Ne možeš da podesiš da 'cue out' bude veće od dužine fajla."
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "Ne možeš da podesiš da 'cue in' bude veće nego 'cue out'."
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "Ne možeš da podesiš da 'cue out' bude manje nego 'cue in'."
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "Reemitovanje od %s od %s"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "Odaberi Državu"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4009,14 +3824,12 @@ msgstr "%s nije valjan direktorijum."
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s je već postavljena kao mapa za skladištenje ili je između popisa praćenih foldera"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s je već postavljena kao mapa za skladištenje ili je između popisa praćenih foldera."
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,28 +3837,18 @@ msgstr "%s je već postavljena kao mapa za skladištenje ili je između popisa p
 msgid "%s doesn't exist in the watched list."
 msgstr "%s ne postoji u listi nadziranih lokacije."
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "Odaberi Državu"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "Emisije mogu da imaju najveću dužinu 24 sata."
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "Ne može da se zakaže preklapajuće emisije.\nNapomena: Promena veličine ponavljane emisije utiče na sve njene ponavljanje."
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4060,48 +3863,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "Zastareo se pregledan raspored! (primer neusklađenost)"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "Zastareo se pregledan raspored!"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "Ne smeš da zakažeš rasporednu emisiju %s."
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "Ne možeš da dodaš datoteke za snimljene emisije."
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "Emisija %s je gotova i ne mogu da bude zakazana."
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "Ranije je %s emisija već bila ažurirana!"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "Sadržaj u povezanim emisijama mora da bude zakazan pre ili posle bilo koje emisije"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "Izabrani Fajl ne postoji!"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "Emisije mogu da imaju najveću dužinu 24 sata."
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"Ne može da se zakaže preklapajuće emisije.\n"
+"Napomena: Promena veličine ponavljane emisije utiče na sve njene ponavljanje."
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "Reemitovanje od %s od %s"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4148,8 +3963,1049 @@ msgstr "Nevažeći prenos - Čini se da je ovo preuzimanje."
 msgid "Unrecognized stream type: %s"
 msgstr "Nepoznati prenosni tip: %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "Snimljena datoteka ne postoji"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "Metapodaci snimljenog fajla"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Uređivanje"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "Uređivanje Programa"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "Dozvola odbijena"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "Ne možeš povući i ispustiti ponavljajuće emisije"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "Ne možeš premestiti događane emisije"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "Ne možeš premestiti emisiju u prošlosti"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "Ne možeš premestiti snimljene emisije ranije od 1 sat vremena pre njenih reemitovanja."
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "Emisija je izbrisana jer je snimljena emisija ne postoji!"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "Moraš pričekati 1 sat za re-emitovanje."
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "Pesma"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "Puštena"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "prethodna"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "pokreni"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "pauza"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "sledeća"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "zaustavi"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "mute"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "uključi"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "maks glasnoća"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "Potrebno Ažuriranje"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "Medija je potrebna za reprodukciju, i moraš da ažuriraš svoj pretraživač na noviju verziju, ili da ažuriraš svoj %sFlash plugin%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "O projektu"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "Za detaljnu pomoć, pročitaj %suputstvo za korišćenje%s."
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Podeli"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "Prenosi:"
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "Stranica nije pronađena!"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "Izgleda stranica koju si tražio ne postoji!"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "Emisijski Izvor"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "Odaberi Dane:"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Dodaj"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "Ponovljeni Dani:"
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "Filtriraj Istorije"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "Odaberi Emisijsku Stepenu"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "Pronađi"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud Podešavanje"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "Majstorski Izvor"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "Odaberi folder"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "Podesi"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "Aktualna Uvozna Mapa:"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "Ukloni nadzoranu direktorijumu"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "Ne pratiš nijedne medijske mape."
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "Airtime Registar"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "(Obavezno)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "(služi samo za proveru, neće da bude objavljena)"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "Pokaži mi šta šaljem"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "Uslovi i Odredbe"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "Pronađi Emisije"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "ili"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "i"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "do"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "datoteke zadovoljavaju kriterijume"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "Prenos"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "Dodatne Opcije"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "Sledeće informacije će da bude prikazane slušaocima u medijskom plejerima:"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "(Tvoja radijska stanica veb stranice)"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "URL Prenosa:"
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "(Kako bi se promovisao svoju stanicu, 'Pošalji povratne informacije' mora da bude omogućena)."
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Pesma:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "Dužina:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "Uzorak Stopa:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "Isrc Broj:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "Staža Datoteka:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "Prenos"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "Dinamički Pametan Blok"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "Statički Pametan Blok"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "Zvučni Zapis"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "Sadržaji Spisak Pesama:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "Statički Pametan Blok Sadržaji:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "Dinamički Pametan Blok Kriterijumi:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "Ograničeno za"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "Uvoz datoteke je u toku..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "Napredne Opcije Pretraživanja"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "Nova lozinka"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "Unesi i potvrdi svoju novu lozinku u polja dole."
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "Prethodna:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "Sledeća:"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "Prenosni Izvori"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "PRENOS"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "Slušaj"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Odjava"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "Vaš nalog ističe u"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "Slučajni izbor spisak pesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "Križno utišavanje spisak pesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "Prazan sadržaj spisak pesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "Očisti"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "Zatamnjenje:"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "Sačuvaj spisak pesama"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "Nema otvorenih spisak pesama"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "Emisijski zvučni talasni oblik"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "Cue In: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "(hh:mm:ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "Cue Out: "
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "Originalna Dužina:"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "(ss.t)"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "Odtamnjenje:"
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "Proširenje Statičkog Bloka"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "Proširenje Dinamičkog Bloka"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "Spisak Prijava"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "Datotečni Izveštaj"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "Programski Izveštaj"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "Šabloni Spisak Prijave"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "Novi Listu šablona"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "Nema Listu Šablona"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "Šabloni za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "Novi Šablon za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "Nema Šablona za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "Stvaranje Šablona za Datotečni Sažeci"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "Stvaranje Listu Šablona"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "Dodaj više elemenata"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "Dodaj Novo Polje"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "Podesi Podrazumevano Šablonu"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "Prenosna Podešavanja"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "dB"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "Dodaj ovu emisiju"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "Ažuriranje emisije"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "Šta"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "Kada"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "Ulaz Uživnog Prenosa"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "Ko"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stil"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "Diskovni Prostor"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "Upravljanje Korisnike"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "Novi Korisnik"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "id"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "Ime"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Prezime"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "Vrsta Korisnika"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "URL Prenosa:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "Zadata Dužina:"
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "Nema prenosa"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "molimo stavi u vreme u sekundama '00 (.0)'"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "Sadržaj u povezanim emisijama mora da bude zakazan pre ili posle bilo koje emisije"

--- a/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/sr_RS@latin/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/template/airtime.po
+++ b/airtime_mvc/locale/template/airtime.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime 2.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,3947 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr ""
+
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
+#: airtime_mvc/application/controllers/PlaylistController.php:147
+#, php-format
+msgid "%s not found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:37
+#: airtime_mvc/application/controllers/PlaylistController.php:168
+msgid "Something went wrong."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
+msgid "Preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
+msgid "Add to Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:114
+msgid "Add to Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
+msgid "Download"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:147
+msgid "View track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:148
+msgid "Update track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:155
+msgid "Duplicate Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:199
+msgid "No action available"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:219
+msgid "You don't have permission to delete selected items."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:265
+msgid "Could not delete file because it is scheduled in the future."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:268
+msgid "Could not delete file(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:308
+#, php-format
+msgid "Copy of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:53
+#, php-format
+msgid "You are viewing an older version of %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:140
+msgid "You cannot add tracks to dynamic blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:161
+#, php-format
+msgid "You don't have permission to delete selected %s(s)."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:174
+msgid "You can only add tracks to smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:192
+msgid "Untitled Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:194
+msgid "Untitled Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PlaylistController.php:521
+msgid "Unknown Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:76
+msgid "Preferences updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:141
+msgid "Support setting updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:149
+msgid "Support Feedback"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:351
+msgid "Stream Setting Updated."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:399
+msgid "path should be specified"
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:494
+msgid "Problem with Liquidsoap..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/PreferenceController.php:556
+msgid "Request method not accepted"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ScheduleController.php:380
+#, php-format
+msgid "Rebroadcast of show %s from %s at %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr ""
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
+msgid "Invalid character entered"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
+msgid "Day must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
+msgid "Time must be specified"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
+msgid "Must wait at least 1 hour to rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
+#, php-format
+msgid "Use %s Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
+msgid "Use Custom Authentication:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
+msgid "Custom Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
+msgid "Custom Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
+msgid "Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
+msgid "Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
+msgid "Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
+msgid "Username field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
+msgid "Password field cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:10
+msgid "Link:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:16
+msgid "Repeat Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:19
+msgid "weekly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:20
+msgid "every 2 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:21
+msgid "every 3 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:22
+msgid "every 4 weeks"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:23
+msgid "monthly"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:32
+msgid "Select Days:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:47
+msgid "Repeat By:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the month"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:50
+msgid "day of the week"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:69
+msgid "No End?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:106
+msgid "End date must be after start date"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRepeats.php:113
+msgid "Please select a repeat day"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr ""
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr ""
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
+msgid "Cue in and cue out are null."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
+msgid "Can't set cue out to be greater than file length."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
+msgid "Can't set cue in to be larger than cue out."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
+msgid "Can't set cue out to be smaller than cue in."
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:1372
+msgid "Upload Time"
+msgstr ""
+
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:160
+#, php-format
+msgid "%s is already watched."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:164
+#, php-format
+msgid "%s contains nested watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:168
+#, php-format
+msgid "%s is nested within existing watched directory: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:189
+#: airtime_mvc/application/models/MusicDir.php:370
+#, php-format
+msgid "%s is not a valid directory."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:232
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list"
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:388
+#, php-format
+msgid "%s is already set as the current storage dir or in the watched folders list."
+msgstr ""
+
+#: airtime_mvc/application/models/MusicDir.php:431
+#, php-format
+msgid "%s doesn't exist in the watched list."
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:470
+#, php-format
+msgid "Powered by %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr ""
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:73
+msgid "Cannot move items out of linked shows"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:119
+msgid "The schedule you're viewing is out of date! (sched mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:124
+msgid "The schedule you're viewing is out of date! (instance mismatch)"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:132
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
+msgid "The schedule you're viewing is out of date!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:143
+#, php-format
+msgid "You are not allowed to schedule show %s."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:147
+msgid "You cannot add files to recording shows."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:153
+#, php-format
+msgid "The show %s is over and cannot be scheduled."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:160
+#, php-format
+msgid "The show %s has been previously updated!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:196
+msgid "Cannot schedule a playlist that contains missing files."
+msgstr ""
+
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
+msgid "A selected File does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:166
+msgid "Length needs to be greater than 0 minutes"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:171
+msgid "Length should be of form \"00h 00m\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:184
+msgid "URL should be of form \"http://domain\""
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:187
+msgid "URL should be 512 characters or less"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:193
+msgid "No MIME type found for webstream."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:209
+msgid "Webstream name cannot be empty"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:278
+msgid "Could not parse XSPF playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:298
+msgid "Could not parse PLS playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:318
+msgid "Could not parse M3U playlist"
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:332
+msgid "Invalid webstream - This appears to be a file download."
+msgstr ""
+
+#: airtime_mvc/application/models/Webstream.php:336
+#, php-format
+msgid "Unrecognized stream type: %s"
+msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:50
 msgid "Record file doesn't exist"
@@ -49,24 +3990,12 @@ msgid "Edit Instance"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
 msgid "Edit"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:158
 #: airtime_mvc/application/services/CalendarService.php:172
 msgid "Edit Show"
-msgstr ""
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
 msgstr ""
 
 #: airtime_mvc/application/services/CalendarService.php:194
@@ -93,13 +4022,6 @@ msgstr ""
 msgid "Can't move show into past"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr ""
-
 #: airtime_mvc/application/services/CalendarService.php:322
 msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
 msgstr ""
@@ -112,1848 +4034,55 @@ msgstr ""
 msgid "Must wait 1 hour to rebroadcast."
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr ""
-
 #: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1128
 msgid "Track"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr ""
-
-#: airtime_mvc/application/services/HistoryService.php:1176
+#: airtime_mvc/application/services/HistoryService.php:1174
 msgid "Played"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
-#: airtime_mvc/application/controllers/PlaylistController.php:147
-#, php-format
-msgid "%s not found"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
-#: airtime_mvc/application/controllers/PlaylistController.php:168
-msgid "Something went wrong."
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
-msgid "Preview"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
-msgid "Add to Playlist"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
-msgid "Add to Smart Block"
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
-msgid "Download"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:147
-msgid "View track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
-msgid "Duplicate Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:213
-msgid "No action available"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:233
-msgid "You don't have permission to delete selected items."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:279
-msgid "Could not delete file because it is scheduled in the future."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:282
-msgid "Could not delete file(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:322
-#, php-format
-msgid "Copy of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid "Please make sure admin user/password is correct on System->Streams page."
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:53
-#, php-format
-msgid "You are viewing an older version of %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:140
-msgid "You cannot add tracks to dynamic blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:161
-#, php-format
-msgid "You don't have permission to delete selected %s(s)."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:174
-msgid "You can only add tracks to smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:192
-msgid "Untitled Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:194
-msgid "Untitled Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PlaylistController.php:522
-msgid "Unknown Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
-msgid "Preferences updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:115
-msgid "Support setting updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:123
-msgid "Support Feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:251
-msgid "Stream Setting Updated."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:342
-msgid "path should be specified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:437
-msgid "Problem with Liquidsoap..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:493
-msgid "Request method not accepted"
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid "Check this box to automatically switch on Master/Show source upon source connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid "If your Icecast server expects a username of 'source', this field can be left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid "If your live streaming client does not ask for a username, this field should be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid "Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid "Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid "Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
-#, php-format
-msgid "Rebroadcast of show %s from %s at %s"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
 msgid "mute"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 #: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
 msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
@@ -2014,266 +4143,94 @@ msgstr ""
 msgid "For more detailed help, read the %suser manual%s."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid "Choose some search criteria above and click Generate to create this playlist."
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid "A track list will be generated when you schedule this smart block into a show."
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
@@ -2284,42 +4241,89 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
 #, php-format
 msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
@@ -2339,9 +4343,9 @@ msgid "Click the box below to promote your station on %s."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
 msgid "(Required)"
 msgstr ""
 
@@ -2352,11 +4356,6 @@ msgstr ""
 msgid "(for verification purposes only, will not be published)"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
 msgid "Show me what I am sending "
 msgstr ""
@@ -2365,8 +4364,12 @@ msgstr ""
 msgid "Terms and Conditions"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
@@ -2402,19 +4405,6 @@ msgstr ""
 msgid "file meets the criteria"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
 msgid "Stream "
 msgstr ""
@@ -2435,120 +4425,24 @@ msgstr ""
 msgid "Stream URL: "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid "Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
@@ -2566,66 +4460,8 @@ msgstr ""
 msgid "Sample Rate:"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
 msgid "Isrc Number:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
@@ -2664,13 +4500,54 @@ msgstr ""
 msgid "Limit to "
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
@@ -2681,13 +4558,37 @@ msgstr ""
 msgid "Stream Data Collection Status"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
@@ -2712,6 +4613,123 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
 msgid "Logout"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
@@ -2750,11 +4768,6 @@ msgstr ""
 msgid "Creating Log Sheet Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr ""
-
 #: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
 msgid "Add more elements"
 msgstr ""
@@ -2767,9 +4780,207 @@ msgstr ""
 msgid "Set Default Template"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
@@ -2784,1256 +4995,6 @@ msgstr ""
 msgid "No webstream"
 msgstr ""
 
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:102
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:121
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:136
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:158
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:168
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:177
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:186
-msgid "Invalid character entered"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid "'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr ""
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
-msgid "Day must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:71
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:76
-msgid "Time must be specified"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:94
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:103
-msgid "Must wait at least 1 hour to rebroadcast"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
-msgstr ""
-
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr ""
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr ""
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
-#, php-format
-msgid "Use %s Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
-msgid "Use Custom Authentication:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
-msgid "Custom Username"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
-msgid "Custom Password"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
-msgid "Host:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
-msgid "Port:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
-msgid "Mount:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
-msgid "Username field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
-msgid "Password field cannot be empty."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:10
-msgid "Link:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:16
-msgid "Repeat Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:19
-msgid "weekly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:20
-msgid "every 2 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:21
-msgid "every 3 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:22
-msgid "every 4 weeks"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:23
-msgid "monthly"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:32
-msgid "Select Days:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:47
-msgid "Repeat By:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the month"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:50
-msgid "day of the week"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:69
-msgid "No End?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:106
-msgid "End date must be after start date"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowRepeats.php:113
-msgid "Please select a repeat day"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr ""
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
-msgid "Cue in and cue out are null."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
-msgid "Can't set cue out to be greater than file length."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
-msgid "Can't set cue in to be larger than cue out."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
-msgid "Can't set cue out to be smaller than cue in."
-msgstr ""
-
-#: airtime_mvc/application/models/Block.php:1366
-msgid "Upload Time"
-msgstr ""
-
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:160
-#, php-format
-msgid "%s is already watched."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:164
-#, php-format
-msgid "%s contains nested watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:168
-#, php-format
-msgid "%s is nested within existing watched directory: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:189
-#: airtime_mvc/application/models/MusicDir.php:370
-#, php-format
-msgid "%s is not a valid directory."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:232
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list"
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:388
-#, php-format
-msgid "%s is already set as the current storage dir or in the watched folders list."
-msgstr ""
-
-#: airtime_mvc/application/models/MusicDir.php:431
-#, php-format
-msgid "%s doesn't exist in the watched list."
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:33
-#, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:73
-msgid "Cannot move items out of linked shows"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:119
-msgid "The schedule you're viewing is out of date! (sched mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:124
-msgid "The schedule you're viewing is out of date! (instance mismatch)"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
-msgid "The schedule you're viewing is out of date!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:142
-#, php-format
-msgid "You are not allowed to schedule show %s."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:146
-msgid "You cannot add files to recording shows."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:152
-#, php-format
-msgid "The show %s is over and cannot be scheduled."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:159
-#, php-format
-msgid "The show %s has been previously updated!"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:195
-msgid "Cannot schedule a playlist that contains missing files."
-msgstr ""
-
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
-msgid "A selected File does not exist!"
-msgstr ""
-
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:166
-msgid "Length needs to be greater than 0 minutes"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:171
-msgid "Length should be of form \"00h 00m\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:184
-msgid "URL should be of form \"http://domain\""
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:187
-msgid "URL should be 512 characters or less"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:193
-msgid "No MIME type found for webstream."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:209
-msgid "Webstream name cannot be empty"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:278
-msgid "Could not parse XSPF playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:298
-msgid "Could not parse PLS playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:318
-msgid "Could not parse M3U playlist"
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:332
-msgid "Invalid webstream - This appears to be a file download."
-msgstr ""
-
-#: airtime_mvc/application/models/Webstream.php:336
-#, php-format
-msgid "Unrecognized stream type: %s"
-msgstr ""
-
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
 msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/template/pro.po
+++ b/airtime_mvc/locale/template/pro.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Airtime 2.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,19 +17,136 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -42,130 +159,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""

--- a/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/tr/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # M.  Ömer Gölgeli <az+transifex.com@cokh.net>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/sourcefabric/airtime/language/tr/)\n"
+"Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "Düzenle"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "Sil"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "Üst üste binen show'lar olamaz"
-
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "Parça Adı"
-
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "Oluşturan"
-
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "Albüm"
-
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "Uzunluk"
-
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "Tür"
-
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "Ruh Hali"
-
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "Plak Şirketi"
-
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "Besteleyen"
-
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC"
-
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "Telif Hakkı"
-
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "Yıl"
-
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
 msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "Orkestra Şefi"
-
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "Dil"
-
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "Başlangıç Saati"
-
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "Bitiş Saati"
-
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr ""
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "Ön izleme"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "Sil"
+
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr ""
 
@@ -276,80 +890,1499 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr ""
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr ""
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
+msgid "Please make sure admin user/password is correct on System->Streams page."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "Audio Player"
+
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "Canlı yayın"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "Parça Adı"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "Oluşturan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "Albüm"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "BPM"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "Besteleyen"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "Orkestra Şefi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "Telif Hakkı"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "Encode eden"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "Tür"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "Plak Şirketi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "Dil"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "Son Değiştirilme Zamanı"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "Son Oynatma Zamanı"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "Uzunluk"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "Mime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "Ruh Hali"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "Sahibi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "Replay Gain"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "Parça Numarası"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "Yüklenme Tarihi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "Website'si"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "Yıl"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "Yükleniyor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "Tümü"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "Değişken seçin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "içersin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "içermesin"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "eşittir"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "eşit değildir"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "ile başlayan"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "ile biten"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "büyüktür"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "küçüktür"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "aralıkta"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
 msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
 msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "Sunucudan bilgiler getiriliyor..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "Pazar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "Pazartesi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "Salı"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "Çarşamba"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "Perşembe"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "Cuma"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "Cumartesi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "Paz"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "Pzt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "Sal"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "Çar"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "Per"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "Cum"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "Cmt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "OK"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "Cue In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "Cue Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "Fade In"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "Fade Out"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "Kaydet"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "İptal"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "Yönetici (Admin)"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "DJ"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "Program Yöneticisi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "Ziyaretçi"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "Destek Geribildirimi gönder"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "Kapat"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "Cmt"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "OK"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "Show Yok"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
 msgstr ""
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
@@ -370,11 +2403,6 @@ msgstr ""
 msgid "You can only add tracks to smart block."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr ""
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr ""
@@ -383,2627 +2411,88 @@ msgstr ""
 msgid "Untitled Smart Block"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr ""
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr ""
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr ""
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "Audio Player"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "Canlı yayın"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "BPM"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "Encode eden"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "Son Değiştirilme Zamanı"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "Son Oynatma Zamanı"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "Mime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "Sahibi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "Replay Gain"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "Parça Numarası"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "Yüklenme Tarihi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "Website'si"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "Yükleniyor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "Tümü"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "Değişken seçin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "içersin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "içermesin"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "eşittir"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "eşit değildir"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "ile başlayan"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "ile biten"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "büyüktür"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "küçüktür"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "aralıkta"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "Sunucudan bilgiler getiriliyor..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "Pazar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "Pazartesi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "Salı"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "Çarşamba"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "Perşembe"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "Cuma"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "Cumartesi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "Paz"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "Pzt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "Sal"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "Çar"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "Per"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "Cum"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "Cmt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "OK"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "Cue In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "Cue Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "Fade In"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "Fade Out"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "Kaydet"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "İptal"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "Yönetici (Admin)"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "DJ"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "Program Yöneticisi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "Ziyaretçi"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "Destek Geribildirimi gönder"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "Kapat"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "Cmt"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "OK"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "Show Yok"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
 msgstr ""
 
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "Canlı yayın"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "Oynat"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "Durdur"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "Cue In değerini ayarla"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "Cue Out değerini ayarla"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "Cursor"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "Paylaş"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "İsim:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "Açıklama:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "Uzunluğu:"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "Karıştır"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "Giriş yap"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "Kullanıcı adı"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "İsim"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "Soyisim"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "Kaldır"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "Ekle"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "DJ"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "Stil"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "Parça Adı:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "Oluşturan:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "Albüm:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "Parça Numarası:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "Bit Değeri:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "Ruh Hali:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "Tür:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "Yıl:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "Plak Şirketi:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "BPM:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "Besteleyen:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "Orkestra Şefi:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "Telif Hakkı:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC No:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "Websitesi:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "Dil:"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "URL"
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "gün"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "Oturumu kapat"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "İsim"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "Tanım"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "önceki"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "sonraki"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "Durdur"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "Tarih Başlangıcı:"
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2502,6 @@ msgstr "Tarih Başlangıcı:"
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "Yanlış karakter girdiniz"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "Tarih Bitişi:"
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "Tüm Show'larım:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "Kullanıcıları Ara:"
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "DJ'ler:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "Radyo Adı"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "Telefon:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "Eposta:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "Radyo Web Sitesi:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "Ülke:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "Şehir:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "Radyo Tanımı:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "Radyo Logosu:"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr "Radyomu %s'da tanıt"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr "Bu kutuyu işaretleyerek %s'un %sgizlilik politikası%s'nı onaylıyorum"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "Gizlilik politikasını kabul etmeniz gerekmektedir."
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "Line In'den Kaydet?"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "Tekrar yayınla?"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "Değer gerekli ve boş bırakılamaz"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' kullanici@site.com yapısına uymayan geçersiz bir adres"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' değeri '%format%' zaman formatına uymuyor"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' değeri olması gereken '%min%' karakterden daha az"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' değeri olması gereken '%max%' karakterden daha fazla"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' değeri '%min%' ve '%max%' değerleri arasında değil"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "Girdiğiniz şifreler örtüşmüyor."
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2518,55 @@ msgstr "Zamanı belirtmelisiniz"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "Tekrar yayın yapmak için en az bir saat bekleyiniz"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "Parolayı değiştir"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "İsimsiz Show"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC No:"
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "OK"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "Varsayılan Çarpraz Geçiş Süresi:"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "Varsayılan Fade In geçişi (s)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "Varsayılan Fade Out geçişi (s)"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "Devre dışı"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "Aktif"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "Radyo Saat Dilimi"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "Hafta Başlangıcı"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "Kullanıcı Adı:"
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "Şifre:"
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "Şifre Onayı:"
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "İsim:"
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "Soyisim:"
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "Cep Telefonu:"
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype:"
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber:"
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "Kullanıcı Tipi:"
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "Kullanıcı adı eşsiz değil."
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "İçe Aktarım Klasörü"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "İzlenen Klasörler:"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "Geçerli bir Klasör değil."
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "Varsayılan Lisans Türü:"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "Tüm Hakları Saklıdır"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "Eser halka açık olarak kayıtlı"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "Arayüz Zaman Dilimi"
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "Kriter seçiniz"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "Bit Oranı (Kbps)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "Örnekleme Oranı (kHz)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "saat"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "dakika"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "parça"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "Sabit"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "Dinamik"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "Çalma listesi içeriği oluştur ve kriterleri kaydet"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "Oluştur"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "Çalma listesi içeriğini karıştır"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "Sınırlama boş veya 0'dan küçük olamaz"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "Sınırlama 24 saati geçemez"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "Değer tamsayı olmalıdır"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "Ayarlayabileceğiniz azami parça sınırı 500'dür"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "Kriter ve Değişken seçin"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "Uzunluk  '00:00:00' türünde olmalıdır"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "Değer saat biçiminde girilmelidir  (eör. 0000-00-00 veya 0000-00-00 00:00:00)"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "Değer rakam cinsinden girilmelidir"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "Değer 2147483648'den küçük olmalıdır"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "Değer %s karakter'den az olmalıdır"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "Değer boş bırakılamaz"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast Vorbis Metadata"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "Yayın Etiketi:"
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "Şarkıcı - Parça Adı"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "Show - Şarkıcı - Parça Adı"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "Radyo adı - Show adı"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "Yayın Dışında Gösterilecek Etiket"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "ReplayGain'i aktif et"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "ReplayGain Değeri"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "Şifre"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "Yeni şifreyi onayla"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "Onay şifresiyle şifreniz aynı değil."
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "Etkin:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "Yayın Türü:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "Servis Türü:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "Kanallar:"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - Mono"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - Stereo"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "Sunucu"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "Port"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "Sadece rakam girebilirsiniz."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "URL"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "Bağlama Noktası"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "Yönetici Hesabı"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "Yönetici Şifresi"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "Sunucu değeri boş bırakılamaz."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "Port değeri boş bırakılamaz."
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "Icecast sunucusunu Bağlama noktası değeri boş olarak kullanamazsınız."
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' değeri 'HH:mm' saat formatına uymuyor"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "Zaman Dilimi:"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "Tekrar Ediyor mu?"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "Geçmiş tarihli bir show oluşturamazsınız"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "Başlamış olan bir yayının tarih/saat bilgilerini değiştiremezsiniz"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "Bitiş tarihi geçmişte olamaz"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "Uzunluk < 0dk'dan kısa olamaz"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "00s 00dk Uzunluk olamaz"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "Yayın süresi 24 saati geçemez"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr "%s Kimlik Doğrulamasını Kullan"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "Özel Kimlik Doğrulama Kullan"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "Özel Kullanıcı Adı"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "Özel Şifre"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "Kullanıcı adı kısmı boş bırakılamaz."
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "Şifre kısmı boş bırakılamaz."
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "Arkaplan Rengi"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "Metin Rengi:"
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "Aşağıdaki resimde gördüğünüz karakterleri girin."
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "gün"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2612,12 @@ msgstr "Ayın günü"
 msgid "day of the week"
 msgstr "Haftanın günü"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "Tarih Bitişi:"
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "Sonu yok?"
@@ -3876,114 +2630,1173 @@ msgstr "Bitiş tarihi başlangıç tarihinden sonra olmalı"
 msgid "Please select a repeat day"
 msgstr "Lütfen tekrar edilmesini istediğiniz günleri seçiniz"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "Line In'den Kaydet?"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "Tekrar yayınla?"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "Arkaplan Rengi"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "Metin Rengi:"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "Kaldır"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "İsim:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "İsimsiz Show"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "Tür:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "Açıklama:"
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' değeri 'HH:mm' saat formatına uymuyor"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "Uzunluğu:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "Zaman Dilimi:"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "Tekrar Ediyor mu?"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "Geçmiş tarihli bir show oluşturamazsınız"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "Başlamış olan bir yayının tarih/saat bilgilerini değiştiremezsiniz"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "Bitiş tarihi geçmişte olamaz"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "Uzunluk < 0dk'dan kısa olamaz"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "00s 00dk Uzunluk olamaz"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "Yayın süresi 24 saati geçemez"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "Üst üste binen show'lar olamaz"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "Kullanıcıları Ara:"
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "DJ'ler:"
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "Kullanıcı Adı:"
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "Şifre:"
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "Şifre Onayı:"
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "İsim:"
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "Soyisim:"
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "Eposta:"
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "Cep Telefonu:"
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype:"
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber:"
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "Kullanıcı Tipi:"
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "Kullanıcı adı eşsiz değil."
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "Değer gerekli ve boş bırakılamaz"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "Tarih Başlangıcı:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "Parça Adı:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "Oluşturan:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "Albüm:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "Yıl:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "Plak Şirketi:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "Besteleyen:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "Orkestra Şefi:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "Ruh Hali:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "BPM:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "Telif Hakkı:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC No:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "Websitesi:"
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "Dil:"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "Başlangıç Saati"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "Bitiş Saati"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "Arayüz Zaman Dilimi"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "Radyo Adı"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "Radyo Logosu:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "Varsayılan Çarpraz Geçiş Süresi:"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "Varsayılan Fade In geçişi (s)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "Varsayılan Fade Out geçişi (s)"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "Devre dışı"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "Aktif"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "Radyo Saat Dilimi"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "Hafta Başlangıcı"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' kullanici@site.com yapısına uymayan geçersiz bir adres"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' değeri '%format%' zaman formatına uymuyor"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' değeri olması gereken '%min%' karakterden daha az"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' değeri olması gereken '%max%' karakterden daha fazla"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' değeri '%min%' ve '%max%' değerleri arasında değil"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "Girdiğiniz şifreler örtüşmüyor."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "Sadece rakam girebilirsiniz."
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "Giriş yap"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "Aşağıdaki resimde gördüğünüz karakterleri girin."
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "Şifre"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "Yeni şifreyi onayla"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "Onay şifresiyle şifreniz aynı değil."
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "Kullanıcı adı"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "Parolayı değiştir"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "Telefon:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "Radyo Web Sitesi:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "Ülke:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "Şehir:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "Radyo Tanımı:"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr "Radyomu %s'da tanıt"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr "Bu kutuyu işaretleyerek %s'un %sgizlilik politikası%s'nı onaylıyorum"
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "Gizlilik politikasını kabul etmeniz gerekmektedir."
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "Tüm Show'larım:"
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "Kriter seçiniz"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "Bit Oranı (Kbps)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "Tanım"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "Örnekleme Oranı (kHz)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "saat"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "dakika"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "parça"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "Sabit"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "Dinamik"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "Çalma listesi içeriği oluştur ve kriterleri kaydet"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "Oluştur"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "Çalma listesi içeriğini karıştır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "Karıştır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "Sınırlama boş veya 0'dan küçük olamaz"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "Sınırlama 24 saati geçemez"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "Değer tamsayı olmalıdır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "Ayarlayabileceğiniz azami parça sınırı 500'dür"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "Kriter ve Değişken seçin"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "Uzunluk  '00:00:00' türünde olmalıdır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "Değer saat biçiminde girilmelidir  (eör. 0000-00-00 veya 0000-00-00 00:00:00)"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "Değer rakam cinsinden girilmelidir"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "Değer 2147483648'den küçük olmalıdır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "Değer %s karakter'den az olmalıdır"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "Değer boş bırakılamaz"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "Varsayılan Lisans Türü:"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "Tüm Hakları Saklıdır"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "Eser halka açık olarak kayıtlı"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr ""
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast Vorbis Metadata"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "Yayın Etiketi:"
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "Şarkıcı - Parça Adı"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "Show - Şarkıcı - Parça Adı"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "Radyo adı - Show adı"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "Yayın Dışında Gösterilecek Etiket"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "ReplayGain'i aktif et"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "ReplayGain Değeri"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "Etkin:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "Yayın Türü:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "Bit Değeri:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "Servis Türü:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "Kanallar:"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - Mono"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - Stereo"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "Sunucu"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "Port"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "URL"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "İsim"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "Bağlama Noktası"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "Yönetici Hesabı"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "Yönetici Şifresi"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "Sunucu değeri boş bırakılamaz."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "Port değeri boş bırakılamaz."
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "Icecast sunucusunu Bağlama noktası değeri boş olarak kullanamazsınız."
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "İçe Aktarım Klasörü"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "İzlenen Klasörler:"
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "Geçerli bir Klasör değil."
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "Oynat"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "Durdur"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "Cue In değerini ayarla"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "Cue Out değerini ayarla"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "Cursor"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "Canlı yayın"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:160
@@ -4009,14 +3822,12 @@ msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr ""
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,27 +3835,17 @@ msgstr ""
 msgid "%s doesn't exist in the watched list."
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
 msgstr ""
 
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr ""
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:73
@@ -4060,47 +3861,57 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr ""
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr ""
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr ""
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
+msgstr ""
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
 msgstr ""
 
 #: airtime_mvc/application/models/Webstream.php:166
@@ -4148,8 +3959,1043 @@ msgstr ""
 msgid "Unrecognized stream type: %s"
 msgstr ""
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "Düzenle"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr ""
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "önceki"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "sonraki"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "Durdur"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "Paylaş"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "Ekle"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
 msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "OK"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "Parça Numarası:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC No:"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "Oturumu kapat"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "DJ"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "Stil"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "İsim"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "Soyisim"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr ""
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
 msgstr ""

--- a/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
+++ b/airtime_mvc/locale/zh_CN/LC_MESSAGES/airtime.po
@@ -1,273 +1,887 @@
 # LANGUAGE (xx_XX) translation for Airtime.
 # Copyright (C) 2012 Sourcefabric
 # This file is distributed under the same license as the Airtime package.
-# 
+#
 # Translators:
 # Sourcefabric <contact@sourcefabric.org>, 2012
 msgid ""
 msgstr ""
 "Project-Id-Version: Airtime\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-09-04 11:17-0400\n"
+"POT-Creation-Date: 2017-03-21 18:06+0000\n"
 "PO-Revision-Date: 2015-09-05 08:33+0000\n"
 "Last-Translator: Daniel James <daniel@64studio.com>\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/sourcefabric/airtime/language/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: airtime_mvc/application/services/CalendarService.php:50
-msgid "Record file doesn't exist"
-msgstr "录制文件不存在"
+#: airtime_mvc/application/common/DateHelper.php:213
+#, php-format
+msgid "The year %s must be within the range of 1753 - 9999"
+msgstr "1753 - 9999 是可以接受的年代值，而不是“%s”"
 
-#: airtime_mvc/application/services/CalendarService.php:54
-msgid "View Recorded File Metadata"
-msgstr "查看录制文件的元数据"
+#: airtime_mvc/application/common/DateHelper.php:216
+#, php-format
+msgid "%s-%s-%s is not a valid date"
+msgstr "%s-%s-%s采用了错误的日期格式"
 
-#: airtime_mvc/application/services/CalendarService.php:61
-#: airtime_mvc/application/services/CalendarService.php:93
-msgid "View"
+#: airtime_mvc/application/common/DateHelper.php:240
+#, php-format
+msgid "%s:%s:%s is not a valid time"
+msgstr "%s:%s:%s 采用了错误的时间格式"
+
+#: airtime_mvc/application/common/LocaleHelper.php:26
+msgid "English"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:81
-msgid "Schedule Tracks"
+#: airtime_mvc/application/common/LocaleHelper.php:27
+msgid "Afar"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:106
-msgid "Clear Show"
+#: airtime_mvc/application/common/LocaleHelper.php:28
+msgid "Abkhazian"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:120
-#: airtime_mvc/application/services/CalendarService.php:125
-msgid "Cancel Show"
+#: airtime_mvc/application/common/LocaleHelper.php:29
+msgid "Afrikaans"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:146
-#: airtime_mvc/application/services/CalendarService.php:165
-msgid "Edit Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:30
+msgid "Amharic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:152
-#: airtime_mvc/application/controllers/LibraryController.php:184
-#: airtime_mvc/application/controllers/LibraryController.php:206
-msgid "Edit"
-msgstr "编辑"
-
-#: airtime_mvc/application/services/CalendarService.php:158
-#: airtime_mvc/application/services/CalendarService.php:172
-msgid "Edit Show"
-msgstr "编辑节目"
-
-#: airtime_mvc/application/services/CalendarService.php:188
-#: airtime_mvc/application/services/CalendarService.php:205
-#: airtime_mvc/application/services/CalendarService.php:210
-#: airtime_mvc/application/controllers/LibraryController.php:122
-#: airtime_mvc/application/controllers/LibraryController.php:189
-#: airtime_mvc/application/controllers/LibraryController.php:208
-#: airtime_mvc/application/controllers/ShowbuilderController.php:144
-msgid "Delete"
-msgstr "删除"
-
-#: airtime_mvc/application/services/CalendarService.php:194
-msgid "Delete Instance"
+#: airtime_mvc/application/common/LocaleHelper.php:31
+msgid "Arabic"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:200
-msgid "Delete Instance and All Following"
+#: airtime_mvc/application/common/LocaleHelper.php:32
+msgid "Assamese"
 msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:254
-msgid "Permission denied"
-msgstr "没有编辑权限"
+#: airtime_mvc/application/common/LocaleHelper.php:33
+msgid "Aymara"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:258
-msgid "Can't drag and drop repeating shows"
-msgstr "系列中的节目无法拖拽"
+#: airtime_mvc/application/common/LocaleHelper.php:34
+msgid "Azerbaijani"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:267
-msgid "Can't move a past show"
-msgstr "已经结束的节目无法更改时间"
+#: airtime_mvc/application/common/LocaleHelper.php:35
+msgid "Bashkir"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:302
-msgid "Can't move show into past"
-msgstr "节目不能设置到已过去的时间点"
+#: airtime_mvc/application/common/LocaleHelper.php:36
+msgid "Belarusian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:309
-#: airtime_mvc/application/forms/AddShowWhen.php:293
-#: airtime_mvc/application/forms/AddShowWhen.php:321
-#: airtime_mvc/application/forms/AddShowWhen.php:327
-msgid "Cannot schedule overlapping shows"
-msgstr "节目时间设置与其他节目有冲突"
+#: airtime_mvc/application/common/LocaleHelper.php:37
+msgid "Bulgarian"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:322
-msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
-msgstr "录音和重播节目之间的间隔必须大于等于1小时。"
+#: airtime_mvc/application/common/LocaleHelper.php:38
+msgid "Bihari"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:332
-msgid "Show was deleted because recorded show does not exist!"
-msgstr "录音节目不存在，节目已删除！"
+#: airtime_mvc/application/common/LocaleHelper.php:39
+msgid "Bislama"
+msgstr ""
 
-#: airtime_mvc/application/services/CalendarService.php:339
-msgid "Must wait 1 hour to rebroadcast."
-msgstr "重播节目必须设置于1小时之后。"
+#: airtime_mvc/application/common/LocaleHelper.php:40
+msgid "Bengali/Bangla"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1117
-#: airtime_mvc/application/services/HistoryService.php:1157
-#: airtime_mvc/application/services/HistoryService.php:1174
-#: airtime_mvc/application/controllers/LocaleController.php:76
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
-#: airtime_mvc/application/models/Block.php:1375
-msgid "Title"
-msgstr "标题"
+#: airtime_mvc/application/common/LocaleHelper.php:41
+msgid "Tibetan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1118
-#: airtime_mvc/application/services/HistoryService.php:1158
-#: airtime_mvc/application/services/HistoryService.php:1175
-#: airtime_mvc/application/controllers/LocaleController.php:77
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
-#: airtime_mvc/application/models/Block.php:1360
-msgid "Creator"
-msgstr "作者"
+#: airtime_mvc/application/common/LocaleHelper.php:42
+msgid "Breton"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1119
-#: airtime_mvc/application/controllers/LocaleController.php:78
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
-#: airtime_mvc/application/models/Block.php:1352
-msgid "Album"
-msgstr "专辑"
+#: airtime_mvc/application/common/LocaleHelper.php:43
+msgid "Catalan"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1120
-#: airtime_mvc/application/services/HistoryService.php:1177
-#: airtime_mvc/application/controllers/LocaleController.php:91
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
-#: airtime_mvc/application/models/Block.php:1369
-msgid "Length"
-msgstr "时长"
+#: airtime_mvc/application/common/LocaleHelper.php:44
+msgid "Corsican"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1121
-#: airtime_mvc/application/controllers/LocaleController.php:85
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
-#: airtime_mvc/application/models/Block.php:1362
-msgid "Genre"
-msgstr "风格"
+#: airtime_mvc/application/common/LocaleHelper.php:45
+msgid "Czech"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1122
-#: airtime_mvc/application/controllers/LocaleController.php:93
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
-#: airtime_mvc/application/models/Block.php:1371
-msgid "Mood"
-msgstr "风格"
+#: airtime_mvc/application/common/LocaleHelper.php:46
+msgid "Welsh"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1123
-#: airtime_mvc/application/controllers/LocaleController.php:87
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
-#: airtime_mvc/application/models/Block.php:1364
-msgid "Label"
-msgstr "标签"
+#: airtime_mvc/application/common/LocaleHelper.php:47
+msgid "Danish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1124
-#: airtime_mvc/application/services/HistoryService.php:1178
-#: airtime_mvc/application/controllers/LocaleController.php:81
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
-#: airtime_mvc/application/models/Block.php:1355
-msgid "Composer"
-msgstr "作曲"
+#: airtime_mvc/application/common/LocaleHelper.php:48
+msgid "German"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1125
-#: airtime_mvc/application/controllers/LocaleController.php:86
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
-#: airtime_mvc/application/models/Block.php:1363
-msgid "ISRC"
-msgstr "ISRC码"
+#: airtime_mvc/application/common/LocaleHelper.php:49
+msgid "Bhutani"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1126
-#: airtime_mvc/application/services/HistoryService.php:1179
-#: airtime_mvc/application/controllers/LocaleController.php:83
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
-#: airtime_mvc/application/models/Block.php:1357
-msgid "Copyright"
-msgstr "版权"
+#: airtime_mvc/application/common/LocaleHelper.php:50
+msgid "Greek"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1127
-#: airtime_mvc/application/controllers/LocaleController.php:100
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
-#: airtime_mvc/application/models/Block.php:1379
-msgid "Year"
-msgstr "年代"
+#: airtime_mvc/application/common/LocaleHelper.php:51
+msgid "Esperanto"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1128
-msgid "Track"
-msgstr "曲目"
+#: airtime_mvc/application/common/LocaleHelper.php:52
+msgid "Spanish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1129
-#: airtime_mvc/application/controllers/LocaleController.php:82
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
-#: airtime_mvc/application/models/Block.php:1356
-msgid "Conductor"
-msgstr "指挥"
+#: airtime_mvc/application/common/LocaleHelper.php:53
+msgid "Estonian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1130
-#: airtime_mvc/application/controllers/LocaleController.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
-#: airtime_mvc/application/models/Block.php:1365
-msgid "Language"
-msgstr "语种"
+#: airtime_mvc/application/common/LocaleHelper.php:54
+msgid "Basque"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1155
-#: airtime_mvc/application/forms/EditHistoryItem.php:32
-msgid "Start Time"
-msgstr "开始时间"
+#: airtime_mvc/application/common/LocaleHelper.php:55
+msgid "Persian"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1156
-#: airtime_mvc/application/forms/EditHistoryItem.php:44
-msgid "End Time"
-msgstr "结束时间"
+#: airtime_mvc/application/common/LocaleHelper.php:56
+msgid "Finnish"
+msgstr ""
 
-#: airtime_mvc/application/services/HistoryService.php:1176
-msgid "Played"
-msgstr "已播放"
+#: airtime_mvc/application/common/LocaleHelper.php:57
+msgid "Fiji"
+msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:31
+#: airtime_mvc/application/common/LocaleHelper.php:58
+msgid "Faeroese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:59
+msgid "French"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:60
+msgid "Frisian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:61
+msgid "Irish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:62
+msgid "Scots/Gaelic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:63
+msgid "Galician"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:64
+msgid "Guarani"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:65
+msgid "Gujarati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:66
+msgid "Hausa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:67
+msgid "Hindi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:68
+msgid "Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:69
+msgid "Hungarian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:70
+msgid "Armenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:71
+msgid "Interlingua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:72
+msgid "Interlingue"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:73
+msgid "Inupiak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:74
+msgid "Indonesian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:75
+msgid "Icelandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:76
+msgid "Italian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:77
+msgid "Hebrew"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:78
+msgid "Japanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:79
+msgid "Yiddish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:80
+msgid "Javanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:81
+msgid "Georgian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:82
+msgid "Kazakh"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:83
+msgid "Greenlandic"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:84
+msgid "Cambodian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:85
+msgid "Kannada"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:86
+msgid "Korean"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:87
+msgid "Kashmiri"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:88
+msgid "Kurdish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:89
+msgid "Kirghiz"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:90
+msgid "Latin"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:91
+msgid "Lingala"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:92
+msgid "Laothian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:93
+msgid "Lithuanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:94
+msgid "Latvian/Lettish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:95
+msgid "Malagasy"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:96
+msgid "Maori"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:97
+msgid "Macedonian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:98
+msgid "Malayalam"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:99
+msgid "Mongolian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:100
+msgid "Moldavian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:101
+msgid "Marathi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:102
+msgid "Malay"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:103
+msgid "Maltese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:104
+msgid "Burmese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:105
+msgid "Nauru"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:106
+msgid "Nepali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:107
+msgid "Dutch"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:108
+msgid "Norwegian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:109
+msgid "Occitan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:110
+msgid "(Afan)/Oromoor/Oriya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:111
+msgid "Punjabi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:112
+msgid "Polish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:113
+msgid "Pashto/Pushto"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:114
+msgid "Portuguese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:115
+msgid "Quechua"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:116
+msgid "Rhaeto-Romance"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:117
+msgid "Kirundi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:118
+msgid "Romanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:119
+msgid "Russian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:120
+msgid "Kinyarwanda"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:121
+msgid "Sanskrit"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:122
+msgid "Sindhi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:123
+msgid "Sangro"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:124
+msgid "Serbo-Croatian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:125
+msgid "Singhalese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:126
+msgid "Slovak"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:127
+msgid "Slovenian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:128
+msgid "Samoan"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:129
+msgid "Shona"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:130
+msgid "Somali"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:131
+msgid "Albanian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:132
+msgid "Serbian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:133
+msgid "Siswati"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:134
+msgid "Sesotho"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:135
+msgid "Sundanese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:136
+msgid "Swedish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:137
+msgid "Swahili"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:138
+msgid "Tamil"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:139
+msgid "Tegulu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:140
+msgid "Tajik"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:141
+msgid "Thai"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:142
+msgid "Tigrinya"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:143
+msgid "Turkmen"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:144
+msgid "Tagalog"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:145
+msgid "Setswana"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:146
+msgid "Tonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:147
+msgid "Turkish"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:148
+msgid "Tsonga"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:149
+msgid "Tatar"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:150
+msgid "Twi"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:151
+msgid "Ukrainian"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:152
+msgid "Urdu"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:153
+msgid "Uzbek"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:154
+msgid "Vietnamese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:155
+msgid "Volapuk"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:156
+msgid "Wolof"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:157
+msgid "Xhosa"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:158
+msgid "Yoruba"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:159
+msgid "Chinese"
+msgstr ""
+
+#: airtime_mvc/application/common/LocaleHelper.php:160
+msgid "Zulu"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:66
+msgid "Upload some tracks below to add them to your library!"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:68
+#, php-format
+msgid "It looks like you haven't uploaded any audio files yet. %sUpload a file now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:74
+msgid "Click the 'New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:76
+#, php-format
+msgid "It looks like you don't have any shows scheduled. %sCreate a show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:84
+msgid "To start broadcasting, cancel the current linked show by clicking on it and selecting 'Cancel Show'."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:86
+#, php-format
+msgid ""
+"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
+"                    %sCreate an unlinked show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:91
+msgid "To start broadcasting, click on the current show and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:93
+#, php-format
+msgid "It looks like the current show needs more tracks. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:100
+msgid "Click on the show starting next and select 'Schedule Tracks'"
+msgstr ""
+
+#: airtime_mvc/application/common/UsabilityHints.php:102
+#, php-format
+msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:12
+#: airtime_mvc/application/controllers/LocaleController.php:125
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:6
+msgid "My Podcast"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:19
+msgid "Radio Page"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:26
+msgid "Calendar"
+msgstr "节目日程"
+
+#: airtime_mvc/application/configs/navigation.php:33
+msgid "Widgets"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:41
+#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
+msgid "Player"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:47
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
+msgid "Weekly Schedule"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:53
+msgid "Facebook"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:61
+msgid "Settings"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:69
+#: airtime_mvc/application/views/scripts/preference/index.phtml:2
+msgid "General"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:74
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
+msgid "My Profile"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:80
+msgid "Users"
+msgstr "用户管理"
+
+#: airtime_mvc/application/configs/navigation.php:87
+msgid "Streams"
+msgstr "媒体流设置"
+
+#: airtime_mvc/application/configs/navigation.php:93
+#: airtime_mvc/application/controllers/LocaleController.php:382
+#: airtime_mvc/application/controllers/LocaleController.php:383
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:31
+msgid "Status"
+msgstr "系统状态"
+
+#: airtime_mvc/application/configs/navigation.php:102
+msgid "Analytics"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:110
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
+msgid "Playout History"
+msgstr "播出历史"
+
+#: airtime_mvc/application/configs/navigation.php:117
+msgid "History Templates"
+msgstr "历史记录模板"
+
+#: airtime_mvc/application/configs/navigation.php:124
+msgid "Listener Stats"
+msgstr "收听状态"
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Upgrade"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:134
+msgid "Billing"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:141
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:148
+msgid "Account Details"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:155
+msgid "View Invoices"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:165
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:13
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:13
+#: airtime_mvc/application/views/scripts/error/error.phtml:14
+msgid "Help"
+msgstr "帮助"
+
+#: airtime_mvc/application/configs/navigation.php:172
+msgid "Getting Started"
+msgstr "基本用法"
+
+#: airtime_mvc/application/configs/navigation.php:179
+msgid "FAQ"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:184
+msgid "User Manual"
+msgstr "用户手册"
+
+#: airtime_mvc/application/configs/navigation.php:189
+msgid "File a Support Ticket"
+msgstr ""
+
+#: airtime_mvc/application/configs/navigation.php:199
+msgid "What's New?"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:102
+#: airtime_mvc/application/controllers/ApiController.php:553
+msgid "You are not allowed to access this resource."
+msgstr "你没有访问该资源的权限"
+
+#: airtime_mvc/application/controllers/ApiController.php:303
+#: airtime_mvc/application/controllers/ApiController.php:369
+#: airtime_mvc/application/controllers/ApiController.php:436
+#: airtime_mvc/application/controllers/ApiController.php:488
+#: airtime_mvc/application/controllers/ApiController.php:520
+msgid "You are not allowed to access this resource. "
+msgstr "你没有访问该资源的权限"
+
+#: airtime_mvc/application/controllers/ApiController.php:745
+#: airtime_mvc/application/controllers/ApiController.php:765
+#: airtime_mvc/application/controllers/ApiController.php:777
+#, php-format
+msgid "File does not exist in %s"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ApiController.php:828
+msgid "Bad request. no 'mode' parameter passed."
+msgstr "请求错误。没有提供‘模式’参数。"
+
+#: airtime_mvc/application/controllers/ApiController.php:838
+msgid "Bad request. 'mode' parameter is invalid"
+msgstr "请求错误。提供的‘模式’参数无效。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:35
+#: airtime_mvc/application/controllers/DashboardController.php:84
+msgid "You don't have permission to disconnect source."
+msgstr "你没有断开输入源的权限。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:37
+#: airtime_mvc/application/controllers/DashboardController.php:86
+msgid "There is no source connected to this input."
+msgstr "没有连接上的输入源。"
+
+#: airtime_mvc/application/controllers/DashboardController.php:81
+msgid "You don't have permission to switch source."
+msgstr "你没有切换的权限。"
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
+msgid ""
+"To configure and use the embeddable player you must:<br><br>\n"
+"            1. Enable at least one MP3, AAC, or OGG stream under Settings -> Streams<br>\n"
+"            2. Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
+msgid ""
+"To use the embeddable weekly schedule widget you must:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:53
+msgid ""
+"To add the Radio Tab to your Facebook Page, you must first:<br><br>\n"
+"            Enable the Public Airtime API under Settings -> Preferences"
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:87
+msgid "Page not found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:96
+msgid "The requested action is not supported."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:107
+msgid "You do not have permission to access this resource."
+msgstr ""
+
+#: airtime_mvc/application/controllers/ErrorController.php:118
+msgid "An internal application error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:84
+#, php-format
+msgid "%s Podcast"
+msgstr ""
+
+#: airtime_mvc/application/controllers/IndexController.php:85
+msgid "No tracks have been published yet."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:28
 #: airtime_mvc/application/controllers/PlaylistController.php:147
 #, php-format
 msgid "%s not found"
 msgstr "%s不存在"
 
-#: airtime_mvc/application/controllers/LibraryController.php:40
+#: airtime_mvc/application/controllers/LibraryController.php:37
 #: airtime_mvc/application/controllers/PlaylistController.php:168
 msgid "Something went wrong."
 msgstr "未知错误。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:95
-#: airtime_mvc/application/controllers/ShowbuilderController.php:136
+#: airtime_mvc/application/controllers/LibraryController.php:92
+#: airtime_mvc/application/controllers/ShowbuilderController.php:135
 msgid "Preview"
 msgstr "预览"
 
-#: airtime_mvc/application/controllers/LibraryController.php:115
-#: airtime_mvc/application/controllers/LibraryController.php:177
-#: airtime_mvc/application/controllers/LibraryController.php:200
+#: airtime_mvc/application/controllers/LibraryController.php:112
+#: airtime_mvc/application/controllers/LibraryController.php:163
+#: airtime_mvc/application/controllers/LibraryController.php:186
 msgid "Add to Playlist"
 msgstr "添加到播放列表"
 
-#: airtime_mvc/application/controllers/LibraryController.php:117
+#: airtime_mvc/application/controllers/LibraryController.php:114
 msgid "Add to Smart Block"
 msgstr "添加到智能模块"
 
-#: airtime_mvc/application/controllers/LibraryController.php:123
-#: airtime_mvc/application/controllers/LocaleController.php:66
-msgid "Edit Metadata"
-msgstr "编辑元数据"
+#: airtime_mvc/application/controllers/LibraryController.php:119
+#: airtime_mvc/application/controllers/LibraryController.php:175
+#: airtime_mvc/application/controllers/LibraryController.php:194
+#: airtime_mvc/application/controllers/ShowbuilderController.php:143
+#: airtime_mvc/application/services/CalendarService.php:188
+#: airtime_mvc/application/services/CalendarService.php:205
+#: airtime_mvc/application/services/CalendarService.php:210
+msgid "Delete"
+msgstr "删除"
 
-#: airtime_mvc/application/controllers/LibraryController.php:131
-#: airtime_mvc/application/controllers/ScheduleController.php:712
+#: airtime_mvc/application/controllers/LibraryController.php:120
+#: airtime_mvc/application/controllers/LibraryController.php:170
+#: airtime_mvc/application/controllers/LibraryController.php:192
+msgid "Edit..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:121
+#: airtime_mvc/application/forms/EditAudioMD.php:226
+msgid "Publish..."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LibraryController.php:129
+#: airtime_mvc/application/controllers/ScheduleController.php:704
 msgid "Download"
 msgstr "下载"
 
@@ -276,81 +890,1502 @@ msgid "View track"
 msgstr ""
 
 #: airtime_mvc/application/controllers/LibraryController.php:148
-msgid "Remove track"
+msgid "Update track"
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:154
-#: airtime_mvc/application/controllers/LibraryController.php:159
-msgid "Upload track"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LibraryController.php:169
+#: airtime_mvc/application/controllers/LibraryController.php:155
 msgid "Duplicate Playlist"
 msgstr "复制播放列表"
 
-#: airtime_mvc/application/controllers/LibraryController.php:213
+#: airtime_mvc/application/controllers/LibraryController.php:199
 msgid "No action available"
 msgstr "没有操作选择"
 
-#: airtime_mvc/application/controllers/LibraryController.php:233
+#: airtime_mvc/application/controllers/LibraryController.php:219
 msgid "You don't have permission to delete selected items."
 msgstr "你没有删除选定项目的权限。"
 
-#: airtime_mvc/application/controllers/LibraryController.php:279
+#: airtime_mvc/application/controllers/LibraryController.php:265
 msgid "Could not delete file because it is scheduled in the future."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:282
+#: airtime_mvc/application/controllers/LibraryController.php:268
 msgid "Could not delete file(s)."
 msgstr ""
 
-#: airtime_mvc/application/controllers/LibraryController.php:322
+#: airtime_mvc/application/controllers/LibraryController.php:308
 #, php-format
 msgid "Copy of %s"
 msgstr "%s的副本"
 
-#: airtime_mvc/application/controllers/WebstreamController.php:28
-#: airtime_mvc/application/controllers/WebstreamController.php:32
-msgid "Untitled Webstream"
-msgstr "未命名的网络流媒体"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:150
-msgid "Webstream saved."
-msgstr "网络流媒体已保存。"
-
-#: airtime_mvc/application/controllers/WebstreamController.php:158
-msgid "Invalid form values."
-msgstr "无效的表格内容。"
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:28
-msgid ""
-"To configure and use the embeddable player you must:<br><br>\n"
-"            1. Enable at least one MP3, AAC, or OGG stream under System -> Streams<br>\n"
-"            2. Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
-#: airtime_mvc/application/controllers/EmbeddablewidgetsController.php:41
-msgid ""
-"To use the embeddable weekly schedule widget you must:<br><br>\n"
-"            Enable the Public Airtime API under System -> Preferences"
-msgstr ""
-
 #: airtime_mvc/application/controllers/ListenerstatController.php:51
-msgid ""
-"Please make sure admin user/password is correct on System->Streams page."
+msgid "Please make sure admin user/password is correct on System->Streams page."
 msgstr "请检查系统->媒体流设置中，管理员用户/密码的设置是否正确。"
 
-#: airtime_mvc/application/controllers/UserController.php:86
-msgid "User added successfully!"
-msgstr "用户已添加成功！"
+#: airtime_mvc/application/controllers/LocaleController.php:30
+#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
+msgid "Audio Player"
+msgstr "音频播放器"
 
-#: airtime_mvc/application/controllers/UserController.php:88
-msgid "User updated successfully!"
-msgstr "用于已成功更新！"
+#: airtime_mvc/application/controllers/LocaleController.php:31
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
+msgid "Something went wrong!"
+msgstr ""
 
-#: airtime_mvc/application/controllers/UserController.php:187
-msgid "Settings updated successfully!"
-msgstr "设置更新成功！"
+#: airtime_mvc/application/controllers/LocaleController.php:33
+msgid "Recording:"
+msgstr "录制："
+
+#: airtime_mvc/application/controllers/LocaleController.php:34
+msgid "Master Stream"
+msgstr "主输入源"
+
+#: airtime_mvc/application/controllers/LocaleController.php:35
+msgid "Live Stream"
+msgstr "节目定制输入源"
+
+#: airtime_mvc/application/controllers/LocaleController.php:36
+msgid "Nothing Scheduled"
+msgstr "没有安排节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:37
+msgid "Current Show:"
+msgstr "当前节目："
+
+#: airtime_mvc/application/controllers/LocaleController.php:38
+msgid "Current"
+msgstr "当前的"
+
+#: airtime_mvc/application/controllers/LocaleController.php:40
+msgid "You are running the latest version"
+msgstr "你已经在使用最新版"
+
+#: airtime_mvc/application/controllers/LocaleController.php:41
+msgid "New version available: "
+msgstr "版本有更新："
+
+#: airtime_mvc/application/controllers/LocaleController.php:42
+msgid "This version will soon be obsolete."
+msgstr "这个版本即将过时。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:43
+msgid "This version is no longer supported."
+msgstr "这个版本即将停支持。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:44
+msgid "Please upgrade to "
+msgstr "请升级到"
+
+#: airtime_mvc/application/controllers/LocaleController.php:46
+msgid "Add to current playlist"
+msgstr "添加到播放列表"
+
+#: airtime_mvc/application/controllers/LocaleController.php:47
+msgid "Add to current smart block"
+msgstr "添加到只能模块"
+
+#: airtime_mvc/application/controllers/LocaleController.php:48
+msgid "Adding 1 Item"
+msgstr "添加1项"
+
+#: airtime_mvc/application/controllers/LocaleController.php:49
+#, php-format
+msgid "Adding %s Items"
+msgstr "添加%s项"
+
+#: airtime_mvc/application/controllers/LocaleController.php:50
+msgid "You can only add tracks to smart blocks."
+msgstr "智能模块只能添加声音文件。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:51
+#: airtime_mvc/application/controllers/PlaylistController.php:180
+msgid "You can only add tracks, smart blocks, and webstreams to playlists."
+msgstr "播放列表只能添加声音文件，只能模块和网络流媒体。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:54
+msgid "Please select a cursor position on timeline."
+msgstr "请在右部的时间表视图中选择一个游标位置。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:55
+msgid "You haven't added any tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:56
+msgid "You haven't added any playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:57
+msgid "You haven't added any smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:58
+msgid "You haven't added any webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:59
+msgid "Learn about tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:60
+msgid "Learn about playlists"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:61
+msgid "Learn about podcasts"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:62
+msgid "Learn about smart blocks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:63
+msgid "Learn about webstreams"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:64
+msgid "Click 'New' to create one."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:68
+msgid "Edit Metadata"
+msgstr "编辑元数据"
+
+#: airtime_mvc/application/controllers/LocaleController.php:69
+msgid "Add to selected show"
+msgstr "添加到所选的节目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:70
+msgid "Select"
+msgstr "选择"
+
+#: airtime_mvc/application/controllers/LocaleController.php:71
+msgid "Select this page"
+msgstr "选择此页"
+
+#: airtime_mvc/application/controllers/LocaleController.php:72
+msgid "Deselect this page"
+msgstr "取消整页"
+
+#: airtime_mvc/application/controllers/LocaleController.php:73
+msgid "Deselect all"
+msgstr "全部取消"
+
+#: airtime_mvc/application/controllers/LocaleController.php:74
+msgid "Are you sure you want to delete the selected item(s)?"
+msgstr "确定删除选择的项？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:75
+msgid "Scheduled"
+msgstr "已安排进日程"
+
+#: airtime_mvc/application/controllers/LocaleController.php:76
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:3
+msgid "Tracks"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:77
+#: airtime_mvc/application/layouts/scripts/layout.phtml:62
+msgid "Playlist"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:78
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
+#: airtime_mvc/application/models/Block.php:1381
+#: airtime_mvc/application/services/HistoryService.php:1115
+#: airtime_mvc/application/services/HistoryService.php:1155
+#: airtime_mvc/application/services/HistoryService.php:1172
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:6
+msgid "Title"
+msgstr "标题"
+
+#: airtime_mvc/application/controllers/LocaleController.php:79
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:60
+#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/services/HistoryService.php:1116
+#: airtime_mvc/application/services/HistoryService.php:1156
+#: airtime_mvc/application/services/HistoryService.php:1173
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:26
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:7
+msgid "Creator"
+msgstr "作者"
+
+#: airtime_mvc/application/controllers/LocaleController.php:80
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
+#: airtime_mvc/application/models/Block.php:1357
+#: airtime_mvc/application/services/HistoryService.php:1117
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:8
+msgid "Album"
+msgstr "专辑"
+
+#: airtime_mvc/application/controllers/LocaleController.php:81
+msgid "Bit Rate"
+msgstr "比特率"
+
+#: airtime_mvc/application/controllers/LocaleController.php:82
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:53
+#: airtime_mvc/application/models/Block.php:1359
+msgid "BPM"
+msgstr "每分钟拍子数"
+
+#: airtime_mvc/application/controllers/LocaleController.php:83
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:54
+#: airtime_mvc/application/models/Block.php:1360
+#: airtime_mvc/application/services/HistoryService.php:1122
+#: airtime_mvc/application/services/HistoryService.php:1176
+msgid "Composer"
+msgstr "作曲"
+
+#: airtime_mvc/application/controllers/LocaleController.php:84
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:55
+#: airtime_mvc/application/models/Block.php:1361
+#: airtime_mvc/application/services/HistoryService.php:1127
+msgid "Conductor"
+msgstr "指挥"
+
+#: airtime_mvc/application/controllers/LocaleController.php:85
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
+#: airtime_mvc/application/models/Block.php:1362
+#: airtime_mvc/application/services/HistoryService.php:1124
+#: airtime_mvc/application/services/HistoryService.php:1177
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:41
+msgid "Copyright"
+msgstr "版权"
+
+#: airtime_mvc/application/controllers/LocaleController.php:86
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:61
+#: airtime_mvc/application/models/Block.php:1367
+msgid "Encoded By"
+msgstr "编曲"
+
+#: airtime_mvc/application/controllers/LocaleController.php:87
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:62
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:127
+#: airtime_mvc/application/models/Block.php:1368
+#: airtime_mvc/application/services/HistoryService.php:1119
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:10
+msgid "Genre"
+msgstr "风格"
+
+#: airtime_mvc/application/controllers/LocaleController.php:88
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:63
+#: airtime_mvc/application/models/Block.php:1369
+#: airtime_mvc/application/services/HistoryService.php:1123
+msgid "ISRC"
+msgstr "ISRC码"
+
+#: airtime_mvc/application/controllers/LocaleController.php:89
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
+#: airtime_mvc/application/models/Block.php:1370
+#: airtime_mvc/application/services/HistoryService.php:1121
+msgid "Label"
+msgstr "标签"
+
+#: airtime_mvc/application/controllers/LocaleController.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
+#: airtime_mvc/application/models/Block.php:1371
+#: airtime_mvc/application/services/HistoryService.php:1128
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:32
+msgid "Language"
+msgstr "语种"
+
+#: airtime_mvc/application/controllers/LocaleController.php:91
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:66
+#: airtime_mvc/application/models/Block.php:1373
+msgid "Last Modified"
+msgstr "最近更新于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:92
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
+#: airtime_mvc/application/models/Block.php:1374
+msgid "Last Played"
+msgstr "上次播放于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:68
+#: airtime_mvc/application/models/Block.php:1375
+#: airtime_mvc/application/services/HistoryService.php:1118
+#: airtime_mvc/application/services/HistoryService.php:1175
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:9
+msgid "Length"
+msgstr "时长"
+
+#: airtime_mvc/application/controllers/LocaleController.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
+#: airtime_mvc/application/models/Block.php:1376
+msgid "Mime"
+msgstr "MIME信息"
+
+#: airtime_mvc/application/controllers/LocaleController.php:95
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
+#: airtime_mvc/application/models/Block.php:1377
+#: airtime_mvc/application/services/HistoryService.php:1120
+msgid "Mood"
+msgstr "风格"
+
+#: airtime_mvc/application/controllers/LocaleController.php:96
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
+#: airtime_mvc/application/models/Block.php:1378
+msgid "Owner"
+msgstr "所有者"
+
+#: airtime_mvc/application/controllers/LocaleController.php:97
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:72
+#: airtime_mvc/application/models/Block.php:1379
+msgid "Replay Gain"
+msgstr "回放增益"
+
+#: airtime_mvc/application/controllers/LocaleController.php:98
+msgid "Sample Rate"
+msgstr "样本率"
+
+#: airtime_mvc/application/controllers/LocaleController.php:99
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
+#: airtime_mvc/application/models/Block.php:1382
+msgid "Track Number"
+msgstr "曲目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:100
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:76
+#: airtime_mvc/application/models/Block.php:1383
+msgid "Uploaded"
+msgstr "上传于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:101
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:77
+#: airtime_mvc/application/models/Block.php:1384
+msgid "Website"
+msgstr "网址"
+
+#: airtime_mvc/application/controllers/LocaleController.php:102
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:78
+#: airtime_mvc/application/models/Block.php:1385
+#: airtime_mvc/application/services/HistoryService.php:1125
+msgid "Year"
+msgstr "年代"
+
+#: airtime_mvc/application/controllers/LocaleController.php:103
+msgid "Loading..."
+msgstr "加载中..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:104
+#: airtime_mvc/application/controllers/LocaleController.php:411
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
+msgid "All"
+msgstr "全部"
+
+#: airtime_mvc/application/controllers/LocaleController.php:105
+msgid "Files"
+msgstr "文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:106
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:8
+msgid "Playlists"
+msgstr "播放列表"
+
+#: airtime_mvc/application/controllers/LocaleController.php:107
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:13
+msgid "Smart Blocks"
+msgstr "智能模块"
+
+#: airtime_mvc/application/controllers/LocaleController.php:108
+msgid "Web Streams"
+msgstr "网络流媒体"
+
+#: airtime_mvc/application/controllers/LocaleController.php:109
+msgid "Unknown type: "
+msgstr "位置类型："
+
+#: airtime_mvc/application/controllers/LocaleController.php:110
+msgid "Are you sure you want to delete the selected item?"
+msgstr "确定删除所选项？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:111
+#: airtime_mvc/application/controllers/LocaleController.php:216
+msgid "Uploading in progress..."
+msgstr "正在上传..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:112
+msgid "Retrieving data from the server..."
+msgstr "数据正在从服务器下载中..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:117
+msgid "The soundcloud id for this file is: "
+msgstr "文件的SoundCloud编号是："
+
+#: airtime_mvc/application/controllers/LocaleController.php:118
+msgid "There was an error while uploading to soundcloud."
+msgstr "文件上传到SoundCloud时发生错误"
+
+#: airtime_mvc/application/controllers/LocaleController.php:119
+msgid "Error code: "
+msgstr "错误代码："
+
+#: airtime_mvc/application/controllers/LocaleController.php:120
+msgid "Error msg: "
+msgstr "错误信息："
+
+#: airtime_mvc/application/controllers/LocaleController.php:121
+msgid "Input must be a positive number"
+msgstr "输入只能为正数"
+
+#: airtime_mvc/application/controllers/LocaleController.php:122
+msgid "Input must be a number"
+msgstr "只允许数字输入"
+
+#: airtime_mvc/application/controllers/LocaleController.php:123
+msgid "Input must be in the format: yyyy-mm-dd"
+msgstr "输入格式应为：年-月-日（yyyy-mm-dd）"
+
+#: airtime_mvc/application/controllers/LocaleController.php:124
+msgid "Input must be in the format: hh:mm:ss.t"
+msgstr "输入格式应为：时:分:秒 （hh:mm:ss.t）"
+
+#: airtime_mvc/application/controllers/LocaleController.php:128
+#, php-format
+msgid "You are currently uploading files. %sGoing to another screen will cancel the upload process. %sAre you sure you want to leave the page?"
+msgstr "你正在上传文件。%s如果离开此页，上传过程将被打断。%s确定离开吗？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:130
+msgid "Open Media Builder"
+msgstr "打开媒体编辑器"
+
+#: airtime_mvc/application/controllers/LocaleController.php:131
+msgid "please put in a time '00:00:00 (.0)'"
+msgstr "请输入时间‘00:00:00（.0）’"
+
+#: airtime_mvc/application/controllers/LocaleController.php:132
+msgid "Please enter a valid time in seconds. Eg. 0.5"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:133
+msgid "Your browser does not support playing this file type: "
+msgstr "你的浏览器不支持这种文件类型："
+
+#: airtime_mvc/application/controllers/LocaleController.php:134
+msgid "Dynamic block is not previewable"
+msgstr "动态智能模块无法预览"
+
+#: airtime_mvc/application/controllers/LocaleController.php:135
+msgid "Limit to: "
+msgstr "限制在："
+
+#: airtime_mvc/application/controllers/LocaleController.php:136
+msgid "Playlist saved"
+msgstr "播放列表已存储"
+
+#: airtime_mvc/application/controllers/LocaleController.php:137
+msgid "Playlist shuffled"
+msgstr "播放列表已经随机化"
+
+#: airtime_mvc/application/controllers/LocaleController.php:139
+msgid "Airtime is unsure about the status of this file. This can happen when the file is on a remote drive that is unaccessible or the file is in a directory that isn't 'watched' anymore."
+msgstr "文件的状态不可知。这可能是由于文件位于远程存储位置，或者所在的文件夹已经不再监控。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:141
+#, php-format
+msgid "Listener Count on %s: %s"
+msgstr "听众统计%s：%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:143
+msgid "Remind me in 1 week"
+msgstr "一周以后再提醒我"
+
+#: airtime_mvc/application/controllers/LocaleController.php:144
+msgid "Remind me never"
+msgstr "不再提醒"
+
+#: airtime_mvc/application/controllers/LocaleController.php:145
+msgid "Yes, help Airtime"
+msgstr "是的，帮助Airtime"
+
+#: airtime_mvc/application/controllers/LocaleController.php:146
+#: airtime_mvc/application/controllers/LocaleController.php:194
+msgid "Image must be one of jpg, jpeg, png, or gif"
+msgstr "图像文件格式只能是jpg，jpeg，png或者gif"
+
+#: airtime_mvc/application/controllers/LocaleController.php:149
+msgid "A static smart block will save the criteria and generate the block content immediately. This allows you to edit and view it in the Library before adding it to a show."
+msgstr "静态的智能模块将会保存条件设置并且马上生成所有内容。这样就可以让你在添加到节目中前，还可以编辑和预览该智能模块。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:151
+msgid "A dynamic smart block will only save the criteria. The block content will get generated upon adding it to a show. You will not be able to view and edit the content in the Library."
+msgstr "动态的智能模块将只保存条件设置。而模块的内容将在每次添加到节目中是动态生成。在媒体库中，你不能直接编辑和预览动态智能模块。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:153
+msgid "The desired block length will not be reached if Airtime cannot find enough unique tracks to match your criteria. Enable this option if you wish to allow tracks to be added multiple times to the smart block."
+msgstr "因为满足条件的声音文件数量有限，只能播放列表指定的时长可能无法达成。如果你不介意出现重复的项目，你可以启用此项。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:154
+msgid "Smart block shuffled"
+msgstr "智能模块已经随机排列"
+
+#: airtime_mvc/application/controllers/LocaleController.php:155
+msgid "Smart block generated and criteria saved"
+msgstr "智能模块已经生成，条件设置已经保存"
+
+#: airtime_mvc/application/controllers/LocaleController.php:156
+msgid "Smart block saved"
+msgstr "智能模块已经保存"
+
+#: airtime_mvc/application/controllers/LocaleController.php:157
+msgid "Processing..."
+msgstr "加载中..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:158
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:265
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:394
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:432
+#: airtime_mvc/application/models/Block.php:1389
+msgid "Select modifier"
+msgstr "选择操作符"
+
+#: airtime_mvc/application/controllers/LocaleController.php:159
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
+#: airtime_mvc/application/models/Block.php:1390
+msgid "contains"
+msgstr "包含"
+
+#: airtime_mvc/application/controllers/LocaleController.php:160
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
+#: airtime_mvc/application/models/Block.php:1391
+msgid "does not contain"
+msgstr "不包含"
+
+#: airtime_mvc/application/controllers/LocaleController.php:161
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
+#: airtime_mvc/application/models/Block.php:1392
+#: airtime_mvc/application/models/Block.php:1396
+msgid "is"
+msgstr "是"
+
+#: airtime_mvc/application/controllers/LocaleController.php:162
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
+#: airtime_mvc/application/models/Block.php:1393
+#: airtime_mvc/application/models/Block.php:1397
+msgid "is not"
+msgstr "不是"
+
+#: airtime_mvc/application/controllers/LocaleController.php:163
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:95
+#: airtime_mvc/application/models/Block.php:1394
+msgid "starts with"
+msgstr "起始于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:164
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:96
+#: airtime_mvc/application/models/Block.php:1395
+msgid "ends with"
+msgstr "结束于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:165
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
+#: airtime_mvc/application/models/Block.php:1398
+msgid "is greater than"
+msgstr "大于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:166
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:110
+#: airtime_mvc/application/models/Block.php:1399
+msgid "is less than"
+msgstr "小于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:167
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:111
+#: airtime_mvc/application/models/Block.php:1400
+msgid "is in the range"
+msgstr "处于"
+
+#: airtime_mvc/application/controllers/LocaleController.php:169
+msgid "Choose Storage Folder"
+msgstr "选择存储文件夹"
+
+#: airtime_mvc/application/controllers/LocaleController.php:170
+msgid "Choose Folder to Watch"
+msgstr "选择监控的文件夹"
+
+#: airtime_mvc/application/controllers/LocaleController.php:172
+msgid ""
+"Are you sure you want to change the storage folder?\n"
+"This will remove the files from your Airtime library!"
+msgstr ""
+"确定更改存储路径？\n"
+"这项操作将从媒体库中删除所有文件！"
+
+#: airtime_mvc/application/controllers/LocaleController.php:173
+#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
+msgid "Manage Media Folders"
+msgstr "管理媒体文件夹"
+
+#: airtime_mvc/application/controllers/LocaleController.php:174
+msgid "Are you sure you want to remove the watched folder?"
+msgstr "确定取消该文件夹的监控？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:175
+msgid "This path is currently not accessible."
+msgstr "指定的路径无法访问。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:177
+#, php-format
+msgid "Some stream types require extra configuration. Details about enabling %sAAC+ Support%s or %sOpus Support%s are provided."
+msgstr "某些类型的输出流需要第三方软件的设置，具体步骤如下：%sAAC+%s 和 %sOpus%s。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:178
+msgid "Connected to the streaming server"
+msgstr "流服务器已连接"
+
+#: airtime_mvc/application/controllers/LocaleController.php:179
+msgid "The stream is disabled"
+msgstr "输出流已禁用"
+
+#: airtime_mvc/application/controllers/LocaleController.php:180
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
+msgid "Getting information from the server..."
+msgstr "从服务器加载中..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:181
+msgid "Can not connect to the streaming server"
+msgstr "无法连接流服务器"
+
+#: airtime_mvc/application/controllers/LocaleController.php:183
+msgid "If Airtime is behind a router or firewall, you may need to configure port forwarding and this field information will be incorrect. In this case you will need to manually update this field so it shows the correct host/port/mount that your DJ's need to connect to. The allowed range is between 1024 and 49151."
+msgstr "如果Airtime配置在路由器或者防火墙之后，你可能需要配置端口转发，所以当前文本框内的信息需要调整。在这种情况下，就需要人工指定该信息以确定所显示的主机名/端口/加载点的正确性，从而让节目编辑能连接的上。端口所允许的范围，介于1024到49151之间。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:184
+#, php-format
+msgid "For more details, please read the %sAirtime Manual%s"
+msgstr "更多的细节可以参阅%sAirtime用户手册%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:186
+msgid "Check this option to enable metadata for OGG streams (stream metadata is the track title, artist, and show name that is displayed in an audio player). VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that has metadata information enabled: they will disconnect from the stream after every song. If you are using an OGG stream and your listeners do not require support for these audio players, then feel free to enable this option."
+msgstr "勾选此项会启用OGG格式流媒体的元数据（流的元数据包括歌曲名，歌手/作者，节目名，这些都会显示在音频播放器中。）VLC和mplayer有个已知的问题，他们在播放OGG/VORBIS媒体流时，如果该流已启用元数据，那么在每首歌的间隙都会断开流。所以，如果你使用OGG媒体流，同时你的听众不使用上述媒体播放器的话，你可以随意地勾选此项。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:187
+msgid "Check this box to automatically switch off Master/Show source upon source disconnection."
+msgstr "勾选此项后，在输入流断开时，主输入源和节目定制输入源将会自动切换为关闭状态。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:188
+msgid "Check this box to automatically switch on Master/Show source upon source connection."
+msgstr "勾选此项后，在输入流连接上时，主输入源和节目定制输入源将会自动切换到开启状态。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:189
+msgid "If your Icecast server expects a username of 'source', this field can be left blank."
+msgstr "如果你的Icecast服务器所要求的用户名是‘source’，那么当前项可以留空。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:190
+#: airtime_mvc/application/controllers/LocaleController.php:200
+msgid "If your live streaming client does not ask for a username, this field should be 'source'."
+msgstr "如果你的流客户端不需要用户名，那么当前项可以留空"
+
+#: airtime_mvc/application/controllers/LocaleController.php:191
+msgid "WARNING: This will restart your stream and may cause a short dropout for your listeners!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:192
+msgid "This is the admin username and password for Icecast/SHOUTcast to get listener statistics."
+msgstr "此处填写Icecast或者SHOUTcast的管理员用户名和密码，用于获取收听数据的统计。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:196
+msgid "Warning: You cannot change this field while the show is currently playing"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:197
+msgid "No result found"
+msgstr "搜索无结果"
+
+#: airtime_mvc/application/controllers/LocaleController.php:198
+msgid "This follows the same security pattern for the shows: only users assigned to the show can connect."
+msgstr "当前遵循与节目同样的安全模式：只有指定到当前节目的用户才能连接的上。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:199
+msgid "Specify custom authentication which will work only for this show."
+msgstr "所设置的自定义认证设置只对当前的节目有效。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:201
+msgid "The show instance doesn't exist anymore!"
+msgstr "此节目已不存在"
+
+#: airtime_mvc/application/controllers/LocaleController.php:202
+msgid "Warning: Shows cannot be re-linked"
+msgstr "注意：节目取消绑定后无法再次绑定"
+
+#: airtime_mvc/application/controllers/LocaleController.php:203
+msgid "By linking your repeating shows any media items scheduled in any repeat show will also get scheduled in the other repeat shows"
+msgstr "系列节目勾选绑定后，所有节目的内容都会一模一样，对任何未开始节目的更改都会影响到其他节目。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:204
+msgid "Timezone is set to the station timezone by default. Shows in the calendar will be displayed in your local time defined by the Interface Timezone in your user settings."
+msgstr "此时区设定的默认值是系统的时区设置。日程表中的节目时间则已用户定义的界面显示时区为准，两者可能有所不同。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:208
+msgid "Show"
+msgstr "节目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:209
+msgid "Show is empty"
+msgstr "节目内容为空"
+
+#: airtime_mvc/application/controllers/LocaleController.php:210
+msgid "1m"
+msgstr "1分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:211
+msgid "5m"
+msgstr "5分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:212
+msgid "10m"
+msgstr "10分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:213
+msgid "15m"
+msgstr "15分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:214
+msgid "30m"
+msgstr "30分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:215
+msgid "60m"
+msgstr "60分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:217
+msgid "Retreiving data from the server..."
+msgstr "从服务器下载数据中..."
+
+#: airtime_mvc/application/controllers/LocaleController.php:223
+msgid "This show has no scheduled content."
+msgstr "此节目没有安排内容。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:224
+msgid "This show is not completely filled with content."
+msgstr "节目内容只填充了一部分。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:228
+msgid "January"
+msgstr "一月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:229
+msgid "February"
+msgstr "二月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:230
+msgid "March"
+msgstr "三月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:231
+msgid "April"
+msgstr "四月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:232
+#: airtime_mvc/application/controllers/LocaleController.php:244
+msgid "May"
+msgstr "五月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:233
+msgid "June"
+msgstr "六月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:234
+msgid "July"
+msgstr "七月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:235
+msgid "August"
+msgstr "八月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:236
+msgid "September"
+msgstr "九月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:237
+msgid "October"
+msgstr "十月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:238
+msgid "November"
+msgstr "十一月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:239
+msgid "December"
+msgstr "十二月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:240
+msgid "Jan"
+msgstr "一月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:241
+msgid "Feb"
+msgstr "二月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:242
+msgid "Mar"
+msgstr "三月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:243
+msgid "Apr"
+msgstr "四月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:245
+msgid "Jun"
+msgstr "六月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:246
+msgid "Jul"
+msgstr "七月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:247
+msgid "Aug"
+msgstr "八月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:248
+msgid "Sep"
+msgstr "九月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:249
+msgid "Oct"
+msgstr "十月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:250
+msgid "Nov"
+msgstr "十一月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:251
+msgid "Dec"
+msgstr "十二月"
+
+#: airtime_mvc/application/controllers/LocaleController.php:252
+msgid "Today"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:253
+msgid "Day"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:254
+msgid "Week"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:255
+msgid "Month"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:256
+#: airtime_mvc/application/forms/GeneralPreferences.php:185
+msgid "Sunday"
+msgstr "周日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:257
+#: airtime_mvc/application/forms/GeneralPreferences.php:186
+msgid "Monday"
+msgstr "周一"
+
+#: airtime_mvc/application/controllers/LocaleController.php:258
+#: airtime_mvc/application/forms/GeneralPreferences.php:187
+msgid "Tuesday"
+msgstr "周二"
+
+#: airtime_mvc/application/controllers/LocaleController.php:259
+#: airtime_mvc/application/forms/GeneralPreferences.php:188
+msgid "Wednesday"
+msgstr "周三"
+
+#: airtime_mvc/application/controllers/LocaleController.php:260
+#: airtime_mvc/application/forms/GeneralPreferences.php:189
+msgid "Thursday"
+msgstr "周四"
+
+#: airtime_mvc/application/controllers/LocaleController.php:261
+#: airtime_mvc/application/forms/GeneralPreferences.php:190
+msgid "Friday"
+msgstr "周五"
+
+#: airtime_mvc/application/controllers/LocaleController.php:262
+#: airtime_mvc/application/forms/GeneralPreferences.php:191
+msgid "Saturday"
+msgstr "周六"
+
+#: airtime_mvc/application/controllers/LocaleController.php:263
+#: airtime_mvc/application/forms/AddShowRepeats.php:35
+msgid "Sun"
+msgstr "周日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:264
+#: airtime_mvc/application/forms/AddShowRepeats.php:36
+msgid "Mon"
+msgstr "周一"
+
+#: airtime_mvc/application/controllers/LocaleController.php:265
+#: airtime_mvc/application/forms/AddShowRepeats.php:37
+msgid "Tue"
+msgstr "周二"
+
+#: airtime_mvc/application/controllers/LocaleController.php:266
+#: airtime_mvc/application/forms/AddShowRepeats.php:38
+msgid "Wed"
+msgstr "周三"
+
+#: airtime_mvc/application/controllers/LocaleController.php:267
+#: airtime_mvc/application/forms/AddShowRepeats.php:39
+msgid "Thu"
+msgstr "周四"
+
+#: airtime_mvc/application/controllers/LocaleController.php:268
+#: airtime_mvc/application/forms/AddShowRepeats.php:40
+msgid "Fri"
+msgstr "周五"
+
+#: airtime_mvc/application/controllers/LocaleController.php:269
+#: airtime_mvc/application/forms/AddShowRepeats.php:41
+msgid "Sat"
+msgstr "周六"
+
+#: airtime_mvc/application/controllers/LocaleController.php:270
+msgid "Shows longer than their scheduled time will be cut off by a following show."
+msgstr "超出的节目内容将被随后的节目所取代。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:271
+msgid "Cancel Current Show?"
+msgstr "取消当前的节目？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:272
+#: airtime_mvc/application/controllers/LocaleController.php:319
+msgid "Stop recording current show?"
+msgstr "停止录制当前的节目？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:273
+msgid "Ok"
+msgstr "确定"
+
+#: airtime_mvc/application/controllers/LocaleController.php:274
+msgid "Contents of Show"
+msgstr "浏览节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:277
+msgid "Remove all content?"
+msgstr "清空全部内容？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:279
+msgid "Delete selected item(s)?"
+msgstr "删除选定的项目？"
+
+#: airtime_mvc/application/controllers/LocaleController.php:280
+#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
+msgid "Start"
+msgstr "开始"
+
+#: airtime_mvc/application/controllers/LocaleController.php:281
+msgid "End"
+msgstr "结束"
+
+#: airtime_mvc/application/controllers/LocaleController.php:282
+msgid "Duration"
+msgstr "时长"
+
+#: airtime_mvc/application/controllers/LocaleController.php:283
+msgid "Filtering out "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:284
+msgid " of "
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:285
+msgid " records"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:291
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
+#: airtime_mvc/application/layouts/scripts/layout.phtml:148
+#: airtime_mvc/application/models/Block.php:1363
+msgid "Cue In"
+msgstr "切入"
+
+#: airtime_mvc/application/controllers/LocaleController.php:292
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:58
+#: airtime_mvc/application/layouts/scripts/layout.phtml:155
+#: airtime_mvc/application/models/Block.php:1364
+msgid "Cue Out"
+msgstr "切出"
+
+#: airtime_mvc/application/controllers/LocaleController.php:293
+#: airtime_mvc/application/layouts/scripts/layout.phtml:175
+msgid "Fade In"
+msgstr "淡入"
+
+#: airtime_mvc/application/controllers/LocaleController.php:294
+#: airtime_mvc/application/layouts/scripts/layout.phtml:176
+msgid "Fade Out"
+msgstr "淡出"
+
+#: airtime_mvc/application/controllers/LocaleController.php:295
+msgid "Show Empty"
+msgstr "节目无内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:296
+msgid "Recording From Line In"
+msgstr "从线路输入录制"
+
+#: airtime_mvc/application/controllers/LocaleController.php:297
+msgid "Track preview"
+msgstr "试听媒体"
+
+#: airtime_mvc/application/controllers/LocaleController.php:301
+msgid "Cannot schedule outside a show."
+msgstr "没有指定节目，无法凭空安排内容。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:302
+msgid "Moving 1 Item"
+msgstr "移动1个项目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:303
+#, php-format
+msgid "Moving %s Items"
+msgstr "移动%s个项目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:304
+#: airtime_mvc/application/forms/AddUser.php:109
+#: airtime_mvc/application/forms/EditAudioMD.php:216
+#: airtime_mvc/application/forms/EditHistory.php:131
+#: airtime_mvc/application/forms/PasswordChange.php:43
+#: airtime_mvc/application/forms/Preferences.php:40
+#: airtime_mvc/application/forms/SupportSettings.php:131
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:87
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:41
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:102
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
+msgid "Save"
+msgstr "保存"
+
+#: airtime_mvc/application/controllers/LocaleController.php:305
+#: airtime_mvc/application/controllers/LocaleController.php:328
+#: airtime_mvc/application/forms/EditAudioMD.php:206
+#: airtime_mvc/application/forms/EditHistory.php:141
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:84
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:36
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
+msgid "Cancel"
+msgstr "取消"
+
+#: airtime_mvc/application/controllers/LocaleController.php:306
+msgid "Fade Editor"
+msgstr "淡入淡出编辑器"
+
+#: airtime_mvc/application/controllers/LocaleController.php:307
+msgid "Cue Editor"
+msgstr "切入切出编辑器"
+
+#: airtime_mvc/application/controllers/LocaleController.php:308
+msgid "Waveform features are available in a browser supporting the Web Audio API"
+msgstr "想要启用波形图功能，需要支持Web Audio API的浏览器。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:311
+msgid "Select all"
+msgstr "全选"
+
+#: airtime_mvc/application/controllers/LocaleController.php:312
+msgid "Select none"
+msgstr "全不选"
+
+#: airtime_mvc/application/controllers/LocaleController.php:313
+msgid "Trim overbooked shows"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:314
+msgid "Remove selected scheduled items"
+msgstr "移除所选的项目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:315
+msgid "Jump to the current playing track"
+msgstr "跳转到当前播放的项目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:316
+msgid "Cancel current show"
+msgstr "取消当前的节目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:321
+msgid "Open library to add or remove content"
+msgstr "打开媒体库，添加或者删除节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:322
+msgid "Add / Remove Content"
+msgstr "添加 / 删除内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:324
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:25
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
+msgid "in use"
+msgstr "使用中"
+
+#: airtime_mvc/application/controllers/LocaleController.php:325
+msgid "Disk"
+msgstr "磁盘"
+
+#: airtime_mvc/application/controllers/LocaleController.php:327
+msgid "Look in"
+msgstr "查询"
+
+#: airtime_mvc/application/controllers/LocaleController.php:329
+msgid "Open"
+msgstr "打开"
+
+#: airtime_mvc/application/controllers/LocaleController.php:331
+#: airtime_mvc/application/forms/AddUser.php:101
+msgid "Admin"
+msgstr "系统管理员"
+
+#: airtime_mvc/application/controllers/LocaleController.php:332
+#: airtime_mvc/application/forms/AddUser.php:99
+msgid "DJ"
+msgstr "节目编辑"
+
+#: airtime_mvc/application/controllers/LocaleController.php:333
+#: airtime_mvc/application/forms/AddUser.php:100
+msgid "Program Manager"
+msgstr "节目主管"
+
+#: airtime_mvc/application/controllers/LocaleController.php:334
+#: airtime_mvc/application/forms/AddUser.php:98
+msgid "Guest"
+msgstr "游客"
+
+#: airtime_mvc/application/controllers/LocaleController.php:335
+msgid "Guests can do the following:"
+msgstr "游客的权限包括："
+
+#: airtime_mvc/application/controllers/LocaleController.php:336
+msgid "View schedule"
+msgstr "显示节目日程"
+
+#: airtime_mvc/application/controllers/LocaleController.php:337
+msgid "View show content"
+msgstr "显示节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:338
+msgid "DJs can do the following:"
+msgstr "节目编辑的权限包括："
+
+#: airtime_mvc/application/controllers/LocaleController.php:339
+msgid "Manage assigned show content"
+msgstr "为指派的节目管理节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:340
+msgid "Import media files"
+msgstr "导入媒体文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:341
+msgid "Create playlists, smart blocks, and webstreams"
+msgstr "创建播放列表，智能模块和网络流媒体"
+
+#: airtime_mvc/application/controllers/LocaleController.php:342
+msgid "Manage their own library content"
+msgstr "管理媒体库中属于自己的内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:343
+msgid "Progam Managers can do the following:"
+msgstr "节目主管的权限是："
+
+#: airtime_mvc/application/controllers/LocaleController.php:344
+msgid "View and manage show content"
+msgstr "查看和管理节目内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:345
+msgid "Schedule shows"
+msgstr "安排节目日程"
+
+#: airtime_mvc/application/controllers/LocaleController.php:346
+msgid "Manage all library content"
+msgstr "管理媒体库的所有内容"
+
+#: airtime_mvc/application/controllers/LocaleController.php:347
+msgid "Admins can do the following:"
+msgstr "管理员的权限包括："
+
+#: airtime_mvc/application/controllers/LocaleController.php:348
+msgid "Manage preferences"
+msgstr "属性管理"
+
+#: airtime_mvc/application/controllers/LocaleController.php:349
+msgid "Manage users"
+msgstr "管理用户"
+
+#: airtime_mvc/application/controllers/LocaleController.php:350
+msgid "Manage watched folders"
+msgstr "管理监控文件夹"
+
+#: airtime_mvc/application/controllers/LocaleController.php:351
+#: airtime_mvc/application/forms/RegisterAirtime.php:116
+#: airtime_mvc/application/forms/SupportSettings.php:98
+msgid "Send support feedback"
+msgstr "提交反馈意见"
+
+#: airtime_mvc/application/controllers/LocaleController.php:352
+msgid "View system status"
+msgstr "显示系统状态"
+
+#: airtime_mvc/application/controllers/LocaleController.php:353
+msgid "Access playout history"
+msgstr "查看播放历史"
+
+#: airtime_mvc/application/controllers/LocaleController.php:354
+msgid "View listener stats"
+msgstr "显示收听统计数据"
+
+#: airtime_mvc/application/controllers/LocaleController.php:356
+msgid "Show / hide columns"
+msgstr "显示/隐藏栏"
+
+#: airtime_mvc/application/controllers/LocaleController.php:358
+msgid "From {from} to {to}"
+msgstr "从{from}到{to}"
+
+#: airtime_mvc/application/controllers/LocaleController.php:359
+msgid "kbps"
+msgstr "千比特每秒"
+
+#: airtime_mvc/application/controllers/LocaleController.php:360
+msgid "yyyy-mm-dd"
+msgstr "年-月-日"
+
+#: airtime_mvc/application/controllers/LocaleController.php:361
+msgid "hh:mm:ss.t"
+msgstr "时:分:秒"
+
+#: airtime_mvc/application/controllers/LocaleController.php:362
+msgid "kHz"
+msgstr "千赫兹"
+
+#: airtime_mvc/application/controllers/LocaleController.php:365
+msgid "Su"
+msgstr "周天"
+
+#: airtime_mvc/application/controllers/LocaleController.php:366
+msgid "Mo"
+msgstr "周一"
+
+#: airtime_mvc/application/controllers/LocaleController.php:367
+msgid "Tu"
+msgstr "周二"
+
+#: airtime_mvc/application/controllers/LocaleController.php:368
+msgid "We"
+msgstr "周三"
+
+#: airtime_mvc/application/controllers/LocaleController.php:369
+msgid "Th"
+msgstr "周四"
+
+#: airtime_mvc/application/controllers/LocaleController.php:370
+msgid "Fr"
+msgstr "周五"
+
+#: airtime_mvc/application/controllers/LocaleController.php:371
+msgid "Sa"
+msgstr "周六"
+
+#: airtime_mvc/application/controllers/LocaleController.php:372
+#: airtime_mvc/application/controllers/LocaleController.php:400
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/podcast/featureupgrade-pane.phtml:17
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
+msgid "Close"
+msgstr "关闭"
+
+#: airtime_mvc/application/controllers/LocaleController.php:374
+msgid "Hour"
+msgstr "小时"
+
+#: airtime_mvc/application/controllers/LocaleController.php:375
+msgid "Minute"
+msgstr "分钟"
+
+#: airtime_mvc/application/controllers/LocaleController.php:376
+msgid "Done"
+msgstr "设定"
+
+#: airtime_mvc/application/controllers/LocaleController.php:379
+msgid "Select files"
+msgstr "选择文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:380
+#: airtime_mvc/application/controllers/LocaleController.php:381
+msgid "Add files to the upload queue and click the start button."
+msgstr "添加需要上传的文件到传输队列中，然后点击开始上传。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:384
+msgid "Add Files"
+msgstr "添加文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:385
+msgid "Stop Upload"
+msgstr "停止上传"
+
+#: airtime_mvc/application/controllers/LocaleController.php:386
+msgid "Start upload"
+msgstr "开始上传"
+
+#: airtime_mvc/application/controllers/LocaleController.php:387
+msgid "Add files"
+msgstr "添加文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:388
+#, php-format
+msgid "Uploaded %d/%d files"
+msgstr "已经上传%d/%d个文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:389
+msgid "N/A"
+msgstr "未知"
+
+#: airtime_mvc/application/controllers/LocaleController.php:390
+msgid "Drag files here."
+msgstr "拖拽文件到此处。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:391
+msgid "File extension error."
+msgstr "文件后缀名出错。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:392
+msgid "File size error."
+msgstr "文件大小出错。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:393
+msgid "File count error."
+msgstr "发生文件统计错误。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:394
+msgid "Init error."
+msgstr "发生初始化错误。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:395
+msgid "HTTP Error."
+msgstr "发生HTTP类型的错误"
+
+#: airtime_mvc/application/controllers/LocaleController.php:396
+msgid "Security error."
+msgstr "发生安全性错误。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:397
+msgid "Generic error."
+msgstr "发生通用类型的错误。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:398
+msgid "IO error."
+msgstr "输入输出错误。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:399
+#, php-format
+msgid "File: %s"
+msgstr "文件：%s"
+
+#: airtime_mvc/application/controllers/LocaleController.php:401
+#, php-format
+msgid "%d files queued"
+msgstr "队列中有%d个文件"
+
+#: airtime_mvc/application/controllers/LocaleController.php:402
+msgid "File: %f, size: %s, max file size: %m"
+msgstr "文件：%f，大小：%s，最大的文件大小：%m"
+
+#: airtime_mvc/application/controllers/LocaleController.php:403
+msgid "Upload URL might be wrong or doesn't exist"
+msgstr "用于上传的地址有误或者不存在"
+
+#: airtime_mvc/application/controllers/LocaleController.php:404
+msgid "Error: File too large: "
+msgstr "错误：文件过大："
+
+#: airtime_mvc/application/controllers/LocaleController.php:405
+msgid "Error: Invalid file extension: "
+msgstr "错误：无效的文件后缀名："
+
+#: airtime_mvc/application/controllers/LocaleController.php:407
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
+msgid "Set Default"
+msgstr "设为默认"
+
+#: airtime_mvc/application/controllers/LocaleController.php:408
+msgid "Create Entry"
+msgstr "创建项目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:409
+msgid "Edit History Record"
+msgstr "编辑历史记录"
+
+#: airtime_mvc/application/controllers/LocaleController.php:410
+#: airtime_mvc/application/forms/EditHistoryItem.php:57
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
+msgid "No Show"
+msgstr "无节目"
+
+#: airtime_mvc/application/controllers/LocaleController.php:412
+#, php-format
+msgid "Copied %s row%s to the clipboard"
+msgstr "复制%s行%s到剪贴板"
+
+#: airtime_mvc/application/controllers/LocaleController.php:413
+#, php-format
+msgid "%sPrint view%sPlease use your browser's print function to print this table. Press escape when finished."
+msgstr "%s打印预览%s请使用浏览器的打印功能进行打印。按下Esc键可以退出当前状态。"
+
+#: airtime_mvc/application/controllers/LocaleController.php:414
+msgid "New Show"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:415
+msgid "New Log Entry"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:434
+msgid "Welcome to the new Airtime Pro!"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:436
+msgid "On Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:437
+msgid "Off Air"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:438
+msgid "Offline"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LocaleController.php:439
+msgid "Nothing scheduled"
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:54
+msgid "Please enter your username and password."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:179
+msgid "Email could not be sent. Check your mail server settings and ensure it has been configured properly."
+msgstr "邮件发送失败。请检查邮件服务器设置，并确定设置无误。"
+
+#: airtime_mvc/application/controllers/LoginController.php:183
+msgid "That username or email address could not be found."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:196
+msgid "There was a problem with the username or email address you entered."
+msgstr ""
+
+#: airtime_mvc/application/controllers/LoginController.php:274
+msgid "Wrong username or password provided. Please try again."
+msgstr "用户名或密码错误，请重试。"
 
 #: airtime_mvc/application/controllers/PlaylistController.php:53
 #, php-format
@@ -370,11 +2405,6 @@ msgstr "你没有删除所选%s的权限。"
 msgid "You can only add tracks to smart block."
 msgstr "智能模块只能添加媒体文件。"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:180
-#: airtime_mvc/application/controllers/LocaleController.php:50
-msgid "You can only add tracks, smart blocks, and webstreams to playlists."
-msgstr "播放列表只能添加声音文件，只能模块和网络流媒体。"
-
 #: airtime_mvc/application/controllers/PlaylistController.php:192
 msgid "Untitled Playlist"
 msgstr "未命名的播放列表"
@@ -383,2627 +2413,88 @@ msgstr "未命名的播放列表"
 msgid "Untitled Smart Block"
 msgstr "未命名的智能模块"
 
-#: airtime_mvc/application/controllers/PlaylistController.php:522
+#: airtime_mvc/application/controllers/PlaylistController.php:521
 msgid "Unknown Playlist"
 msgstr "位置播放列表"
 
-#: airtime_mvc/application/controllers/ErrorController.php:78
-msgid "Page not found."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:87
-msgid "The requested action is not supported."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:98
-msgid "You do not have permission to access this resource."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ErrorController.php:109
-msgid "An internal application error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/controllers/Apiv2Controller.php:77
-#: airtime_mvc/application/controllers/ApiController.php:79
-msgid "You are not allowed to access this resource."
-msgstr "你没有访问该资源的权限"
-
-#: airtime_mvc/application/controllers/PreferenceController.php:72
+#: airtime_mvc/application/controllers/PreferenceController.php:76
 msgid "Preferences updated."
 msgstr "属性已更新。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:115
+#: airtime_mvc/application/controllers/PreferenceController.php:141
 msgid "Support setting updated."
 msgstr "支持设定已更新。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:123
+#: airtime_mvc/application/controllers/PreferenceController.php:149
 msgid "Support Feedback"
 msgstr "意见反馈"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:251
+#: airtime_mvc/application/controllers/PreferenceController.php:351
 msgid "Stream Setting Updated."
 msgstr "流设置已更新。"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:342
+#: airtime_mvc/application/controllers/PreferenceController.php:399
 msgid "path should be specified"
 msgstr "请指定路径"
 
-#: airtime_mvc/application/controllers/PreferenceController.php:437
+#: airtime_mvc/application/controllers/PreferenceController.php:494
 msgid "Problem with Liquidsoap..."
 msgstr "Liquidsoap出错..."
 
-#: airtime_mvc/application/controllers/PreferenceController.php:493
+#: airtime_mvc/application/controllers/PreferenceController.php:556
 msgid "Request method not accepted"
 msgstr ""
 
-#: airtime_mvc/application/controllers/DashboardController.php:35
-#: airtime_mvc/application/controllers/DashboardController.php:84
-msgid "You don't have permission to disconnect source."
-msgstr "你没有断开输入源的权限。"
-
-#: airtime_mvc/application/controllers/DashboardController.php:37
-#: airtime_mvc/application/controllers/DashboardController.php:86
-msgid "There is no source connected to this input."
-msgstr "没有连接上的输入源。"
-
-#: airtime_mvc/application/controllers/DashboardController.php:81
-msgid "You don't have permission to switch source."
-msgstr "你没有切换的权限。"
-
-#: airtime_mvc/application/controllers/LoginController.php:43
-msgid "Please enter your username and password."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LoginController.php:93
-msgid "Wrong username or password provided. Please try again."
-msgstr "用户名或密码错误，请重试。"
-
-#: airtime_mvc/application/controllers/LoginController.php:167
-msgid ""
-"Email could not be sent. Check your mail server settings and ensure it has "
-"been configured properly."
-msgstr "邮件发送失败。请检查邮件服务器设置，并确定设置无误。"
-
-#: airtime_mvc/application/controllers/LoginController.php:173
-msgid "There was a problem with the username or email address you entered."
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:244
-#: airtime_mvc/application/controllers/ApiController.php:317
-#: airtime_mvc/application/controllers/ApiController.php:392
-#: airtime_mvc/application/controllers/ApiController.php:435
-#: airtime_mvc/application/controllers/ApiController.php:474
-#: airtime_mvc/application/controllers/ApiController.php:507
-msgid "You are not allowed to access this resource. "
-msgstr "你没有访问该资源的权限"
-
-#: airtime_mvc/application/controllers/ApiController.php:698
-#: airtime_mvc/application/controllers/ApiController.php:718
-#: airtime_mvc/application/controllers/ApiController.php:730
-#, php-format
-msgid "File does not exist in %s"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ApiController.php:781
-msgid "Bad request. no 'mode' parameter passed."
-msgstr "请求错误。没有提供‘模式’参数。"
-
-#: airtime_mvc/application/controllers/ApiController.php:791
-msgid "Bad request. 'mode' parameter is invalid"
-msgstr "请求错误。提供的‘模式’参数无效。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:30
-#: airtime_mvc/application/layouts/scripts/audio-player.phtml:5
-msgid "Audio Player"
-msgstr "音频播放器"
-
-#: airtime_mvc/application/controllers/LocaleController.php:32
-msgid "Recording:"
-msgstr "录制："
-
-#: airtime_mvc/application/controllers/LocaleController.php:33
-msgid "Master Stream"
-msgstr "主输入源"
-
-#: airtime_mvc/application/controllers/LocaleController.php:34
-msgid "Live Stream"
-msgstr "节目定制输入源"
-
-#: airtime_mvc/application/controllers/LocaleController.php:35
-msgid "Nothing Scheduled"
-msgstr "没有安排节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:36
-msgid "Current Show:"
-msgstr "当前节目："
-
-#: airtime_mvc/application/controllers/LocaleController.php:37
-msgid "Current"
-msgstr "当前的"
-
-#: airtime_mvc/application/controllers/LocaleController.php:39
-msgid "You are running the latest version"
-msgstr "你已经在使用最新版"
-
-#: airtime_mvc/application/controllers/LocaleController.php:40
-msgid "New version available: "
-msgstr "版本有更新："
-
-#: airtime_mvc/application/controllers/LocaleController.php:41
-msgid "This version will soon be obsolete."
-msgstr "这个版本即将过时。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:42
-msgid "This version is no longer supported."
-msgstr "这个版本即将停支持。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:43
-msgid "Please upgrade to "
-msgstr "请升级到"
-
-#: airtime_mvc/application/controllers/LocaleController.php:45
-msgid "Add to current playlist"
-msgstr "添加到播放列表"
-
-#: airtime_mvc/application/controllers/LocaleController.php:46
-msgid "Add to current smart block"
-msgstr "添加到只能模块"
-
-#: airtime_mvc/application/controllers/LocaleController.php:47
-msgid "Adding 1 Item"
-msgstr "添加1项"
-
-#: airtime_mvc/application/controllers/LocaleController.php:48
-#, php-format
-msgid "Adding %s Items"
-msgstr "添加%s项"
-
-#: airtime_mvc/application/controllers/LocaleController.php:49
-msgid "You can only add tracks to smart blocks."
-msgstr "智能模块只能添加声音文件。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:53
-msgid "Please select a cursor position on timeline."
-msgstr "请在右部的时间表视图中选择一个游标位置。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:54
-msgid "You haven't added any tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:55
-msgid "You haven't added any playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:56
-msgid "You haven't added any smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:57
-msgid "You haven't added any webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:58
-msgid "Learn about tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:59
-msgid "Learn about playlists"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:60
-msgid "Learn about smart blocks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:61
-msgid "Learn about webstreams"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:62
-msgid "Click 'New' to create one."
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:67
-msgid "Add to selected show"
-msgstr "添加到所选的节目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:68
-msgid "Select"
-msgstr "选择"
-
-#: airtime_mvc/application/controllers/LocaleController.php:69
-msgid "Select this page"
-msgstr "选择此页"
-
-#: airtime_mvc/application/controllers/LocaleController.php:70
-msgid "Deselect this page"
-msgstr "取消整页"
-
-#: airtime_mvc/application/controllers/LocaleController.php:71
-msgid "Deselect all"
-msgstr "全部取消"
-
-#: airtime_mvc/application/controllers/LocaleController.php:72
-msgid "Are you sure you want to delete the selected item(s)?"
-msgstr "确定删除选择的项？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:73
-msgid "Scheduled"
-msgstr "已安排进日程"
-
-#: airtime_mvc/application/controllers/LocaleController.php:74
-#: airtime_mvc/application/layouts/scripts/layout.phtml:78
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:7
-msgid "Tracks"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:75
-#: airtime_mvc/application/layouts/scripts/layout.phtml:60
-msgid "Playlist"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:79
-msgid "Bit Rate"
-msgstr "比特率"
-
-#: airtime_mvc/application/controllers/LocaleController.php:80
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
-#: airtime_mvc/application/models/Block.php:1354
-msgid "BPM"
-msgstr "每分钟拍子数"
-
-#: airtime_mvc/application/controllers/LocaleController.php:84
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
-#: airtime_mvc/application/models/Block.php:1361
-msgid "Encoded By"
-msgstr "编曲"
-
-#: airtime_mvc/application/controllers/LocaleController.php:89
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:64
-#: airtime_mvc/application/models/Block.php:1367
-msgid "Last Modified"
-msgstr "最近更新于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:90
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:65
-#: airtime_mvc/application/models/Block.php:1368
-msgid "Last Played"
-msgstr "上次播放于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:67
-#: airtime_mvc/application/models/Block.php:1370
-msgid "Mime"
-msgstr "MIME信息"
-
-#: airtime_mvc/application/controllers/LocaleController.php:94
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:69
-#: airtime_mvc/application/models/Block.php:1372
-msgid "Owner"
-msgstr "所有者"
-
-#: airtime_mvc/application/controllers/LocaleController.php:95
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:70
-#: airtime_mvc/application/models/Block.php:1373
-msgid "Replay Gain"
-msgstr "回放增益"
-
-#: airtime_mvc/application/controllers/LocaleController.php:96
-msgid "Sample Rate"
-msgstr "样本率"
-
-#: airtime_mvc/application/controllers/LocaleController.php:97
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
-#: airtime_mvc/application/models/Block.php:1376
-msgid "Track Number"
-msgstr "曲目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:98
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:74
-#: airtime_mvc/application/models/Block.php:1377
-msgid "Uploaded"
-msgstr "上传于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:99
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:75
-#: airtime_mvc/application/models/Block.php:1378
-msgid "Website"
-msgstr "网址"
-
-#: airtime_mvc/application/controllers/LocaleController.php:101
-msgid "Loading..."
-msgstr "加载中..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:102
-#: airtime_mvc/application/controllers/LocaleController.php:404
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:65
-msgid "All"
-msgstr "全部"
-
-#: airtime_mvc/application/controllers/LocaleController.php:103
-msgid "Files"
-msgstr "文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:104
-#: airtime_mvc/application/layouts/scripts/layout.phtml:80
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:13
-msgid "Playlists"
-msgstr "播放列表"
-
-#: airtime_mvc/application/controllers/LocaleController.php:105
-#: airtime_mvc/application/layouts/scripts/layout.phtml:82
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:19
-msgid "Smart Blocks"
-msgstr "智能模块"
-
-#: airtime_mvc/application/controllers/LocaleController.php:106
-msgid "Web Streams"
-msgstr "网络流媒体"
-
-#: airtime_mvc/application/controllers/LocaleController.php:107
-msgid "Unknown type: "
-msgstr "位置类型："
-
-#: airtime_mvc/application/controllers/LocaleController.php:108
-msgid "Are you sure you want to delete the selected item?"
-msgstr "确定删除所选项？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:109
-#: airtime_mvc/application/controllers/LocaleController.php:209
-msgid "Uploading in progress..."
-msgstr "正在上传..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:110
-msgid "Retrieving data from the server..."
-msgstr "数据正在从服务器下载中..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:111
-msgid "The soundcloud id for this file is: "
-msgstr "文件的SoundCloud编号是："
-
-#: airtime_mvc/application/controllers/LocaleController.php:112
-msgid "There was an error while uploading to soundcloud."
-msgstr "文件上传到SoundCloud时发生错误"
-
-#: airtime_mvc/application/controllers/LocaleController.php:113
-msgid "Error code: "
-msgstr "错误代码："
-
-#: airtime_mvc/application/controllers/LocaleController.php:114
-msgid "Error msg: "
-msgstr "错误信息："
-
-#: airtime_mvc/application/controllers/LocaleController.php:115
-msgid "Input must be a positive number"
-msgstr "输入只能为正数"
-
-#: airtime_mvc/application/controllers/LocaleController.php:116
-msgid "Input must be a number"
-msgstr "只允许数字输入"
-
-#: airtime_mvc/application/controllers/LocaleController.php:117
-msgid "Input must be in the format: yyyy-mm-dd"
-msgstr "输入格式应为：年-月-日（yyyy-mm-dd）"
-
-#: airtime_mvc/application/controllers/LocaleController.php:118
-msgid "Input must be in the format: hh:mm:ss.t"
-msgstr "输入格式应为：时:分:秒 （hh:mm:ss.t）"
-
-#: airtime_mvc/application/controllers/LocaleController.php:121
-#, php-format
-msgid ""
-"You are currently uploading files. %sGoing to another screen will cancel the"
-" upload process. %sAre you sure you want to leave the page?"
-msgstr "你正在上传文件。%s如果离开此页，上传过程将被打断。%s确定离开吗？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:123
-msgid "Open Media Builder"
-msgstr "打开媒体编辑器"
-
-#: airtime_mvc/application/controllers/LocaleController.php:124
-msgid "please put in a time '00:00:00 (.0)'"
-msgstr "请输入时间‘00:00:00（.0）’"
-
-#: airtime_mvc/application/controllers/LocaleController.php:125
-msgid "please put in a time in seconds '00 (.0)'"
-msgstr "请输入秒数‘00（.0）’"
-
-#: airtime_mvc/application/controllers/LocaleController.php:126
-msgid "Your browser does not support playing this file type: "
-msgstr "你的浏览器不支持这种文件类型："
-
-#: airtime_mvc/application/controllers/LocaleController.php:127
-msgid "Dynamic block is not previewable"
-msgstr "动态智能模块无法预览"
-
-#: airtime_mvc/application/controllers/LocaleController.php:128
-msgid "Limit to: "
-msgstr "限制在："
-
-#: airtime_mvc/application/controllers/LocaleController.php:129
-msgid "Playlist saved"
-msgstr "播放列表已存储"
-
-#: airtime_mvc/application/controllers/LocaleController.php:130
-msgid "Playlist shuffled"
-msgstr "播放列表已经随机化"
-
-#: airtime_mvc/application/controllers/LocaleController.php:132
-msgid ""
-"Airtime is unsure about the status of this file. This can happen when the "
-"file is on a remote drive that is unaccessible or the file is in a directory"
-" that isn't 'watched' anymore."
-msgstr "文件的状态不可知。这可能是由于文件位于远程存储位置，或者所在的文件夹已经不再监控。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:134
-#, php-format
-msgid "Listener Count on %s: %s"
-msgstr "听众统计%s：%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:136
-msgid "Remind me in 1 week"
-msgstr "一周以后再提醒我"
-
-#: airtime_mvc/application/controllers/LocaleController.php:137
-msgid "Remind me never"
-msgstr "不再提醒"
-
-#: airtime_mvc/application/controllers/LocaleController.php:138
-msgid "Yes, help Airtime"
-msgstr "是的，帮助Airtime"
-
-#: airtime_mvc/application/controllers/LocaleController.php:139
-#: airtime_mvc/application/controllers/LocaleController.php:187
-msgid "Image must be one of jpg, jpeg, png, or gif"
-msgstr "图像文件格式只能是jpg，jpeg，png或者gif"
-
-#: airtime_mvc/application/controllers/LocaleController.php:142
-msgid ""
-"A static smart block will save the criteria and generate the block content "
-"immediately. This allows you to edit and view it in the Library before "
-"adding it to a show."
-msgstr "静态的智能模块将会保存条件设置并且马上生成所有内容。这样就可以让你在添加到节目中前，还可以编辑和预览该智能模块。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:144
-msgid ""
-"A dynamic smart block will only save the criteria. The block content will "
-"get generated upon adding it to a show. You will not be able to view and "
-"edit the content in the Library."
-msgstr "动态的智能模块将只保存条件设置。而模块的内容将在每次添加到节目中是动态生成。在媒体库中，你不能直接编辑和预览动态智能模块。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:146
-msgid ""
-"The desired block length will not be reached if Airtime cannot find enough "
-"unique tracks to match your criteria. Enable this option if you wish to "
-"allow tracks to be added multiple times to the smart block."
-msgstr "因为满足条件的声音文件数量有限，只能播放列表指定的时长可能无法达成。如果你不介意出现重复的项目，你可以启用此项。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:147
-msgid "Smart block shuffled"
-msgstr "智能模块已经随机排列"
-
-#: airtime_mvc/application/controllers/LocaleController.php:148
-msgid "Smart block generated and criteria saved"
-msgstr "智能模块已经生成，条件设置已经保存"
-
-#: airtime_mvc/application/controllers/LocaleController.php:149
-msgid "Smart block saved"
-msgstr "智能模块已经保存"
-
-#: airtime_mvc/application/controllers/LocaleController.php:150
-msgid "Processing..."
-msgstr "加载中..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:151
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:88
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:104
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:263
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:392
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:430
-#: airtime_mvc/application/models/Block.php:1383
-msgid "Select modifier"
-msgstr "选择操作符"
-
-#: airtime_mvc/application/controllers/LocaleController.php:152
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:89
-#: airtime_mvc/application/models/Block.php:1384
-msgid "contains"
-msgstr "包含"
-
-#: airtime_mvc/application/controllers/LocaleController.php:153
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:90
-#: airtime_mvc/application/models/Block.php:1385
-msgid "does not contain"
-msgstr "不包含"
-
-#: airtime_mvc/application/controllers/LocaleController.php:154
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:91
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:105
-#: airtime_mvc/application/models/Block.php:1386
-#: airtime_mvc/application/models/Block.php:1390
-msgid "is"
-msgstr "是"
-
-#: airtime_mvc/application/controllers/LocaleController.php:155
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:92
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:106
-#: airtime_mvc/application/models/Block.php:1387
-#: airtime_mvc/application/models/Block.php:1391
-msgid "is not"
-msgstr "不是"
-
-#: airtime_mvc/application/controllers/LocaleController.php:156
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:93
-#: airtime_mvc/application/models/Block.php:1388
-msgid "starts with"
-msgstr "起始于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:157
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:94
-#: airtime_mvc/application/models/Block.php:1389
-msgid "ends with"
-msgstr "结束于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:158
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:107
-#: airtime_mvc/application/models/Block.php:1392
-msgid "is greater than"
-msgstr "大于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:159
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:108
-#: airtime_mvc/application/models/Block.php:1393
-msgid "is less than"
-msgstr "小于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:160
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:109
-#: airtime_mvc/application/models/Block.php:1394
-msgid "is in the range"
-msgstr "处于"
-
-#: airtime_mvc/application/controllers/LocaleController.php:162
-msgid "Choose Storage Folder"
-msgstr "选择存储文件夹"
-
-#: airtime_mvc/application/controllers/LocaleController.php:163
-msgid "Choose Folder to Watch"
-msgstr "选择监控的文件夹"
-
-#: airtime_mvc/application/controllers/LocaleController.php:165
-msgid ""
-"Are you sure you want to change the storage folder?\n"
-"This will remove the files from your Airtime library!"
-msgstr "确定更改存储路径？\n这项操作将从媒体库中删除所有文件！"
-
-#: airtime_mvc/application/controllers/LocaleController.php:166
-#: airtime_mvc/application/views/scripts/preference/directory-config.phtml:2
-msgid "Manage Media Folders"
-msgstr "管理媒体文件夹"
-
-#: airtime_mvc/application/controllers/LocaleController.php:167
-msgid "Are you sure you want to remove the watched folder?"
-msgstr "确定取消该文件夹的监控？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:168
-msgid "This path is currently not accessible."
-msgstr "指定的路径无法访问。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:170
-#, php-format
-msgid ""
-"Some stream types require extra configuration. Details about enabling %sAAC+"
-" Support%s or %sOpus Support%s are provided."
-msgstr "某些类型的输出流需要第三方软件的设置，具体步骤如下：%sAAC+%s 和 %sOpus%s。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:171
-msgid "Connected to the streaming server"
-msgstr "流服务器已连接"
-
-#: airtime_mvc/application/controllers/LocaleController.php:172
-msgid "The stream is disabled"
-msgstr "输出流已禁用"
-
-#: airtime_mvc/application/controllers/LocaleController.php:173
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:191
-msgid "Getting information from the server..."
-msgstr "从服务器加载中..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:174
-msgid "Can not connect to the streaming server"
-msgstr "无法连接流服务器"
-
-#: airtime_mvc/application/controllers/LocaleController.php:176
-msgid ""
-"If Airtime is behind a router or firewall, you may need to configure port "
-"forwarding and this field information will be incorrect. In this case you "
-"will need to manually update this field so it shows the correct "
-"host/port/mount that your DJ's need to connect to. The allowed range is "
-"between 1024 and 49151."
-msgstr "如果Airtime配置在路由器或者防火墙之后，你可能需要配置端口转发，所以当前文本框内的信息需要调整。在这种情况下，就需要人工指定该信息以确定所显示的主机名/端口/加载点的正确性，从而让节目编辑能连接的上。端口所允许的范围，介于1024到49151之间。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:177
-#, php-format
-msgid "For more details, please read the %sAirtime Manual%s"
-msgstr "更多的细节可以参阅%sAirtime用户手册%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:179
-msgid ""
-"Check this option to enable metadata for OGG streams (stream metadata is the"
-" track title, artist, and show name that is displayed in an audio player). "
-"VLC and mplayer have a serious bug when playing an OGG/VORBIS stream that "
-"has metadata information enabled: they will disconnect from the stream after"
-" every song. If you are using an OGG stream and your listeners do not "
-"require support for these audio players, then feel free to enable this "
-"option."
-msgstr "勾选此项会启用OGG格式流媒体的元数据（流的元数据包括歌曲名，歌手/作者，节目名，这些都会显示在音频播放器中。）VLC和mplayer有个已知的问题，他们在播放OGG/VORBIS媒体流时，如果该流已启用元数据，那么在每首歌的间隙都会断开流。所以，如果你使用OGG媒体流，同时你的听众不使用上述媒体播放器的话，你可以随意地勾选此项。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:180
-msgid ""
-"Check this box to automatically switch off Master/Show source upon source "
-"disconnection."
-msgstr "勾选此项后，在输入流断开时，主输入源和节目定制输入源将会自动切换为关闭状态。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:181
-msgid ""
-"Check this box to automatically switch on Master/Show source upon source "
-"connection."
-msgstr "勾选此项后，在输入流连接上时，主输入源和节目定制输入源将会自动切换到开启状态。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:182
-msgid ""
-"If your Icecast server expects a username of 'source', this field can be "
-"left blank."
-msgstr "如果你的Icecast服务器所要求的用户名是‘source’，那么当前项可以留空。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:183
-#: airtime_mvc/application/controllers/LocaleController.php:193
-msgid ""
-"If your live streaming client does not ask for a username, this field should"
-" be 'source'."
-msgstr "如果你的流客户端不需要用户名，那么当前项可以留空"
-
-#: airtime_mvc/application/controllers/LocaleController.php:184
-msgid ""
-"WARNING: This will restart your stream and may cause a short dropout for "
-"your listeners!"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:185
-msgid ""
-"This is the admin username and password for Icecast/SHOUTcast to get "
-"listener statistics."
-msgstr "此处填写Icecast或者SHOUTcast的管理员用户名和密码，用于获取收听数据的统计。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:189
-msgid ""
-"Warning: You cannot change this field while the show is currently playing"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:190
-msgid "No result found"
-msgstr "搜索无结果"
-
-#: airtime_mvc/application/controllers/LocaleController.php:191
-msgid ""
-"This follows the same security pattern for the shows: only users assigned to"
-" the show can connect."
-msgstr "当前遵循与节目同样的安全模式：只有指定到当前节目的用户才能连接的上。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:192
-msgid "Specify custom authentication which will work only for this show."
-msgstr "所设置的自定义认证设置只对当前的节目有效。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:194
-msgid "The show instance doesn't exist anymore!"
-msgstr "此节目已不存在"
-
-#: airtime_mvc/application/controllers/LocaleController.php:195
-msgid "Warning: Shows cannot be re-linked"
-msgstr "注意：节目取消绑定后无法再次绑定"
-
-#: airtime_mvc/application/controllers/LocaleController.php:196
-msgid ""
-"By linking your repeating shows any media items scheduled in any repeat show"
-" will also get scheduled in the other repeat shows"
-msgstr "系列节目勾选绑定后，所有节目的内容都会一模一样，对任何未开始节目的更改都会影响到其他节目。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:197
-msgid ""
-"Timezone is set to the station timezone by default. Shows in the calendar "
-"will be displayed in your local time defined by the Interface Timezone in "
-"your user settings."
-msgstr "此时区设定的默认值是系统的时区设置。日程表中的节目时间则已用户定义的界面显示时区为准，两者可能有所不同。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:201
-msgid "Show"
-msgstr "节目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:202
-msgid "Show is empty"
-msgstr "节目内容为空"
-
-#: airtime_mvc/application/controllers/LocaleController.php:203
-msgid "1m"
-msgstr "1分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:204
-msgid "5m"
-msgstr "5分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:205
-msgid "10m"
-msgstr "10分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:206
-msgid "15m"
-msgstr "15分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:207
-msgid "30m"
-msgstr "30分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:208
-msgid "60m"
-msgstr "60分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:210
-msgid "Retreiving data from the server..."
-msgstr "从服务器下载数据中..."
-
-#: airtime_mvc/application/controllers/LocaleController.php:216
-msgid "This show has no scheduled content."
-msgstr "此节目没有安排内容。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:217
-msgid "This show is not completely filled with content."
-msgstr "节目内容只填充了一部分。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:221
-msgid "January"
-msgstr "一月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:222
-msgid "February"
-msgstr "二月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:223
-msgid "March"
-msgstr "三月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:224
-msgid "April"
-msgstr "四月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:225
-#: airtime_mvc/application/controllers/LocaleController.php:237
-msgid "May"
-msgstr "五月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:226
-msgid "June"
-msgstr "六月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:227
-msgid "July"
-msgstr "七月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:228
-msgid "August"
-msgstr "八月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:229
-msgid "September"
-msgstr "九月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:230
-msgid "October"
-msgstr "十月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:231
-msgid "November"
-msgstr "十一月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:232
-msgid "December"
-msgstr "十二月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:233
-msgid "Jan"
-msgstr "一月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:234
-msgid "Feb"
-msgstr "二月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:235
-msgid "Mar"
-msgstr "三月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:236
-msgid "Apr"
-msgstr "四月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:238
-msgid "Jun"
-msgstr "六月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:239
-msgid "Jul"
-msgstr "七月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:240
-msgid "Aug"
-msgstr "八月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:241
-msgid "Sep"
-msgstr "九月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:242
-msgid "Oct"
-msgstr "十月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:243
-msgid "Nov"
-msgstr "十一月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:244
-msgid "Dec"
-msgstr "十二月"
-
-#: airtime_mvc/application/controllers/LocaleController.php:245
-msgid "Today"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:246
-msgid "Day"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:247
-msgid "Week"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:248
-msgid "Month"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:249
-#: airtime_mvc/application/forms/GeneralPreferences.php:158
-msgid "Sunday"
-msgstr "周日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:250
-#: airtime_mvc/application/forms/GeneralPreferences.php:159
-msgid "Monday"
-msgstr "周一"
-
-#: airtime_mvc/application/controllers/LocaleController.php:251
-#: airtime_mvc/application/forms/GeneralPreferences.php:160
-msgid "Tuesday"
-msgstr "周二"
-
-#: airtime_mvc/application/controllers/LocaleController.php:252
-#: airtime_mvc/application/forms/GeneralPreferences.php:161
-msgid "Wednesday"
-msgstr "周三"
-
-#: airtime_mvc/application/controllers/LocaleController.php:253
-#: airtime_mvc/application/forms/GeneralPreferences.php:162
-msgid "Thursday"
-msgstr "周四"
-
-#: airtime_mvc/application/controllers/LocaleController.php:254
-#: airtime_mvc/application/forms/GeneralPreferences.php:163
-msgid "Friday"
-msgstr "周五"
-
-#: airtime_mvc/application/controllers/LocaleController.php:255
-#: airtime_mvc/application/forms/GeneralPreferences.php:164
-msgid "Saturday"
-msgstr "周六"
-
-#: airtime_mvc/application/controllers/LocaleController.php:256
-#: airtime_mvc/application/forms/AddShowRepeats.php:35
-msgid "Sun"
-msgstr "周日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:257
-#: airtime_mvc/application/forms/AddShowRepeats.php:36
-msgid "Mon"
-msgstr "周一"
-
-#: airtime_mvc/application/controllers/LocaleController.php:258
-#: airtime_mvc/application/forms/AddShowRepeats.php:37
-msgid "Tue"
-msgstr "周二"
-
-#: airtime_mvc/application/controllers/LocaleController.php:259
-#: airtime_mvc/application/forms/AddShowRepeats.php:38
-msgid "Wed"
-msgstr "周三"
-
-#: airtime_mvc/application/controllers/LocaleController.php:260
-#: airtime_mvc/application/forms/AddShowRepeats.php:39
-msgid "Thu"
-msgstr "周四"
-
-#: airtime_mvc/application/controllers/LocaleController.php:261
-#: airtime_mvc/application/forms/AddShowRepeats.php:40
-msgid "Fri"
-msgstr "周五"
-
-#: airtime_mvc/application/controllers/LocaleController.php:262
-#: airtime_mvc/application/forms/AddShowRepeats.php:41
-msgid "Sat"
-msgstr "周六"
-
-#: airtime_mvc/application/controllers/LocaleController.php:263
-msgid ""
-"Shows longer than their scheduled time will be cut off by a following show."
-msgstr "超出的节目内容将被随后的节目所取代。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:264
-msgid "Cancel Current Show?"
-msgstr "取消当前的节目？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:265
-#: airtime_mvc/application/controllers/LocaleController.php:312
-msgid "Stop recording current show?"
-msgstr "停止录制当前的节目？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:266
-msgid "Ok"
-msgstr "确定"
-
-#: airtime_mvc/application/controllers/LocaleController.php:267
-msgid "Contents of Show"
-msgstr "浏览节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:270
-msgid "Remove all content?"
-msgstr "清空全部内容？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:272
-msgid "Delete selected item(s)?"
-msgstr "删除选定的项目？"
-
-#: airtime_mvc/application/controllers/LocaleController.php:273
-#: airtime_mvc/application/views/scripts/schedule/show-content-dialog.phtml:5
-msgid "Start"
-msgstr "开始"
-
-#: airtime_mvc/application/controllers/LocaleController.php:274
-msgid "End"
-msgstr "结束"
-
-#: airtime_mvc/application/controllers/LocaleController.php:275
-msgid "Duration"
-msgstr "时长"
-
-#: airtime_mvc/application/controllers/LocaleController.php:276
-msgid "Filtering out "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:277
-msgid " of "
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:278
-msgid " records"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:284
-#: airtime_mvc/application/layouts/scripts/layout.phtml:140
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:56
-#: airtime_mvc/application/models/Block.php:1358
-msgid "Cue In"
-msgstr "切入"
-
-#: airtime_mvc/application/controllers/LocaleController.php:285
-#: airtime_mvc/application/layouts/scripts/layout.phtml:147
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:57
-#: airtime_mvc/application/models/Block.php:1359
-msgid "Cue Out"
-msgstr "切出"
-
-#: airtime_mvc/application/controllers/LocaleController.php:286
-#: airtime_mvc/application/layouts/scripts/layout.phtml:167
-msgid "Fade In"
-msgstr "淡入"
-
-#: airtime_mvc/application/controllers/LocaleController.php:287
-#: airtime_mvc/application/layouts/scripts/layout.phtml:168
-msgid "Fade Out"
-msgstr "淡出"
-
-#: airtime_mvc/application/controllers/LocaleController.php:288
-msgid "Show Empty"
-msgstr "节目无内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:289
-msgid "Recording From Line In"
-msgstr "从线路输入录制"
-
-#: airtime_mvc/application/controllers/LocaleController.php:290
-msgid "Track preview"
-msgstr "试听媒体"
-
-#: airtime_mvc/application/controllers/LocaleController.php:294
-msgid "Cannot schedule outside a show."
-msgstr "没有指定节目，无法凭空安排内容。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:295
-msgid "Moving 1 Item"
-msgstr "移动1个项目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:296
-#, php-format
-msgid "Moving %s Items"
-msgstr "移动%s个项目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:297
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:86
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:5
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:118
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:173
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:85
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:48
-#: airtime_mvc/application/forms/Preferences.php:40
-#: airtime_mvc/application/forms/EditHistory.php:131
-#: airtime_mvc/application/forms/AddUser.php:110
-#: airtime_mvc/application/forms/PasswordChange.php:43
-#: airtime_mvc/application/forms/SupportSettings.php:131
-msgid "Save"
-msgstr "保存"
-
-#: airtime_mvc/application/controllers/LocaleController.php:298
-#: airtime_mvc/application/controllers/LocaleController.php:321
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:75
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:83
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:45
-#: airtime_mvc/application/forms/EditHistory.php:141
-#: airtime_mvc/application/forms/EditAudioMD.php:186
-msgid "Cancel"
-msgstr "取消"
-
-#: airtime_mvc/application/controllers/LocaleController.php:299
-msgid "Fade Editor"
-msgstr "淡入淡出编辑器"
-
-#: airtime_mvc/application/controllers/LocaleController.php:300
-msgid "Cue Editor"
-msgstr "切入切出编辑器"
-
-#: airtime_mvc/application/controllers/LocaleController.php:301
-msgid ""
-"Waveform features are available in a browser supporting the Web Audio API"
-msgstr "想要启用波形图功能，需要支持Web Audio API的浏览器。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:304
-msgid "Select all"
-msgstr "全选"
-
-#: airtime_mvc/application/controllers/LocaleController.php:305
-msgid "Select none"
-msgstr "全不选"
-
-#: airtime_mvc/application/controllers/LocaleController.php:306
-msgid "Trim overbooked shows"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:307
-msgid "Remove selected scheduled items"
-msgstr "移除所选的项目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:308
-msgid "Jump to the current playing track"
-msgstr "跳转到当前播放的项目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:309
-msgid "Cancel current show"
-msgstr "取消当前的节目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:314
-msgid "Open library to add or remove content"
-msgstr "打开媒体库，添加或者删除节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:315
-msgid "Add / Remove Content"
-msgstr "添加 / 删除内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:317
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:49
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:203
-msgid "in use"
-msgstr "使用中"
-
-#: airtime_mvc/application/controllers/LocaleController.php:318
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:189
-msgid "Disk"
-msgstr "磁盘"
-
-#: airtime_mvc/application/controllers/LocaleController.php:320
-msgid "Look in"
-msgstr "查询"
-
-#: airtime_mvc/application/controllers/LocaleController.php:322
-msgid "Open"
-msgstr "打开"
-
-#: airtime_mvc/application/controllers/LocaleController.php:324
-#: airtime_mvc/application/forms/AddUser.php:102
-msgid "Admin"
-msgstr "系统管理员"
-
-#: airtime_mvc/application/controllers/LocaleController.php:325
-#: airtime_mvc/application/forms/AddUser.php:100
-msgid "DJ"
-msgstr "节目编辑"
-
-#: airtime_mvc/application/controllers/LocaleController.php:326
-#: airtime_mvc/application/forms/AddUser.php:101
-msgid "Program Manager"
-msgstr "节目主管"
-
-#: airtime_mvc/application/controllers/LocaleController.php:327
-#: airtime_mvc/application/forms/AddUser.php:99
-msgid "Guest"
-msgstr "游客"
-
-#: airtime_mvc/application/controllers/LocaleController.php:328
-msgid "Guests can do the following:"
-msgstr "游客的权限包括："
-
-#: airtime_mvc/application/controllers/LocaleController.php:329
-msgid "View schedule"
-msgstr "显示节目日程"
-
-#: airtime_mvc/application/controllers/LocaleController.php:330
-msgid "View show content"
-msgstr "显示节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:331
-msgid "DJs can do the following:"
-msgstr "节目编辑的权限包括："
-
-#: airtime_mvc/application/controllers/LocaleController.php:332
-msgid "Manage assigned show content"
-msgstr "为指派的节目管理节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:333
-msgid "Import media files"
-msgstr "导入媒体文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:334
-msgid "Create playlists, smart blocks, and webstreams"
-msgstr "创建播放列表，智能模块和网络流媒体"
-
-#: airtime_mvc/application/controllers/LocaleController.php:335
-msgid "Manage their own library content"
-msgstr "管理媒体库中属于自己的内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:336
-msgid "Progam Managers can do the following:"
-msgstr "节目主管的权限是："
-
-#: airtime_mvc/application/controllers/LocaleController.php:337
-msgid "View and manage show content"
-msgstr "查看和管理节目内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:338
-msgid "Schedule shows"
-msgstr "安排节目日程"
-
-#: airtime_mvc/application/controllers/LocaleController.php:339
-msgid "Manage all library content"
-msgstr "管理媒体库的所有内容"
-
-#: airtime_mvc/application/controllers/LocaleController.php:340
-msgid "Admins can do the following:"
-msgstr "管理员的权限包括："
-
-#: airtime_mvc/application/controllers/LocaleController.php:341
-msgid "Manage preferences"
-msgstr "属性管理"
-
-#: airtime_mvc/application/controllers/LocaleController.php:342
-msgid "Manage users"
-msgstr "管理用户"
-
-#: airtime_mvc/application/controllers/LocaleController.php:343
-msgid "Manage watched folders"
-msgstr "管理监控文件夹"
-
-#: airtime_mvc/application/controllers/LocaleController.php:344
-#: airtime_mvc/application/forms/RegisterAirtime.php:116
-#: airtime_mvc/application/forms/SupportSettings.php:98
-msgid "Send support feedback"
-msgstr "提交反馈意见"
-
-#: airtime_mvc/application/controllers/LocaleController.php:345
-msgid "View system status"
-msgstr "显示系统状态"
-
-#: airtime_mvc/application/controllers/LocaleController.php:346
-msgid "Access playout history"
-msgstr "查看播放历史"
-
-#: airtime_mvc/application/controllers/LocaleController.php:347
-msgid "View listener stats"
-msgstr "显示收听统计数据"
-
-#: airtime_mvc/application/controllers/LocaleController.php:349
-msgid "Show / hide columns"
-msgstr "显示/隐藏栏"
-
-#: airtime_mvc/application/controllers/LocaleController.php:351
-msgid "From {from} to {to}"
-msgstr "从{from}到{to}"
-
-#: airtime_mvc/application/controllers/LocaleController.php:352
-msgid "kbps"
-msgstr "千比特每秒"
-
-#: airtime_mvc/application/controllers/LocaleController.php:353
-msgid "yyyy-mm-dd"
-msgstr "年-月-日"
-
-#: airtime_mvc/application/controllers/LocaleController.php:354
-msgid "hh:mm:ss.t"
-msgstr "时:分:秒"
-
-#: airtime_mvc/application/controllers/LocaleController.php:355
-msgid "kHz"
-msgstr "千赫兹"
-
-#: airtime_mvc/application/controllers/LocaleController.php:358
-msgid "Su"
-msgstr "周天"
-
-#: airtime_mvc/application/controllers/LocaleController.php:359
-msgid "Mo"
-msgstr "周一"
-
-#: airtime_mvc/application/controllers/LocaleController.php:360
-msgid "Tu"
-msgstr "周二"
-
-#: airtime_mvc/application/controllers/LocaleController.php:361
-msgid "We"
-msgstr "周三"
-
-#: airtime_mvc/application/controllers/LocaleController.php:362
-msgid "Th"
-msgstr "周四"
-
-#: airtime_mvc/application/controllers/LocaleController.php:363
-msgid "Fr"
-msgstr "周五"
-
-#: airtime_mvc/application/controllers/LocaleController.php:364
-msgid "Sa"
-msgstr "周六"
-
-#: airtime_mvc/application/controllers/LocaleController.php:365
-#: airtime_mvc/application/controllers/LocaleController.php:393
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:3
-msgid "Close"
-msgstr "关闭"
-
-#: airtime_mvc/application/controllers/LocaleController.php:367
-msgid "Hour"
-msgstr "小时"
-
-#: airtime_mvc/application/controllers/LocaleController.php:368
-msgid "Minute"
-msgstr "分钟"
-
-#: airtime_mvc/application/controllers/LocaleController.php:369
-msgid "Done"
-msgstr "设定"
-
-#: airtime_mvc/application/controllers/LocaleController.php:372
-msgid "Select files"
-msgstr "选择文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:373
-#: airtime_mvc/application/controllers/LocaleController.php:374
-msgid "Add files to the upload queue and click the start button."
-msgstr "添加需要上传的文件到传输队列中，然后点击开始上传。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:375
-#: airtime_mvc/application/controllers/LocaleController.php:376
-msgid "Status"
-msgstr "系统状态"
-
-#: airtime_mvc/application/controllers/LocaleController.php:377
-msgid "Add Files"
-msgstr "添加文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:378
-msgid "Stop Upload"
-msgstr "停止上传"
-
-#: airtime_mvc/application/controllers/LocaleController.php:379
-msgid "Start upload"
-msgstr "开始上传"
-
-#: airtime_mvc/application/controllers/LocaleController.php:380
-msgid "Add files"
-msgstr "添加文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:381
-#, php-format
-msgid "Uploaded %d/%d files"
-msgstr "已经上传%d/%d个文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:382
-msgid "N/A"
-msgstr "未知"
-
-#: airtime_mvc/application/controllers/LocaleController.php:383
-msgid "Drag files here."
-msgstr "拖拽文件到此处。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:384
-msgid "File extension error."
-msgstr "文件后缀名出错。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:385
-msgid "File size error."
-msgstr "文件大小出错。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:386
-msgid "File count error."
-msgstr "发生文件统计错误。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:387
-msgid "Init error."
-msgstr "发生初始化错误。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:388
-msgid "HTTP Error."
-msgstr "发生HTTP类型的错误"
-
-#: airtime_mvc/application/controllers/LocaleController.php:389
-msgid "Security error."
-msgstr "发生安全性错误。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:390
-msgid "Generic error."
-msgstr "发生通用类型的错误。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:391
-msgid "IO error."
-msgstr "输入输出错误。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:392
-#, php-format
-msgid "File: %s"
-msgstr "文件：%s"
-
-#: airtime_mvc/application/controllers/LocaleController.php:394
-#, php-format
-msgid "%d files queued"
-msgstr "队列中有%d个文件"
-
-#: airtime_mvc/application/controllers/LocaleController.php:395
-msgid "File: %f, size: %s, max file size: %m"
-msgstr "文件：%f，大小：%s，最大的文件大小：%m"
-
-#: airtime_mvc/application/controllers/LocaleController.php:396
-msgid "Upload URL might be wrong or doesn't exist"
-msgstr "用于上传的地址有误或者不存在"
-
-#: airtime_mvc/application/controllers/LocaleController.php:397
-msgid "Error: File too large: "
-msgstr "错误：文件过大："
-
-#: airtime_mvc/application/controllers/LocaleController.php:398
-msgid "Error: Invalid file extension: "
-msgstr "错误：无效的文件后缀名："
-
-#: airtime_mvc/application/controllers/LocaleController.php:400
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:27
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:58
-msgid "Set Default"
-msgstr "设为默认"
-
-#: airtime_mvc/application/controllers/LocaleController.php:401
-msgid "Create Entry"
-msgstr "创建项目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:402
-msgid "Edit History Record"
-msgstr "编辑历史记录"
-
-#: airtime_mvc/application/controllers/LocaleController.php:403
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:53
-#: airtime_mvc/application/forms/EditHistoryItem.php:57
-msgid "No Show"
-msgstr "无节目"
-
-#: airtime_mvc/application/controllers/LocaleController.php:405
-#, php-format
-msgid "Copied %s row%s to the clipboard"
-msgstr "复制%s行%s到剪贴板"
-
-#: airtime_mvc/application/controllers/LocaleController.php:406
-#, php-format
-msgid ""
-"%sPrint view%sPlease use your browser's print function to print this table. "
-"Press escape when finished."
-msgstr "%s打印预览%s请使用浏览器的打印功能进行打印。按下Esc键可以退出当前状态。"
-
-#: airtime_mvc/application/controllers/LocaleController.php:407
-msgid "New Show"
-msgstr ""
-
-#: airtime_mvc/application/controllers/LocaleController.php:408
-msgid "New Log Entry"
-msgstr ""
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:138
-msgid "Select cursor"
-msgstr "选择游标"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:139
-msgid "Remove cursor"
-msgstr "删除游标"
-
-#: airtime_mvc/application/controllers/ShowbuilderController.php:158
-msgid "show does not exist"
-msgstr "节目不存在"
-
-#: airtime_mvc/application/controllers/ScheduleController.php:389
+#: airtime_mvc/application/controllers/ScheduleController.php:380
 #, php-format
 msgid "Rebroadcast of show %s from %s at %s"
 msgstr "节目%s是节目%s的重播，时间是%s"
 
-#: airtime_mvc/application/common/UsabilityHints.php:55
-msgid "Upload some tracks below to add them to your library!"
-msgstr ""
+#: airtime_mvc/application/controllers/ShowbuilderController.php:137
+msgid "Select cursor"
+msgstr "选择游标"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:138
+msgid "Remove cursor"
+msgstr "删除游标"
+
+#: airtime_mvc/application/controllers/ShowbuilderController.php:157
+msgid "show does not exist"
+msgstr "节目不存在"
+
+#: airtime_mvc/application/controllers/UserController.php:86
+msgid "User added successfully!"
+msgstr "用户已添加成功！"
+
+#: airtime_mvc/application/controllers/UserController.php:88
+msgid "User updated successfully!"
+msgstr "用于已成功更新！"
+
+#: airtime_mvc/application/controllers/UserController.php:188
+msgid "Settings updated successfully!"
+msgstr "设置更新成功！"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:28
+#: airtime_mvc/application/controllers/WebstreamController.php:32
+msgid "Untitled Webstream"
+msgstr "未命名的网络流媒体"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:154
+msgid "Webstream saved."
+msgstr "网络流媒体已保存。"
+
+#: airtime_mvc/application/controllers/WebstreamController.php:162
+msgid "Invalid form values."
+msgstr "无效的表格内容。"
 
-#: airtime_mvc/application/common/UsabilityHints.php:57
-#, php-format
-msgid ""
-"It looks like you haven't uploaded any audio files yet. %sUpload a file "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:63
-msgid "Click the 'New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:65
-#, php-format
-msgid ""
-"It looks like you don't have any shows scheduled. %sCreate a show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:73
-msgid ""
-"To start broadcasting, cancel the current linked show by clicking on it and "
-"selecting 'Cancel Show'."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:75
-#, php-format
-msgid ""
-"Linked shows need to be filled with tracks before it starts. To start broadcasting cancel the current linked show and schedule an unlinked show.\n"
-"                    %sCreate an unlinked show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:80
-msgid ""
-"To start broadcasting, click on the current show and select 'Schedule "
-"Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:82
-#, php-format
-msgid ""
-"It looks like the current show needs more tracks. %sAdd tracks to your show "
-"now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:89
-msgid "Click on the show starting next and select 'Schedule Tracks'"
-msgstr ""
-
-#: airtime_mvc/application/common/UsabilityHints.php:91
-#, php-format
-msgid "It looks like the next show is empty. %sAdd tracks to your show now%s."
-msgstr ""
-
-#: airtime_mvc/application/common/DateHelper.php:213
-#, php-format
-msgid "The year %s must be within the range of 1753 - 9999"
-msgstr "1753 - 9999 是可以接受的年代值，而不是“%s”"
-
-#: airtime_mvc/application/common/DateHelper.php:216
-#, php-format
-msgid "%s-%s-%s is not a valid date"
-msgstr "%s-%s-%s采用了错误的日期格式"
-
-#: airtime_mvc/application/common/DateHelper.php:240
-#, php-format
-msgid "%s:%s:%s is not a valid time"
-msgstr "%s:%s:%s 采用了错误的时间格式"
-
-#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
-msgid "Live stream"
-msgstr "插播流"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:63
-msgid "Smart Block"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:66
-msgid "Webstream"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:71
-msgid "Upload"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:76
-#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:33
-msgid "Dashboard"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:84
-#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:25
-msgid "Webstreams"
-msgstr ""
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:135
-#: airtime_mvc/application/layouts/scripts/layout.phtml:161
-msgid "Play"
-msgstr "试听"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:136
-#: airtime_mvc/application/layouts/scripts/layout.phtml:162
-msgid "Stop"
-msgstr "暂停"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:142
-msgid "Set Cue In"
-msgstr "设为切入时间"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:149
-msgid "Set Cue Out"
-msgstr "设为切出时间"
-
-#: airtime_mvc/application/layouts/scripts/layout.phtml:166
-msgid "Cursor"
-msgstr "设置游标"
-
-#: airtime_mvc/application/layouts/scripts/login.phtml:24
-#, php-format
-msgid ""
-"%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and "
-"distributed under the %3$s by %4$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
-msgid "Drop files here or click to browse your computer."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
-msgid "Failed"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
-msgid "Pending"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
-msgid "Recent Uploads"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
-msgid "Share"
-msgstr "共享"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
-msgid "Select stream:"
-msgstr "选择流："
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
-msgid "mute"
-msgstr "静音"
-
-#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
-msgid "unmute"
-msgstr "取消静音"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
-msgid "About"
-msgstr "关于"
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
-#, php-format
-msgid ""
-"%1$s %2$s, the open radio software for scheduling and remote station "
-"management."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
-#, php-format
-msgid "%1$s %2$s is distributed under the %3$s"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
-#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
-#, php-format
-msgid "Welcome to %s!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
-#, php-format
-msgid "Here's how you can get started using %s to automate your broadcasts: "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
-msgid "Upload audio tracks"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
-msgid ""
-"Click the 'Upload' button in the left corner to upload tracks to your "
-"library."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
-msgid "Schedule a show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
-msgid ""
-"Click on 'Calendar' in the navigation bar on the left. From there click the "
-"'+ New Show' button and fill out the required fields."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
-msgid "Add tracks to your show"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
-msgid ""
-"Click on your show in the calendar and select 'Schedule Show'. In the popup "
-"window drag tracks into your show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
-msgid "Now you're good to go!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
-#, php-format
-msgid "For more detailed help, read the %suser manual%s."
-msgstr "详细的指导，可以参考%s用户手册%s。"
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:5
-#: airtime_mvc/application/configs/navigation.php:40
-msgid "Weekly Schedule"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
-#: airtime_mvc/application/forms/Player.php:77
-msgid "Preview:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/embeddablewidgets/player.phtml:6
-#: airtime_mvc/application/configs/navigation.php:34
-msgid "Player"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:97
-msgid "Playout History"
-msgstr "播出历史"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
-msgid "Log Sheet"
-msgstr "历史记录表单"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
-msgid "File Summary"
-msgstr "文件播放记录"
-
-#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
-msgid "Show Summary"
-msgstr "节目播放记录"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
-msgid "Expand Static Block"
-msgstr "展开静态智能模块"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
-msgid "Expand Dynamic Block"
-msgstr "展开动态智能模块"
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
-msgid ""
-"Choose some search criteria above and click Generate to create this "
-"playlist."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
-msgid ""
-"A track list will be generated when you schedule this smart block into a "
-"show."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
-msgid "Drag tracks here from your library to add them to the playlist"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
-msgid "Editing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:26
-msgid "Name:"
-msgstr "名字："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
-#: airtime_mvc/application/forms/AddShowWhat.php:54
-msgid "Description:"
-msgstr "描述："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
-#: airtime_mvc/application/forms/AddShowWhen.php:89
-msgid "Duration:"
-msgstr "时长："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
-msgid "Toggle Details"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-msgid "Shuffle playlist"
-msgstr "随机打乱播放列表"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
-msgid "Shuffle"
-msgstr "随机"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
-msgid "Playlist crossfade"
-msgstr "播放列表交错淡入淡出效果"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-msgid "Empty playlist content"
-msgstr "播放列表无内容"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Clear"
-msgstr "清除"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-msgid "Fade in: "
-msgstr "淡入："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "Fade out: "
-msgstr "淡出："
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
-msgid "Save playlist"
-msgstr "保存播放列表"
-
-#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
-msgid "No open playlist"
-msgstr "没有打开的播放列表"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
-msgid "Show Waveform"
-msgstr "显示波形图"
-
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
-#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:71
-msgid "(ss.t)"
-msgstr "（秒.分秒）"
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
-msgid "Remove all content from this smart block"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:92
-msgid "No smart block currently open"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-msgid "Cue In: "
-msgstr "切入："
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "(hh:mm:ss.t)"
-msgstr "（时:分:秒.分秒）"
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
-msgid "Cue Out: "
-msgstr "切出："
-
-#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
-msgid "Original Length:"
-msgstr "原始长度："
-
-#: airtime_mvc/application/views/scripts/preference/index.phtml:2
-#: airtime_mvc/application/configs/navigation.php:56
-msgid "General"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
-msgid "Stream Settings"
-msgstr "流设定"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
-msgid "Global"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
-msgid "dB"
-msgstr "分贝"
-
-#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
-msgid "Output Streams"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:3
-#: airtime_mvc/application/forms/Login.php:83
-msgid "Login"
-msgstr "登录"
-
-#: airtime_mvc/application/views/scripts/login/index.phtml:7
-#, php-format
-msgid ""
-"Welcome to the %s demo! You can log in using the username 'admin' and the "
-"password 'admin'."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
-msgid "Email Sent!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
-msgid ""
-"A password reset link has been sent to your email address. Please check your"
-" email and follow the instructions inside to reset your password. If you "
-"don't see the email, please check your spam folder!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:48
-msgid "Back"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
-msgid "Password Reset"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
-msgid "New password"
-msgstr "新密码"
-
-#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
-msgid "Please enter and confirm your new password in the fields below."
-msgstr "请再次输入你的新密码。"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
-msgid "Manage Users"
-msgstr "用户管理"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
-msgid "New User"
-msgstr "新建用户"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
-msgid "id"
-msgstr "编号"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
-#: airtime_mvc/application/forms/PasswordRestore.php:25
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
-msgid "Username"
-msgstr "用户名"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
-msgid "First Name"
-msgstr "名"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
-msgid "Last Name"
-msgstr "姓"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
-msgid "User Type"
-msgstr "用户类型"
-
-#: airtime_mvc/application/views/scripts/user/add-user.phtml:30
-#, php-format
-msgid ""
-"Super Admin details can be changed in your <a href=\"%s\">Billing "
-"Settings</a>."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
-msgid "Find Shows"
-msgstr "查找节目"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
-msgid "Choose Show Instance"
-msgstr "选择节目项"
-
-#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
-msgid "Find"
-msgstr "查找"
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:1
-#: airtime_mvc/application/configs/navigation.php:61
-msgid "My Profile"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
-#, php-format
-msgid ""
-"<b>Note:</b> Since you're the station owner, your account information can be"
-" edited in <a href=\"%s\">Billing Settings</a> instead."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
-msgid "Repeat Days:"
-msgstr "重复天数："
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
-#: airtime_mvc/application/forms/GeneralPreferences.php:53
-#: airtime_mvc/application/forms/AddShowStyle.php:64
-msgid "Remove"
-msgstr "移除"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
-msgid "Add"
-msgstr "添加"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:25
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
-msgid "Show Source"
-msgstr "节目定制的输入流"
-
-#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
-msgid ""
-"DJs can use these settings to connect with compatible software and broadcast"
-" live during this show. Assign a DJ below."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
-msgid "Register Airtime"
-msgstr "注册Airtime"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
-#, php-format
-msgid ""
-"Help improve %s by letting us know how you're using it. This information "
-"will be collected regularly in order to enhance your user experience.<br "
-"/>Click the box below and we'll make sure the features you use are "
-"constantly improving."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
-#, php-format
-msgid "Click the box below to promote your station on %s."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
-msgid "(Required)"
-msgstr "（必填）"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
-msgid "(for verification purposes only, will not be published)"
-msgstr "（仅作为验证目的使用，不会用于发布）"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
-#: airtime_mvc/application/forms/GeneralPreferences.php:43
-msgid "Note: Anything larger than 600x600 will be resized."
-msgstr "注意：大于600x600的图片将会被缩放"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
-msgid "Show me what I am sending "
-msgstr "显示我所发送的信息"
-
-#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
-msgid "Terms and Conditions"
-msgstr "使用条款"
-
-#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
-msgid "Choose Days:"
-msgstr "选择天数："
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
-msgid "Search Criteria:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
-msgid "New Criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
-msgid "or"
-msgstr "或"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
-msgid "and"
-msgstr "和"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
-msgid "New Modifier"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
-msgid " to "
-msgstr "到"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
-msgid "files meet the criteria"
-msgstr "个文件符合条件"
-
-#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
-msgid "file meets the criteria"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
-#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
-msgid "Filter History"
-msgstr "历史记录过滤"
-
-#: airtime_mvc/application/views/scripts/form/login.phtml:41
-msgid "Forgot your password?"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
-msgid ""
-"(In order to promote your station, 'Send support feedback' must be enabled)."
-msgstr "（为了推广您的电台，请启用‘发送支持反馈’）"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
-msgid "Stream "
-msgstr "流"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
-msgid "Additional Options"
-msgstr "附属选项"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
-msgid ""
-"The following info will be displayed to listeners in their media player:"
-msgstr "以下内容将会在听众的媒体播放器上显示："
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
-msgid "(Your radio station website)"
-msgstr "（你电台的网站）"
-
-#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
-msgid "Stream URL: "
-msgstr "流的链接地址："
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
-msgid "Choose folder"
-msgstr "选择文件夹"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
-msgid "Set"
-msgstr "设置"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
-msgid "Current Import Folder:"
-msgstr "当前的导入文件夹："
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
-#, php-format
-msgid ""
-"Rescan watched directory (This is useful if it is network mount and may be "
-"out of sync with %s)"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
-msgid "Remove watched directory"
-msgstr "移除监控文件夹"
-
-#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
-msgid "You are not watching any media folders."
-msgstr "你没有正在监控的文件夹。"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
-msgid "Live Broadcasting"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
-msgid "Master Source"
-msgstr "主输入流"
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
-msgid ""
-"Use these settings in your broadcasting software to stream live at any time."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:27
-msgid ""
-"DJs can use these settings in their broadcasting software to broadcast live "
-"only during shows assigned to them."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
-msgid "TuneIn Settings"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:11
-msgid "SoundCloud Settings"
-msgstr "SoundCloud设置"
-
-#: airtime_mvc/application/views/scripts/form/preferences.phtml:17
-msgid "Dangerous Options"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Add this show"
-msgstr "添加此节目"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:43
-msgid "Update show"
-msgstr "更新节目"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
-msgid "What"
-msgstr "名称"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
-msgid "When"
-msgstr "时间"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:28
-msgid "Live Stream Input"
-msgstr "输入流设置"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
-msgid "Who"
-msgstr "管理和编辑"
-
-#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
-msgid "Style"
-msgstr "风格"
-
-#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:186
-msgid "Disk Space"
-msgstr "磁盘空间"
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:3
-msgid "File import in progress..."
-msgstr "导入文件进行中..."
-
-#: airtime_mvc/application/views/scripts/library/library.phtml:10
-#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
-msgid "Advanced Search Options"
-msgstr "高级查询选项"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
-#: airtime_mvc/application/forms/EditAudioMD.php:24
-#: airtime_mvc/application/forms/Player.php:15
-msgid "Title:"
-msgstr "歌曲名："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
-#: airtime_mvc/application/forms/EditAudioMD.php:34
-msgid "Creator:"
-msgstr "作者："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
-#: airtime_mvc/application/forms/EditAudioMD.php:44
-msgid "Album:"
-msgstr "专辑名："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
-msgid "Track:"
-msgstr "曲目编号："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
-msgid "Length:"
-msgstr "长度："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
-msgid "Sample Rate:"
-msgstr "样本率："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
-msgid "Bit Rate:"
-msgstr "比特率："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
-#: airtime_mvc/application/forms/EditAudioMD.php:115
-msgid "Mood:"
-msgstr "情怀："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
-#: airtime_mvc/application/forms/AddShowWhat.php:45
-#: airtime_mvc/application/forms/EditAudioMD.php:62
-msgid "Genre:"
-msgstr "风格："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
-#: airtime_mvc/application/forms/EditAudioMD.php:72
-msgid "Year:"
-msgstr "年份："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
-#: airtime_mvc/application/forms/EditAudioMD.php:85
-msgid "Label:"
-msgstr "标签："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
-#: airtime_mvc/application/forms/EditAudioMD.php:125
-msgid "BPM:"
-msgstr "拍子（BPM）："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
-#: airtime_mvc/application/forms/EditAudioMD.php:95
-msgid "Composer:"
-msgstr "编曲："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
-#: airtime_mvc/application/forms/EditAudioMD.php:105
-msgid "Conductor:"
-msgstr "制作："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
-#: airtime_mvc/application/forms/EditAudioMD.php:135
-msgid "Copyright:"
-msgstr "版权："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
-msgid "Isrc Number:"
-msgstr "ISRC编号："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
-#: airtime_mvc/application/forms/EditAudioMD.php:155
-msgid "Website:"
-msgstr "网站："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
-#: airtime_mvc/application/forms/EditAudioMD.php:165
-#: airtime_mvc/application/forms/EditUser.php:119
-#: airtime_mvc/application/forms/Login.php:68
-msgid "Language:"
-msgstr "语言："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
-msgid "File Path:"
-msgstr "文件路径："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
-msgid "Web Stream"
-msgstr "网络流媒体"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
-msgid "Dynamic Smart Block"
-msgstr "动态智能模块"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
-msgid "Static Smart Block"
-msgstr "静态智能模块"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
-msgid "Audio Track"
-msgstr "音频文件"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
-msgid "Playlist Contents: "
-msgstr "播放列表内容："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
-msgid "Static Smart Block Contents: "
-msgstr "静态智能模块条件："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
-msgid "Dynamic Smart Block Criteria: "
-msgstr "动态智能模块条件："
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
-msgid "Limit to "
-msgstr "限制到"
-
-#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
-#: airtime_mvc/application/forms/AddShowWhat.php:36
-msgid "URL:"
-msgstr "链接地址："
-
-#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
-msgid "Viewing "
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
-msgid "Listeners"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
-msgid "Stream Data Collection Status"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
-msgid "Your trial expires in"
-msgstr "你的试用天数还剩"
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
-#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
-msgid "days"
-msgstr "天"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
-msgid "Previous:"
-msgstr "之前的："
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
-msgid "Next:"
-msgstr "之后的："
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
-msgid "Source Streams"
-msgstr "输入流"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
-msgid "ON AIR"
-msgstr "直播中"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
-msgid "Listen"
-msgstr "收听"
-
-#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
-msgid "Logout"
-msgstr "登出"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
-msgid "Playout History Templates"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
-msgid "Log Sheet Templates"
-msgstr "历史记录表单模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
-msgid "New Log Sheet Template"
-msgstr "新建历史记录模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
-msgid "No Log Sheet Templates"
-msgstr "无历史记录表单模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
-msgid "File Summary Templates"
-msgstr "文件播放记录模板列表"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
-msgid "New File Summary Template"
-msgstr "新建文件播放记录模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
-msgid "No File Summary Templates"
-msgstr "无文件播放记录模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
-msgid "Creating File Summary Template"
-msgstr "创建文件播放记录模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
-msgid "Creating Log Sheet Template"
-msgstr "创建历史记录表单模板"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
-msgid "Name"
-msgstr "名字"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
-msgid "Add more elements"
-msgstr "增加更多元素"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
-msgid "Add New Field"
-msgstr "添加新项目"
-
-#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
-msgid "Set Default Template"
-msgstr "设为默认模板"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
-msgid "Description"
-msgstr "描述"
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
-msgid "Stream URL:"
-msgstr "流的链接地址："
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
-msgid "Default Length:"
-msgstr "默认长度："
-
-#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
-msgid "No webstream"
-msgstr "没有网络流媒体"
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:6
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:6
-#: airtime_mvc/application/views/scripts/error/error.phtml:6
-msgid "An error has occurred."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
-msgid "Access Denied!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:12
-msgid "You do not have permission to access this page!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-403.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:14
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:14
-#: airtime_mvc/application/views/scripts/error/error.phtml:14
-#: airtime_mvc/application/configs/navigation.php:143
-msgid "Help"
-msgstr "帮助"
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:11
-msgid "Oops!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-500.phtml:12
-msgid "Something went wrong!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
-msgid "Bad Request!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-400.phtml:12
-msgid "The requested action is not supported!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
-msgid "Page not found!"
-msgstr "页面不存在！"
-
-#: airtime_mvc/application/views/scripts/error/error-404.phtml:12
-msgid "We couldn't find the page you were looking for."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/error/error.phtml:12
-msgid "Looks like the page you were looking for doesn't exist!"
-msgstr "你所寻找的页面不存在！"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
-msgid "previous"
-msgstr "往前"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
-msgid "play"
-msgstr "播放"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
-msgid "pause"
-msgstr "暂停"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
-msgid "next"
-msgstr "往后"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
-msgid "stop"
-msgstr "停止"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
-msgid "max volume"
-msgstr "最大音量"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
-msgid "Update Required"
-msgstr "需要更新升级"
-
-#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
-#, php-format
-msgid ""
-"To play the media you will need to either update your browser to a recent "
-"version or update your %sFlash plugin%s."
-msgstr "想要播放媒体，需要更新你的浏览器到最新的版本，或者更新你的%sFalsh插件%s。"
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:20
-msgid "Plan type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:32
-msgid "Billing cycle:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:40
-msgid "Payment method:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
-msgid "PayPal"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:44
-msgid "Credit Card via 2Checkout"
-msgstr ""
-
-#: airtime_mvc/application/forms/DateRange.php:16
-#: airtime_mvc/application/forms/ShowBuilder.php:18
-msgid "Date Start:"
-msgstr "开始日期："
-
-#: airtime_mvc/application/forms/DateRange.php:35
-#: airtime_mvc/application/forms/DateRange.php:63
-#: airtime_mvc/application/forms/ShowBuilder.php:37
-#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:26
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:31
+#: airtime_mvc/application/forms/DateRange.php:35
+#: airtime_mvc/application/forms/DateRange.php:63
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:92
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:119
+#: airtime_mvc/application/forms/ShowBuilder.php:37
+#: airtime_mvc/application/forms/ShowBuilder.php:65
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:102
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:121
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:136
@@ -3013,127 +2504,6 @@ msgstr "开始日期："
 #: airtime_mvc/application/forms/StreamSettingSubForm.php:186
 msgid "Invalid character entered"
 msgstr "输入的字符不合要求"
-
-#: airtime_mvc/application/forms/DateRange.php:44
-#: airtime_mvc/application/forms/ShowBuilder.php:46
-#: airtime_mvc/application/forms/AddShowRepeats.php:56
-msgid "Date End:"
-msgstr "结束日期："
-
-#: airtime_mvc/application/forms/ShowBuilder.php:72
-#: airtime_mvc/application/forms/ShowBuilder.php:88
-msgid "Filter by Show"
-msgstr ""
-
-#: airtime_mvc/application/forms/ShowBuilder.php:80
-msgid "All My Shows:"
-msgstr "我的全部节目："
-
-#: airtime_mvc/application/forms/AddShowWho.php:10
-msgid "Search Users:"
-msgstr "查找用户："
-
-#: airtime_mvc/application/forms/AddShowWho.php:24
-msgid "DJs:"
-msgstr "选择节目编辑："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:30
-#: airtime_mvc/application/forms/GeneralPreferences.php:25
-#: airtime_mvc/application/forms/SupportSettings.php:18
-msgid "Station Name"
-msgstr "电台名称"
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:39
-#: airtime_mvc/application/forms/SupportSettings.php:31
-msgid "Phone:"
-msgstr "电话："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:51
-#: airtime_mvc/application/forms/AddUser.php:67
-#: airtime_mvc/application/forms/EditUser.php:83
-#: airtime_mvc/application/forms/SupportSettings.php:43
-msgid "Email:"
-msgstr "电邮："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:62
-#: airtime_mvc/application/forms/SupportSettings.php:54
-msgid "Station Web Site:"
-msgstr "电台网址："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:73
-#: airtime_mvc/application/forms/SupportSettings.php:65
-msgid "Country:"
-msgstr "国家："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:84
-#: airtime_mvc/application/forms/SupportSettings.php:76
-msgid "City:"
-msgstr "城市："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:96
-#: airtime_mvc/application/forms/SupportSettings.php:88
-msgid "Station Description:"
-msgstr "电台描述："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:106
-#: airtime_mvc/application/forms/GeneralPreferences.php:42
-msgid "Station Logo:"
-msgstr "电台标志："
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:126
-#: airtime_mvc/application/forms/SupportSettings.php:108
-#, php-format
-msgid "Promote my station on %s"
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:151
-#: airtime_mvc/application/forms/SupportSettings.php:120
-#, php-format
-msgid "By checking this box, I agree to %s's %sprivacy policy%s."
-msgstr ""
-
-#: airtime_mvc/application/forms/RegisterAirtime.php:169
-#: airtime_mvc/application/forms/SupportSettings.php:143
-msgid "You have to agree to privacy policy."
-msgstr "请先接受隐私策略"
-
-#: airtime_mvc/application/forms/AddShowRR.php:10
-msgid "Record from Line In?"
-msgstr "从线路输入录制？"
-
-#: airtime_mvc/application/forms/AddShowRR.php:16
-msgid "Rebroadcast?"
-msgstr "重播？"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
-#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:26
-msgid "Value is required and can't be empty"
-msgstr "不能为空"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
-msgid ""
-"'%value%' is no valid email address in the basic format local-part@hostname"
-msgstr "'%value%' 不是合法的电邮地址，应该类似于 local-part@hostname"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
-msgid "'%value%' does not fit the date format '%format%'"
-msgstr "'%value%' 不符合格式要求： '%format%'"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
-msgid "'%value%' is less than %min% characters long"
-msgstr "'%value%' 小于最小长度要求 %min% "
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
-msgid "'%value%' is more than %max% characters long"
-msgstr "'%value%' 大于最大长度要求 %max%"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
-msgid "'%value%' is not between '%min%' and '%max%', inclusively"
-msgstr "'%value%' 应该介于 '%min%' 和 '%max%'之间"
-
-#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
-msgid "Passwords do not match"
-msgstr "两次密码输入不匹配"
 
 #: airtime_mvc/application/forms/AddShowAbsoluteRebroadcastDates.php:66
 #: airtime_mvc/application/forms/AddShowRebroadcastDates.php:71
@@ -3150,675 +2520,55 @@ msgstr "请指定时间"
 msgid "Must wait at least 1 hour to rebroadcast"
 msgstr "至少间隔一个小时"
 
-#: airtime_mvc/application/forms/PasswordRestore.php:14
-msgid "Email"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:18
+msgid "Auto Schedule Playlist ?"
 msgstr ""
 
-#: airtime_mvc/application/forms/PasswordRestore.php:36
-msgid "Reset password"
-msgstr "重置密码"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:30
-msgid "Untitled Show"
-msgstr "未命名节目"
-
-#: airtime_mvc/application/forms/AddShowWhat.php:69
-msgid "Instance Description:"
+#: airtime_mvc/application/forms/AddShowAutoPlaylist.php:25
+msgid "Select Playlist"
 msgstr ""
 
-#: airtime_mvc/application/forms/DangerousPreferences.php:12
-msgid "Delete All Tracks in Library"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditAudioMD.php:145
-msgid "ISRC Number:"
-msgstr "ISRC编号："
-
-#: airtime_mvc/application/forms/EditAudioMD.php:176
-msgid "OK"
-msgstr "确定"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:33
-msgid "Station Description"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:62
-msgid "Default Crossfade Duration (s):"
-msgstr "默认混合淡入淡出效果（秒）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:68
-#: airtime_mvc/application/forms/GeneralPreferences.php:82
-#: airtime_mvc/application/forms/GeneralPreferences.php:96
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
-msgid "Please enter a time in seconds (eg. 0.5)"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:76
-msgid "Default Fade In (s):"
-msgstr "默认淡入效果（秒）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:90
-msgid "Default Fade Out (s):"
-msgstr "默认淡出效果（秒）："
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:102
-msgid "Public Airtime API"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:103
-msgid "Required for embeddable schedule widget."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:105
-msgid "Disabled"
-msgstr "禁用"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:106
-msgid "Enabled"
-msgstr "启用"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:109
-msgid ""
-"Enabling this feature will allow Airtime to provide schedule data\n"
-"                                            to external widgets that can be embedded in your website."
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:120
-msgid "Default Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:127
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
-msgid "Station Timezone"
-msgstr "系统使用的时区"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:134
-msgid "Week Starts On"
-msgstr "一周开始于"
-
-#: airtime_mvc/application/forms/GeneralPreferences.php:150
-msgid "Display login button on your Radio Page?"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddUser.php:29
-#: airtime_mvc/application/forms/EditUser.php:37
-#: airtime_mvc/application/forms/Login.php:41
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
-msgid "Username:"
-msgstr "用户名："
-
-#: airtime_mvc/application/forms/AddUser.php:38
-#: airtime_mvc/application/forms/EditUser.php:48
-#: airtime_mvc/application/forms/Login.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
-msgid "Password:"
-msgstr "密码："
-
-#: airtime_mvc/application/forms/AddUser.php:46
-#: airtime_mvc/application/forms/EditUser.php:57
-msgid "Verify Password:"
-msgstr "再次输入密码："
-
-#: airtime_mvc/application/forms/AddUser.php:55
-#: airtime_mvc/application/forms/EditUser.php:67
-msgid "Firstname:"
-msgstr "名："
-
-#: airtime_mvc/application/forms/AddUser.php:61
-#: airtime_mvc/application/forms/EditUser.php:75
-msgid "Lastname:"
-msgstr "姓："
-
-#: airtime_mvc/application/forms/AddUser.php:76
-#: airtime_mvc/application/forms/EditUser.php:94
-msgid "Mobile Phone:"
-msgstr "手机："
-
-#: airtime_mvc/application/forms/AddUser.php:82
-#: airtime_mvc/application/forms/EditUser.php:102
-msgid "Skype:"
-msgstr "Skype帐号："
-
-#: airtime_mvc/application/forms/AddUser.php:88
-#: airtime_mvc/application/forms/EditUser.php:110
-msgid "Jabber:"
-msgstr "Jabber帐号："
-
-#: airtime_mvc/application/forms/AddUser.php:95
-msgid "User Type:"
-msgstr "用户类型："
-
-#: airtime_mvc/application/forms/AddUser.php:120
-#: airtime_mvc/application/forms/EditUser.php:155
-msgid "Login name is not unique."
-msgstr "帐号重名。"
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
-msgid "Import Folder:"
-msgstr "导入文件夹："
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
-msgid "Watched Folders:"
-msgstr "监控文件夹："
-
-#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
-msgid "Not a valid Directory"
-msgstr "无效的路径"
-
-#: airtime_mvc/application/forms/BillingClient.php:126
-msgid "What is the name of your favorite childhood friend?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:127
-msgid "What school did you attend for sixth grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:128
-msgid "In what city did you meet your spouse/significant other?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:129
-msgid "What street did you live on in third grade?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:130
-msgid "What is the first name of the boy or girl that you first kissed?"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:131
-msgid "In what city or town was your first job?"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:14
-msgid "Default License:"
-msgstr "默认版权策略："
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:17
-msgid "All rights are reserved"
-msgstr "版权所有"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
-msgid "The work is in the public domain"
-msgstr "公开"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
-msgid "Creative Commons Attribution"
-msgstr "知识共享署名"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
-msgid "Creative Commons Attribution Noncommercial"
-msgstr "知识共享署名-非商业应用"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
-msgid "Creative Commons Attribution No Derivative Works"
-msgstr "知识共享署名-不允许衍生"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
-msgid "Creative Commons Attribution Share Alike"
-msgstr "知识共享署名-相同方式共享"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
-msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
-msgstr "知识共享署名-非商业应用且不允许衍生"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
-msgid "Creative Commons Attribution Noncommercial Share Alike"
-msgstr "知识共享署名-非商业应用且相同方式共享"
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:31
-msgid "Default Sharing Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:34
-msgid "Public"
-msgstr ""
-
-#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
-msgid "Private"
-msgstr ""
-
-#: airtime_mvc/application/forms/EditUser.php:129
-msgid "Interface Timezone:"
-msgstr "用户界面使用的时区："
-
-#: airtime_mvc/application/forms/Player.php:14
-msgid "Now Playing"
-msgstr "直播室"
-
-#: airtime_mvc/application/forms/Player.php:25
-msgid "Select Stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:28
-msgid "Auto detect the most appropriate stream to use."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:29
-msgid "Select a stream:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:41
-msgid " - Mobile friendly"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:45
-msgid " - The player does not support Opus streams."
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:71
-msgid "Embeddable code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Player.php:72
-msgid ""
-"Copy this code and paste it into your website's HTML to embed the player in "
-"your site."
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:49
-#: airtime_mvc/application/models/Block.php:1351
-msgid "Select criteria"
-msgstr "选择属性"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:51
-#: airtime_mvc/application/models/Block.php:1353
-msgid "Bit Rate (Kbps)"
-msgstr "比特率（Kbps）"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:71
-#: airtime_mvc/application/models/Block.php:1374
-msgid "Sample Rate (kHz)"
-msgstr "样本率（KHz）"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:119
-msgid "hours"
-msgstr "小时"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:120
-msgid "minutes"
-msgstr "分钟"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
-#: airtime_mvc/application/models/Block.php:333
-msgid "items"
-msgstr "个数"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:130
-msgid "Randomly"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:131
-msgid "Newest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
-msgid "Oldest"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:179
-msgid "Type:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:182
-msgid "Static"
-msgstr "静态"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:183
-msgid "Dynamic"
-msgstr "动态"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:297
-msgid "Allow Repeated Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:306
-msgid "Sort Tracks:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:324
-msgid "Limit to:"
-msgstr ""
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:346
-msgid "Generate playlist content and save criteria"
-msgstr "保存条件设置并生成播放列表内容"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
-msgid "Generate"
-msgstr "开始生成"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:354
-msgid "Shuffle playlist content"
-msgstr "随机打乱歌曲次序"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:526
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:538
-msgid "Limit cannot be empty or smaller than 0"
-msgstr "限制的设置不能比0小"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:531
-msgid "Limit cannot be more than 24 hrs"
-msgstr "限制的设置不能大于24小时"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
-msgid "The value should be an integer"
-msgstr "值只能为整数"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
-msgid "500 is the max item limit value you can set"
-msgstr "最多只能允许500条内容"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:555
-msgid "You must select Criteria and Modifier"
-msgstr "条件和操作符不能为空"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:562
-msgid "'Length' should be in '00:00:00' format"
-msgstr "‘长度’格式应该为‘00:00:00’"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:567
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:580
-msgid ""
-"The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 "
-"00:00:00)"
-msgstr "时间格式错误，应该为形如0000-00-00 或 0000-00-00 00:00:00的格式"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:594
-msgid "The value has to be numeric"
-msgstr "应该为数字"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:599
-msgid "The value should be less then 2147483648"
-msgstr "不能大于2147483648"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:604
-#, php-format
-msgid "The value should be less than %s characters"
-msgstr "不能小于%s个字符"
-
-#: airtime_mvc/application/forms/SmartBlockCriteria.php:611
-msgid "Value cannot be empty"
-msgstr "不能为空"
-
-#: airtime_mvc/application/forms/StreamSetting.php:26
-msgid "Icecast Vorbis Metadata"
-msgstr "Icecast的Vorbis元数据"
-
-#: airtime_mvc/application/forms/StreamSetting.php:36
-msgid "Stream Label:"
-msgstr "流标签："
-
-#: airtime_mvc/application/forms/StreamSetting.php:37
-msgid "Artist - Title"
-msgstr "歌手 - 歌名"
-
-#: airtime_mvc/application/forms/StreamSetting.php:38
-msgid "Show - Artist - Title"
-msgstr "节目 - 歌手 - 歌名"
-
-#: airtime_mvc/application/forms/StreamSetting.php:39
-msgid "Station name - Show name"
-msgstr "电台名 - 节目名"
-
-#: airtime_mvc/application/forms/StreamSetting.php:45
-msgid "Off Air Metadata"
-msgstr "非直播状态下的输出流元数据"
-
-#: airtime_mvc/application/forms/StreamSetting.php:51
-msgid "Enable Replay Gain"
-msgstr "启用回放增益"
-
-#: airtime_mvc/application/forms/StreamSetting.php:57
-msgid "Replay Gain Modifier"
-msgstr "回放增益调整"
-
-#: airtime_mvc/application/forms/StreamSetting.php:65
-msgid "Streaming Server:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Airtime Pro Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSetting.php:66
-msgid "Custom / 3rd Party Streaming"
-msgstr ""
-
-#: airtime_mvc/application/forms/PasswordChange.php:17
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
-msgid "Password"
-msgstr "密码"
-
-#: airtime_mvc/application/forms/PasswordChange.php:28
-msgid "Confirm new password"
-msgstr "确认新密码"
-
-#: airtime_mvc/application/forms/PasswordChange.php:36
-msgid "Password confirmation does not match your password."
-msgstr "新密码不匹配"
-
-#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
-msgid "Station Language"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
-msgid "Enabled:"
-msgstr "启用："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
-msgid "Mobile:"
-msgstr ""
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
-msgid "Stream Type:"
-msgstr "流格式："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
-msgid "Service Type:"
-msgstr "服务类型："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
-msgid "Channels:"
-msgstr "声道："
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "1 - Mono"
-msgstr "1 - 单声道"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
-msgid "2 - Stereo"
-msgstr "2 - 立体声"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
-msgid "Server"
-msgstr "服务器"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
-msgid "Port"
-msgstr "端口号"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
-msgid "Only numbers are allowed."
-msgstr "只允许输入数字"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
-msgid "URL"
-msgstr "链接地址"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
-msgid "Mount Point"
-msgstr "加载点"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
-msgid "Admin User"
-msgstr "管理员用户名"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
-msgid "Admin Password"
-msgstr "管理员密码"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
-msgid "Server cannot be empty."
-msgstr "请填写“服务器”。"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
-msgid "Port cannot be empty."
-msgstr "请填写“端口”。"
-
-#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
-msgid "Mount cannot be empty with Icecast server."
-msgstr "请填写“加载点”。"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:16
-msgid "'%value%' does not fit the time format 'HH:mm'"
-msgstr "'%value%' 不符合形如 '小时:分'的格式要求，例如，‘01：59’"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:22
-msgid "Start Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:37
-msgid "In the Future:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:64
-msgid "End Time:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowWhen.php:98
-msgid "Timezone:"
-msgstr "时区"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:107
-msgid "Repeats?"
-msgstr "是否设置为系列节目？"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:139
-msgid "Cannot create show in the past"
-msgstr "节目不能设置为过去的时间"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:147
-msgid "Cannot modify start date/time of the show that is already started"
-msgstr "节目已经启动，无法修改开始时间/日期"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:156
-#: airtime_mvc/application/models/Show.php:282
-msgid "End date/time cannot be in the past"
-msgstr "节目结束的时间或日期不能设置为过去的时间"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:164
-msgid "Cannot have duration < 0m"
-msgstr "节目时长不能小于0"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:168
-msgid "Cannot have duration 00h 00m"
-msgstr "节目时长不能为0"
-
-#: airtime_mvc/application/forms/AddShowWhen.php:175
-msgid "Cannot have duration greater than 24h"
-msgstr "节目时长不能超过24小时"
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:19
-msgid "Push metadata to your station on TuneIn?"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:24
-msgid "Station ID:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:30
-msgid "Partner Key:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:36
-msgid "Partner Id:"
-msgstr ""
-
-#: airtime_mvc/application/forms/TuneInPreferences.php:77
-#: airtime_mvc/application/forms/TuneInPreferences.php:86
-msgid ""
-"Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and "
-"try again."
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowLiveStream.php:10
+#: airtime_mvc/application/forms/AddShowLiveStream.php:11
 #, php-format
 msgid "Use %s Authentication:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:16
+#: airtime_mvc/application/forms/AddShowLiveStream.php:17
 msgid "Use Custom Authentication:"
 msgstr "使用自定义的用户认证："
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:25
+#: airtime_mvc/application/forms/AddShowLiveStream.php:26
 msgid "Custom Username"
 msgstr "自定义用户名"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:37
+#: airtime_mvc/application/forms/AddShowLiveStream.php:38
 msgid "Custom Password"
 msgstr "自定义密码"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:48
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:67
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:88
+#: airtime_mvc/application/forms/AddShowLiveStream.php:49
 msgid "Host:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:54
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:73
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:94
+#: airtime_mvc/application/forms/AddShowLiveStream.php:55
 msgid "Port:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:60
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:79
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:100
+#: airtime_mvc/application/forms/AddShowLiveStream.php:61
 msgid "Mount:"
 msgstr ""
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:77
+#: airtime_mvc/application/forms/AddShowLiveStream.php:78
 msgid "Username field cannot be empty."
 msgstr "请填写用户名"
 
-#: airtime_mvc/application/forms/AddShowLiveStream.php:82
+#: airtime_mvc/application/forms/AddShowLiveStream.php:83
 msgid "Password field cannot be empty."
 msgstr "请填写密码"
 
-#: airtime_mvc/application/forms/AddShowStyle.php:12
-msgid "Background Colour:"
-msgstr "背景色："
-
-#: airtime_mvc/application/forms/AddShowStyle.php:31
-msgid "Text Colour:"
-msgstr "文字颜色："
-
-#: airtime_mvc/application/forms/AddShowStyle.php:49
-msgid "Current Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:72
-msgid "Show Logo:"
-msgstr ""
-
-#: airtime_mvc/application/forms/AddShowStyle.php:87
-msgid "Logo Preview:"
-msgstr ""
-
-#: airtime_mvc/application/forms/Login.php:102
-msgid "Type the characters you see in the picture below."
-msgstr "请输入图像里的字符。"
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
-msgid "Auto Switch Off:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
-msgid "Auto Switch On:"
-msgstr ""
-
-#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
-msgid "Switch Transition Fade (s):"
-msgstr ""
+#: airtime_mvc/application/forms/AddShowRebroadcastDates.php:15
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:6
+msgid "days"
+msgstr "天"
 
 #: airtime_mvc/application/forms/AddShowRepeats.php:10
 msgid "Link:"
@@ -3864,6 +2614,12 @@ msgstr "按月的同一日期"
 msgid "day of the week"
 msgstr "一个星期的同一日子"
 
+#: airtime_mvc/application/forms/AddShowRepeats.php:56
+#: airtime_mvc/application/forms/DateRange.php:44
+#: airtime_mvc/application/forms/ShowBuilder.php:46
+msgid "Date End:"
+msgstr "结束日期："
+
 #: airtime_mvc/application/forms/AddShowRepeats.php:69
 msgid "No End?"
 msgstr "无休止？"
@@ -3876,115 +2632,1174 @@ msgstr "结束日期应晚于开始日期"
 msgid "Please select a repeat day"
 msgstr "请选择在哪一天重复"
 
-#: airtime_mvc/application/configs/navigation.php:12
-msgid "Radio Page"
+#: airtime_mvc/application/forms/AddShowRR.php:10
+msgid "Record from Line In?"
+msgstr "从线路输入录制？"
+
+#: airtime_mvc/application/forms/AddShowRR.php:16
+msgid "Rebroadcast?"
+msgstr "重播？"
+
+#: airtime_mvc/application/forms/AddShowStyle.php:12
+msgid "Background Colour:"
+msgstr "背景色："
+
+#: airtime_mvc/application/forms/AddShowStyle.php:31
+msgid "Text Colour:"
+msgstr "文字颜色："
+
+#: airtime_mvc/application/forms/AddShowStyle.php:49
+msgid "Current Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:19
-msgid "Calendar"
-msgstr "节目日程"
+#: airtime_mvc/application/forms/AddShowStyle.php:64
+#: airtime_mvc/application/forms/GeneralPreferences.php:55
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:18
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:18
+msgid "Remove"
+msgstr "移除"
 
-#: airtime_mvc/application/configs/navigation.php:26
-msgid "Widgets"
+#: airtime_mvc/application/forms/AddShowStyle.php:72
+msgid "Show Logo:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:48
-msgid "Settings"
+#: airtime_mvc/application/forms/AddShowStyle.php:87
+msgid "Logo Preview:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:67
-msgid "Users"
-msgstr "用户管理"
+#: airtime_mvc/application/forms/AddShowWhat.php:26
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:33
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:146
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:20
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:20
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:17
+msgid "Name:"
+msgstr "名字："
 
-#: airtime_mvc/application/configs/navigation.php:74
-msgid "Streams"
-msgstr "媒体流设置"
+#: airtime_mvc/application/forms/AddShowWhat.php:30
+msgid "Untitled Show"
+msgstr "未命名节目"
 
-#: airtime_mvc/application/configs/navigation.php:82
-msgid "Analytics"
+#: airtime_mvc/application/forms/AddShowWhat.php:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:150
+msgid "URL:"
+msgstr "链接地址："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:45
+#: airtime_mvc/application/forms/EditAudioMD.php:72
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:17
+msgid "Genre:"
+msgstr "风格："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:54
+#: airtime_mvc/application/forms/EditAudioMD.php:54
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:40
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:149
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:17
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:25
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:28
+msgid "Description:"
+msgstr "描述："
+
+#: airtime_mvc/application/forms/AddShowWhat.php:69
+msgid "Instance Description:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:90
-msgid "Listener Stats"
-msgstr "收听状态"
+#: airtime_mvc/application/forms/AddShowWhen.php:16
+msgid "'%value%' does not fit the time format 'HH:mm'"
+msgstr "'%value%' 不符合形如 '小时:分'的格式要求，例如，‘01：59’"
 
-#: airtime_mvc/application/configs/navigation.php:104
-msgid "History Templates"
-msgstr "历史记录模板"
-
-#: airtime_mvc/application/configs/navigation.php:113
-msgid "Billing"
+#: airtime_mvc/application/forms/AddShowWhen.php:22
+msgid "Start Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:120
-msgid "Account Plans"
+#: airtime_mvc/application/forms/AddShowWhen.php:37
+msgid "In the Future:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:127
-msgid "Account Details"
+#: airtime_mvc/application/forms/AddShowWhen.php:64
+msgid "End Time:"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:134
-msgid "View Invoices"
+#: airtime_mvc/application/forms/AddShowWhen.php:89
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:37
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:43
+msgid "Duration:"
+msgstr "时长："
+
+#: airtime_mvc/application/forms/AddShowWhen.php:98
+msgid "Timezone:"
+msgstr "时区"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:107
+msgid "Repeats?"
+msgstr "是否设置为系列节目？"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:139
+msgid "Cannot create show in the past"
+msgstr "节目不能设置为过去的时间"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:147
+msgid "Cannot modify start date/time of the show that is already started"
+msgstr "节目已经启动，无法修改开始时间/日期"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:156
+#: airtime_mvc/application/models/Show.php:308
+msgid "End date/time cannot be in the past"
+msgstr "节目结束的时间或日期不能设置为过去的时间"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:164
+msgid "Cannot have duration < 0m"
+msgstr "节目时长不能小于0"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:168
+msgid "Cannot have duration 00h 00m"
+msgstr "节目时长不能为0"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:175
+msgid "Cannot have duration greater than 24h"
+msgstr "节目时长不能超过24小时"
+
+#: airtime_mvc/application/forms/AddShowWhen.php:293
+#: airtime_mvc/application/forms/AddShowWhen.php:321
+#: airtime_mvc/application/forms/AddShowWhen.php:327
+#: airtime_mvc/application/services/CalendarService.php:309
+msgid "Cannot schedule overlapping shows"
+msgstr "节目时间设置与其他节目有冲突"
+
+#: airtime_mvc/application/forms/AddShowWho.php:10
+msgid "Search Users:"
+msgstr "查找用户："
+
+#: airtime_mvc/application/forms/AddShowWho.php:24
+msgid "DJs:"
+msgstr "选择节目编辑："
+
+#: airtime_mvc/application/forms/AddUser.php:28
+#: airtime_mvc/application/forms/EditUser.php:36
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:42
+#: airtime_mvc/application/forms/Login.php:39
+msgid "Username:"
+msgstr "用户名："
+
+#: airtime_mvc/application/forms/AddUser.php:37
+#: airtime_mvc/application/forms/EditUser.php:47
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:58
+#: airtime_mvc/application/forms/Login.php:52
+msgid "Password:"
+msgstr "密码："
+
+#: airtime_mvc/application/forms/AddUser.php:45
+#: airtime_mvc/application/forms/EditUser.php:56
+msgid "Verify Password:"
+msgstr "再次输入密码："
+
+#: airtime_mvc/application/forms/AddUser.php:54
+#: airtime_mvc/application/forms/EditUser.php:66
+msgid "Firstname:"
+msgstr "名："
+
+#: airtime_mvc/application/forms/AddUser.php:60
+#: airtime_mvc/application/forms/EditUser.php:74
+msgid "Lastname:"
+msgstr "姓："
+
+#: airtime_mvc/application/forms/AddUser.php:66
+#: airtime_mvc/application/forms/EditUser.php:82
+#: airtime_mvc/application/forms/RegisterAirtime.php:51
+#: airtime_mvc/application/forms/SupportSettings.php:43
+msgid "Email:"
+msgstr "电邮："
+
+#: airtime_mvc/application/forms/AddUser.php:75
+#: airtime_mvc/application/forms/EditUser.php:93
+msgid "Mobile Phone:"
+msgstr "手机："
+
+#: airtime_mvc/application/forms/AddUser.php:81
+#: airtime_mvc/application/forms/EditUser.php:101
+msgid "Skype:"
+msgstr "Skype帐号："
+
+#: airtime_mvc/application/forms/AddUser.php:87
+#: airtime_mvc/application/forms/EditUser.php:109
+msgid "Jabber:"
+msgstr "Jabber帐号："
+
+#: airtime_mvc/application/forms/AddUser.php:94
+msgid "User Type:"
+msgstr "用户类型："
+
+#: airtime_mvc/application/forms/AddUser.php:119
+#: airtime_mvc/application/forms/EditUser.php:154
+msgid "Login name is not unique."
+msgstr "帐号重名。"
+
+#: airtime_mvc/application/forms/BillingClient.php:125
+msgid "What is the name of your favorite childhood friend?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:150
-msgid "Getting Started"
-msgstr "基本用法"
-
-#: airtime_mvc/application/configs/navigation.php:157
-msgid "FAQ"
+#: airtime_mvc/application/forms/BillingClient.php:126
+msgid "What school did you attend for sixth grade?"
 msgstr ""
 
-#: airtime_mvc/application/configs/navigation.php:162
-msgid "User Manual"
-msgstr "用户手册"
-
-#: airtime_mvc/application/configs/navigation.php:167
-msgid "File a Support Ticket"
+#: airtime_mvc/application/forms/BillingClient.php:127
+msgid "In what city did you meet your spouse/significant other?"
 msgstr ""
 
-#: airtime_mvc/application/models/Block.php:833
-#: airtime_mvc/application/models/Playlist.php:812
+#: airtime_mvc/application/forms/BillingClient.php:128
+msgid "What street did you live on in third grade?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:129
+msgid "What is the first name of the boy or girl that you first kissed?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:130
+msgid "In what city or town was your first job?"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:19
+msgid "Plan type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:31
+msgid "Billing cycle:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:39
+msgid "Payment method:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:42
+msgid "PayPal"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingUpgradeDowngrade.php:43
+msgid "Credit Card via 2Checkout"
+msgstr ""
+
+#: airtime_mvc/application/forms/customvalidators/ConditionalNotEmpty.php:32
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:8
+msgid "Value is required and can't be empty"
+msgstr "不能为空"
+
+#: airtime_mvc/application/forms/DangerousPreferences.php:12
+msgid "Delete All Tracks in Library"
+msgstr ""
+
+#: airtime_mvc/application/forms/DateRange.php:16
+#: airtime_mvc/application/forms/ShowBuilder.php:18
+msgid "Date Start:"
+msgstr "开始日期："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:24
+#: airtime_mvc/application/forms/Player.php:15
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:9
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:11
+msgid "Title:"
+msgstr "歌曲名："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:10
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:34
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:148
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:14
+msgid "Creator:"
+msgstr "作者："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:44
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:11
+msgid "Album:"
+msgstr "专辑名："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:82
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:18
+msgid "Year:"
+msgstr "年份："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:95
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:19
+msgid "Label:"
+msgstr "标签："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:105
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:21
+msgid "Composer:"
+msgstr "编曲："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:115
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:22
+msgid "Conductor:"
+msgstr "制作："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:125
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:16
+msgid "Mood:"
+msgstr "情怀："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:135
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:20
+msgid "BPM:"
+msgstr "拍子（BPM）："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:145
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:23
+msgid "Copyright:"
+msgstr "版权："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:155
+msgid "ISRC Number:"
+msgstr "ISRC编号："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:165
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:25
+msgid "Website:"
+msgstr "网站："
+
+#: airtime_mvc/application/forms/EditAudioMD.php:175
+#: airtime_mvc/application/forms/EditUser.php:118
+#: airtime_mvc/application/forms/Login.php:66
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:26
+msgid "Language:"
+msgstr "语言："
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:32
+#: airtime_mvc/application/services/HistoryService.php:1153
+msgid "Start Time"
+msgstr "开始时间"
+
+#: airtime_mvc/application/forms/EditHistoryItem.php:44
+#: airtime_mvc/application/services/HistoryService.php:1154
+msgid "End Time"
+msgstr "结束时间"
+
+#: airtime_mvc/application/forms/EditUser.php:128
+msgid "Interface Timezone:"
+msgstr "用户界面使用的时区："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:27
+#: airtime_mvc/application/forms/RegisterAirtime.php:30
+#: airtime_mvc/application/forms/SupportSettings.php:18
+msgid "Station Name"
+msgstr "电台名称"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:35
+msgid "Station Description"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:44
+#: airtime_mvc/application/forms/RegisterAirtime.php:106
+msgid "Station Logo:"
+msgstr "电台标志："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:45
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:152
+msgid "Note: Anything larger than 600x600 will be resized."
+msgstr "注意：大于600x600的图片将会被缩放"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:64
+msgid "Default Crossfade Duration (s):"
+msgstr "默认混合淡入淡出效果（秒）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:70
+#: airtime_mvc/application/forms/GeneralPreferences.php:84
+#: airtime_mvc/application/forms/GeneralPreferences.php:98
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:34
+msgid "Please enter a time in seconds (eg. 0.5)"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:78
+msgid "Default Fade In (s):"
+msgstr "默认淡入效果（秒）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:92
+msgid "Default Fade Out (s):"
+msgstr "默认淡出效果（秒）："
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:105
+msgid "Podcast Album Override"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:107
+#: airtime_mvc/application/forms/GeneralPreferences.php:125
+msgid "Disabled"
+msgstr "禁用"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:108
+#: airtime_mvc/application/forms/GeneralPreferences.php:126
+msgid "Enabled"
+msgstr "启用"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:111
+msgid "Enabling this means that podcast tracks will always contain the podcast name in their album field."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:122
+msgid "Public Airtime API"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:123
+msgid "Required for embeddable schedule widget."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:129
+msgid ""
+"Enabling this feature will allow Airtime to provide schedule data\n"
+"                                            to external widgets that can be embedded in your website."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:141
+msgid "Allowed CORS URLs"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:142
+msgid "Remote URLs that are allowed to access this LibreTime instance in a browser. One URL per line."
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:147
+msgid "Default Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:154
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:23
+msgid "Station Timezone"
+msgstr "系统使用的时区"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:161
+msgid "Week Starts On"
+msgstr "一周开始于"
+
+#: airtime_mvc/application/forms/GeneralPreferences.php:177
+msgid "Display login button on your Radio Page?"
+msgstr ""
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:19
+msgid "'%value%' is no valid email address in the basic format local-part@hostname"
+msgstr "'%value%' 不是合法的电邮地址，应该类似于 local-part@hostname"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:33
+msgid "'%value%' does not fit the date format '%format%'"
+msgstr "'%value%' 不符合格式要求： '%format%'"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:59
+msgid "'%value%' is less than %min% characters long"
+msgstr "'%value%' 小于最小长度要求 %min% "
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:64
+msgid "'%value%' is more than %max% characters long"
+msgstr "'%value%' 大于最大长度要求 %max%"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:76
+msgid "'%value%' is not between '%min%' and '%max%', inclusively"
+msgstr "'%value%' 应该介于 '%min%' 和 '%max%'之间"
+
+#: airtime_mvc/application/forms/helpers/ValidationTypes.php:89
+msgid "Passwords do not match"
+msgstr "两次密码输入不匹配"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:19
+msgid "Auto Switch Off:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:25
+msgid "Auto Switch On:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:31
+msgid "Switch Transition Fade (s):"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:66
+msgid "Master Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:78
+msgid "Master Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:81
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:111
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:112
+msgid "Only numbers are allowed."
+msgstr "只允许输入数字"
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:89
+msgid "Master Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:99
+msgid "Show Source Host:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:108
+msgid "Show Source Port:"
+msgstr ""
+
+#: airtime_mvc/application/forms/LiveStreamingPreferences.php:116
+msgid "Show Source Mount:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Login.php:81
+#: airtime_mvc/application/views/scripts/login/index.phtml:3
+msgid "Login"
+msgstr "登录"
+
+#: airtime_mvc/application/forms/Login.php:100
+msgid "Type the characters you see in the picture below."
+msgstr "请输入图像里的字符。"
+
+#: airtime_mvc/application/forms/PasswordChange.php:17
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:117
+msgid "Password"
+msgstr "密码"
+
+#: airtime_mvc/application/forms/PasswordChange.php:28
+msgid "Confirm new password"
+msgstr "确认新密码"
+
+#: airtime_mvc/application/forms/PasswordChange.php:36
+msgid "Password confirmation does not match your password."
+msgstr "新密码不匹配"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:14
+msgid "Email"
+msgstr ""
+
+#: airtime_mvc/application/forms/PasswordRestore.php:25
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:164
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:18
+msgid "Username"
+msgstr "用户名"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:36
+msgid "Reset password"
+msgstr "重置密码"
+
+#: airtime_mvc/application/forms/PasswordRestore.php:46
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:52
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:11
+msgid "Back"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:14
+msgid "Now Playing"
+msgstr "直播室"
+
+#: airtime_mvc/application/forms/Player.php:25
+msgid "Select Stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:28
+msgid "Auto detect the most appropriate stream to use."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:29
+msgid "Select a stream:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:41
+msgid " - Mobile friendly"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:45
+msgid " - The player does not support Opus streams."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:71
+msgid "Embeddable code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:72
+msgid "Copy this code and paste it into your website's HTML to embed the player in your site."
+msgstr ""
+
+#: airtime_mvc/application/forms/Player.php:77
+#: airtime_mvc/application/views/scripts/embeddablewidgets/schedule.phtml:14
+msgid "Preview:"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:8
+msgid "Feed Privacy"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:10
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:35
+msgid "Public"
+msgstr ""
+
+#: airtime_mvc/application/forms/PodcastPreferences.php:11
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:36
+msgid "Private"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:39
+#: airtime_mvc/application/forms/SupportSettings.php:31
+msgid "Phone:"
+msgstr "电话："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:62
+#: airtime_mvc/application/forms/SupportSettings.php:54
+msgid "Station Web Site:"
+msgstr "电台网址："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:73
+#: airtime_mvc/application/forms/SupportSettings.php:65
+msgid "Country:"
+msgstr "国家："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:84
+#: airtime_mvc/application/forms/SupportSettings.php:76
+msgid "City:"
+msgstr "城市："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:96
+#: airtime_mvc/application/forms/SupportSettings.php:88
+msgid "Station Description:"
+msgstr "电台描述："
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:126
+#: airtime_mvc/application/forms/SupportSettings.php:108
+#, php-format
+msgid "Promote my station on %s"
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:151
+#: airtime_mvc/application/forms/SupportSettings.php:120
+#, php-format
+msgid "By checking this box, I agree to %s's %sprivacy policy%s."
+msgstr ""
+
+#: airtime_mvc/application/forms/RegisterAirtime.php:169
+#: airtime_mvc/application/forms/SupportSettings.php:143
+msgid "You have to agree to privacy policy."
+msgstr "请先接受隐私策略"
+
+#: airtime_mvc/application/forms/SetupLanguageTimezone.php:18
+msgid "Station Language"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:72
+#: airtime_mvc/application/forms/ShowBuilder.php:89
+msgid "Filter by Show"
+msgstr ""
+
+#: airtime_mvc/application/forms/ShowBuilder.php:80
+msgid "All My Shows:"
+msgstr "我的全部节目："
+
+#: airtime_mvc/application/forms/ShowBuilder.php:91
+msgid "My Shows"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:50
+#: airtime_mvc/application/models/Block.php:1356
+msgid "Select criteria"
+msgstr "选择属性"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:52
+#: airtime_mvc/application/models/Block.php:1358
+msgid "Bit Rate (Kbps)"
+msgstr "比特率（Kbps）"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:59
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:148
+#: airtime_mvc/application/models/Block.php:1365
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:29
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:30
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:24
+msgid "Description"
+msgstr "描述"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:73
+#: airtime_mvc/application/models/Block.php:1380
+msgid "Sample Rate (kHz)"
+msgstr "样本率（KHz）"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:121
+msgid "hours"
+msgstr "小时"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:122
+msgid "minutes"
+msgstr "分钟"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:123
+#: airtime_mvc/application/models/Block.php:330
+msgid "items"
+msgstr "个数"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:132
+msgid "Randomly"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:133
+msgid "Newest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:134
+msgid "Oldest"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:181
+msgid "Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:184
+msgid "Static"
+msgstr "静态"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:185
+msgid "Dynamic"
+msgstr "动态"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:299
+msgid "Allow Repeated Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:308
+msgid "Sort Tracks:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:326
+msgid "Limit to:"
+msgstr ""
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:348
+msgid "Generate playlist content and save criteria"
+msgstr "保存条件设置并生成播放列表内容"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:350
+msgid "Generate"
+msgstr "开始生成"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:356
+msgid "Shuffle playlist content"
+msgstr "随机打乱歌曲次序"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:358
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle"
+msgstr "随机"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:529
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:541
+msgid "Limit cannot be empty or smaller than 0"
+msgstr "限制的设置不能比0小"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:534
+msgid "Limit cannot be more than 24 hrs"
+msgstr "限制的设置不能大于24小时"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:544
+msgid "The value should be an integer"
+msgstr "值只能为整数"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:547
+msgid "500 is the max item limit value you can set"
+msgstr "最多只能允许500条内容"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:558
+msgid "You must select Criteria and Modifier"
+msgstr "条件和操作符不能为空"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:565
+msgid "'Length' should be in '00:00:00' format"
+msgstr "‘长度’格式应该为‘00:00:00’"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:570
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:583
+msgid "The value should be in timestamp format (e.g. 0000-00-00 or 0000-00-00 00:00:00)"
+msgstr "时间格式错误，应该为形如0000-00-00 或 0000-00-00 00:00:00的格式"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:597
+msgid "The value has to be numeric"
+msgstr "应该为数字"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:602
+msgid "The value should be less then 2147483648"
+msgstr "不能大于2147483648"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:607
+#, php-format
+msgid "The value should be less than %s characters"
+msgstr "不能小于%s个字符"
+
+#: airtime_mvc/application/forms/SmartBlockCriteria.php:614
+msgid "Value cannot be empty"
+msgstr "不能为空"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:15
+msgid "Default License:"
+msgstr "默认版权策略："
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:18
+msgid "All rights are reserved"
+msgstr "版权所有"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:19
+msgid "The work is in the public domain"
+msgstr "公开"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:20
+msgid "Creative Commons Attribution"
+msgstr "知识共享署名"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:21
+msgid "Creative Commons Attribution Noncommercial"
+msgstr "知识共享署名-非商业应用"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:22
+msgid "Creative Commons Attribution No Derivative Works"
+msgstr "知识共享署名-不允许衍生"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:23
+msgid "Creative Commons Attribution Share Alike"
+msgstr "知识共享署名-相同方式共享"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:24
+msgid "Creative Commons Attribution Noncommercial Non Derivate Works"
+msgstr "知识共享署名-非商业应用且不允许衍生"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:25
+msgid "Creative Commons Attribution Noncommercial Share Alike"
+msgstr "知识共享署名-非商业应用且相同方式共享"
+
+#: airtime_mvc/application/forms/SoundCloudPreferences.php:32
+msgid "Default Sharing Type:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:26
+msgid "Hardware Audio Output:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:33
+msgid "Output Type"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:35
+msgid "ALSA"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:36
+msgid "AO"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:37
+msgid "OSS"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:38
+msgid "Portaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:39
+msgid "Pulseaudio"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:40
+msgid "Jack"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:46
+msgid "Icecast Vorbis Metadata"
+msgstr "Icecast的Vorbis元数据"
+
+#: airtime_mvc/application/forms/StreamSetting.php:56
+msgid "Stream Label:"
+msgstr "流标签："
+
+#: airtime_mvc/application/forms/StreamSetting.php:57
+msgid "Artist - Title"
+msgstr "歌手 - 歌名"
+
+#: airtime_mvc/application/forms/StreamSetting.php:58
+msgid "Show - Artist - Title"
+msgstr "节目 - 歌手 - 歌名"
+
+#: airtime_mvc/application/forms/StreamSetting.php:59
+msgid "Station name - Show name"
+msgstr "电台名 - 节目名"
+
+#: airtime_mvc/application/forms/StreamSetting.php:65
+msgid "Off Air Metadata"
+msgstr "非直播状态下的输出流元数据"
+
+#: airtime_mvc/application/forms/StreamSetting.php:71
+msgid "Enable Replay Gain"
+msgstr "启用回放增益"
+
+#: airtime_mvc/application/forms/StreamSetting.php:77
+msgid "Replay Gain Modifier"
+msgstr "回放增益调整"
+
+#: airtime_mvc/application/forms/StreamSetting.php:85
+msgid "Streaming Server:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Default Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSetting.php:86
+msgid "Custom / 3rd Party Streaming"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:52
+msgid "Enabled:"
+msgstr "启用："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:59
+msgid "Mobile:"
+msgstr ""
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:66
+msgid "Stream Type:"
+msgstr "流格式："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:74
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:15
+msgid "Bit Rate:"
+msgstr "比特率："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:82
+msgid "Service Type:"
+msgstr "服务类型："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:90
+msgid "Channels:"
+msgstr "声道："
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "1 - Mono"
+msgstr "1 - 单声道"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:91
+msgid "2 - Stereo"
+msgstr "2 - 立体声"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:98
+msgid "Server"
+msgstr "服务器"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:108
+msgid "Port"
+msgstr "端口号"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:133
+msgid "URL"
+msgstr "链接地址"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:142
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:9
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:23
+msgid "Name"
+msgstr "名字"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:154
+msgid "Mount Point"
+msgstr "加载点"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:174
+msgid "Admin User"
+msgstr "管理员用户名"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:183
+msgid "Admin Password"
+msgstr "管理员密码"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:211
+msgid "Server cannot be empty."
+msgstr "请填写“服务器”。"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:216
+msgid "Port cannot be empty."
+msgstr "请填写“端口”。"
+
+#: airtime_mvc/application/forms/StreamSettingSubForm.php:222
+msgid "Mount cannot be empty with Icecast server."
+msgstr "请填写“加载点”。"
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:20
+msgid "Push metadata to your station on TuneIn?"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:25
+msgid "Station ID:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:31
+msgid "Partner Key:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:37
+msgid "Partner Id:"
+msgstr ""
+
+#: airtime_mvc/application/forms/TuneInPreferences.php:78
+#: airtime_mvc/application/forms/TuneInPreferences.php:87
+msgid "Invalid TuneIn Settings. Please ensure your TuneIn settings are correct and try again."
+msgstr ""
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:14
+msgid "Import Folder:"
+msgstr "导入文件夹："
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:25
+msgid "Watched Folders:"
+msgstr "监控文件夹："
+
+#: airtime_mvc/application/forms/WatchedDirPreferences.php:40
+msgid "Not a valid Directory"
+msgstr "无效的路径"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:65
+msgid "Smart Block"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:68
+msgid "Webstream"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:73
+msgid "Upload"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:81
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:10
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:5
+msgid "Dashboard"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:87
+msgid "Podcasts"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:143
+#: airtime_mvc/application/layouts/scripts/layout.phtml:169
+msgid "Play"
+msgstr "试听"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:144
+#: airtime_mvc/application/layouts/scripts/layout.phtml:170
+msgid "Stop"
+msgstr "暂停"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:150
+msgid "Set Cue In"
+msgstr "设为切入时间"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:157
+msgid "Set Cue Out"
+msgstr "设为切出时间"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:174
+msgid "Cursor"
+msgstr "设置游标"
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:191
+msgid "Airtime Pro has a new look!"
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:192
+msgid ""
+"Your favorite features are now even easier to use - and we've even\n"
+"                    added a few new ones! Check out the video above or read on to find out more."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:195
+msgid ""
+"Our new Dashboard view now has a powerful tabbed editing interface, so updating your tracks and playlists\n"
+"                        is easier than ever."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:197
+msgid ""
+"We've streamlined the Airtime interface to make navigation easier. With the most important tools\n"
+"                        just a click away, you'll be on air and hands-free in no time."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:199
+msgid "Got a huge music library? No problem! With the new Upload page, you can drag and drop whole folders to our private cloud."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/layout.phtml:200
+msgid ""
+"The new Airtime is smoother, sleeker, and faster - on even more devices! We're committed to improving the Airtime\n"
+"                        experience, no matter how you're connected."
+msgstr ""
+
+#: airtime_mvc/application/layouts/scripts/livestream.phtml:9
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:2
+msgid "Live stream"
+msgstr "插播流"
+
+#: airtime_mvc/application/layouts/scripts/login.phtml:24
+#, php-format
+msgid "%1$s copyright &copy; %2$s All rights reserved.<br />Maintained and distributed under the %3$s by %4$s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:33
+#, php-format
+msgid ""
+"Hi %s, \n"
+"\n"
+"Please click this link to reset your password: "
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:35
+#, php-format
+msgid ""
+"\n"
+"\n"
+"If you have any problems, please contact our support team: %s"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:36
+#, php-format
+msgid ""
+"\n"
+"\n"
+"Thank you,\n"
+"The %s Team"
+msgstr ""
+
+#: airtime_mvc/application/models/Auth.php:38
+#, php-format
+msgid "%s Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/models/Block.php:830
+#: airtime_mvc/application/models/Playlist.php:810
 msgid "Cue in and cue out are null."
 msgstr "切入点和切出点均为空"
 
-#: airtime_mvc/application/models/Block.php:868
-#: airtime_mvc/application/models/Block.php:924
-#: airtime_mvc/application/models/Playlist.php:851
-#: airtime_mvc/application/models/Playlist.php:895
+#: airtime_mvc/application/models/Block.php:865
+#: airtime_mvc/application/models/Block.php:921
+#: airtime_mvc/application/models/Playlist.php:849
+#: airtime_mvc/application/models/Playlist.php:893
 msgid "Can't set cue out to be greater than file length."
 msgstr "切出点不能超出文件原长度"
 
-#: airtime_mvc/application/models/Block.php:879
-#: airtime_mvc/application/models/Block.php:900
-#: airtime_mvc/application/models/Playlist.php:843
-#: airtime_mvc/application/models/Playlist.php:868
+#: airtime_mvc/application/models/Block.php:876
+#: airtime_mvc/application/models/Block.php:897
+#: airtime_mvc/application/models/Playlist.php:841
+#: airtime_mvc/application/models/Playlist.php:866
 msgid "Can't set cue in to be larger than cue out."
 msgstr "切入点不能晚于切出点"
 
-#: airtime_mvc/application/models/Block.php:935
-#: airtime_mvc/application/models/Playlist.php:887
+#: airtime_mvc/application/models/Block.php:932
+#: airtime_mvc/application/models/Playlist.php:885
 msgid "Can't set cue out to be smaller than cue in."
 msgstr "切出点不能早于切入点"
 
-#: airtime_mvc/application/models/Block.php:1366
+#: airtime_mvc/application/models/Block.php:1372
 msgid "Upload Time"
 msgstr ""
 
-#: airtime_mvc/application/models/ShowBuilder.php:212
-#, php-format
-msgid "Rebroadcast of %s from %s"
-msgstr "%s是%s的重播"
-
-#: airtime_mvc/application/models/Preference.php:460
-#, php-format
-msgid "Powered by %s"
+#: airtime_mvc/application/models/Library.php:38
+msgid "None"
 msgstr ""
-
-#: airtime_mvc/application/models/Preference.php:588
-msgid "Select Country"
-msgstr "选择国家"
 
 #: airtime_mvc/application/models/MusicDir.php:160
 #, php-format
@@ -4009,14 +3824,12 @@ msgstr "%s 不是文件夹。"
 
 #: airtime_mvc/application/models/MusicDir.php:232
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list"
+msgid "%s is already set as the current storage dir or in the watched folders list"
 msgstr "%s 已经设置成媒体存储文件夹，或者监控文件夹。"
 
 #: airtime_mvc/application/models/MusicDir.php:388
 #, php-format
-msgid ""
-"%s is already set as the current storage dir or in the watched folders list."
+msgid "%s is already set as the current storage dir or in the watched folders list."
 msgstr "%s 已经设置成媒体存储文件夹，或者监控文件夹。"
 
 #: airtime_mvc/application/models/MusicDir.php:431
@@ -4024,28 +3837,18 @@ msgstr "%s 已经设置成媒体存储文件夹，或者监控文件夹。"
 msgid "%s doesn't exist in the watched list."
 msgstr "监控文件夹名单里不存在 %s "
 
-#: airtime_mvc/application/models/Auth.php:33
+#: airtime_mvc/application/models/Preference.php:470
 #, php-format
-msgid ""
-"Hi %s, \n"
-"\n"
-"Please click this link to reset your password: "
+msgid "Powered by %s"
 msgstr ""
 
-#: airtime_mvc/application/models/Auth.php:38
-#, php-format
-msgid "%s Password Reset"
+#: airtime_mvc/application/models/Preference.php:600
+msgid "Select Country"
+msgstr "选择国家"
+
+#: airtime_mvc/application/models/Schedule.php:206
+msgid "livestream"
 msgstr ""
-
-#: airtime_mvc/application/models/Show.php:184
-msgid "Shows can have a max length of 24 hours."
-msgstr "节目时长只能设置在24小时以内"
-
-#: airtime_mvc/application/models/Show.php:293
-msgid ""
-"Cannot schedule overlapping shows.\n"
-"Note: Resizing a repeating show affects all of its repeats."
-msgstr "节目时间设置于其他的节目有冲突。\n提示：修改系列节目中的一个，将影响整个节目系列"
 
 #: airtime_mvc/application/models/Scheduler.php:73
 msgid "Cannot move items out of linked shows"
@@ -4060,48 +3863,60 @@ msgid "The schedule you're viewing is out of date! (instance mismatch)"
 msgstr "当前节目内容表（节目已更改）需要刷新"
 
 #: airtime_mvc/application/models/Scheduler.php:132
-#: airtime_mvc/application/models/Scheduler.php:458
-#: airtime_mvc/application/models/Scheduler.php:490
+#: airtime_mvc/application/models/Scheduler.php:477
+#: airtime_mvc/application/models/Scheduler.php:514
+#: airtime_mvc/application/models/Scheduler.php:549
 msgid "The schedule you're viewing is out of date!"
 msgstr "当前节目内容需要刷新！"
 
-#: airtime_mvc/application/models/Scheduler.php:142
+#: airtime_mvc/application/models/Scheduler.php:143
 #, php-format
 msgid "You are not allowed to schedule show %s."
 msgstr "没有赋予修改节目 %s 的权限。"
 
-#: airtime_mvc/application/models/Scheduler.php:146
+#: airtime_mvc/application/models/Scheduler.php:147
 msgid "You cannot add files to recording shows."
 msgstr "录音节目不能添加别的内容。"
 
-#: airtime_mvc/application/models/Scheduler.php:152
+#: airtime_mvc/application/models/Scheduler.php:153
 #, php-format
 msgid "The show %s is over and cannot be scheduled."
 msgstr "节目%s已结束，不能在添加任何内容。"
 
-#: airtime_mvc/application/models/Scheduler.php:159
+#: airtime_mvc/application/models/Scheduler.php:160
 #, php-format
 msgid "The show %s has been previously updated!"
 msgstr "节目%s已经更改，需要刷新后再尝试。"
 
-#: airtime_mvc/application/models/Scheduler.php:178
-msgid ""
-"Content in linked shows must be scheduled before or after any one is "
-"broadcasted"
-msgstr "绑定的节目要么提前设置好，要么等待其中的任何一个节目结束后才能编辑内容"
+#: airtime_mvc/application/models/Scheduler.php:179
+msgid "Content in linked shows cannot be changed while on air!"
+msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:195
+#: airtime_mvc/application/models/Scheduler.php:196
 msgid "Cannot schedule a playlist that contains missing files."
 msgstr ""
 
-#: airtime_mvc/application/models/Scheduler.php:216
-#: airtime_mvc/application/models/Scheduler.php:305
+#: airtime_mvc/application/models/Scheduler.php:217
+#: airtime_mvc/application/models/Scheduler.php:306
 msgid "A selected File does not exist!"
 msgstr "某个选中的文件不存在。"
 
-#: airtime_mvc/application/models/Schedule.php:206
-msgid "livestream"
+#: airtime_mvc/application/models/Show.php:210
+msgid "Shows can have a max length of 24 hours."
+msgstr "节目时长只能设置在24小时以内"
+
+#: airtime_mvc/application/models/Show.php:319
+msgid ""
+"Cannot schedule overlapping shows.\n"
+"Note: Resizing a repeating show affects all of its repeats."
 msgstr ""
+"节目时间设置于其他的节目有冲突。\n"
+"提示：修改系列节目中的一个，将影响整个节目系列"
+
+#: airtime_mvc/application/models/ShowBuilder.php:209
+#, php-format
+msgid "Rebroadcast of %s from %s"
+msgstr "%s是%s的重播"
 
 #: airtime_mvc/application/models/Webstream.php:166
 msgid "Length needs to be greater than 0 minutes"
@@ -4148,8 +3963,1049 @@ msgstr "媒体流格式错误，当前“媒体流”只是一个可下载的文
 msgid "Unrecognized stream type: %s"
 msgstr "未知的媒体流格式： %s"
 
-#: airtime_mvc/public/setup/rabbitmq-setup.php:78
-msgid ""
-"Couldn't connect to RabbitMQ server! Please check if the server is running "
-"and your credentials are correct."
+#: airtime_mvc/application/services/CalendarService.php:50
+msgid "Record file doesn't exist"
+msgstr "录制文件不存在"
+
+#: airtime_mvc/application/services/CalendarService.php:54
+msgid "View Recorded File Metadata"
+msgstr "查看录制文件的元数据"
+
+#: airtime_mvc/application/services/CalendarService.php:61
+#: airtime_mvc/application/services/CalendarService.php:93
+msgid "View"
 msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:81
+msgid "Schedule Tracks"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:106
+msgid "Clear Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:120
+#: airtime_mvc/application/services/CalendarService.php:125
+msgid "Cancel Show"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:146
+#: airtime_mvc/application/services/CalendarService.php:165
+msgid "Edit Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:152
+msgid "Edit"
+msgstr "编辑"
+
+#: airtime_mvc/application/services/CalendarService.php:158
+#: airtime_mvc/application/services/CalendarService.php:172
+msgid "Edit Show"
+msgstr "编辑节目"
+
+#: airtime_mvc/application/services/CalendarService.php:194
+msgid "Delete Instance"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:200
+msgid "Delete Instance and All Following"
+msgstr ""
+
+#: airtime_mvc/application/services/CalendarService.php:254
+msgid "Permission denied"
+msgstr "没有编辑权限"
+
+#: airtime_mvc/application/services/CalendarService.php:258
+msgid "Can't drag and drop repeating shows"
+msgstr "系列中的节目无法拖拽"
+
+#: airtime_mvc/application/services/CalendarService.php:267
+msgid "Can't move a past show"
+msgstr "已经结束的节目无法更改时间"
+
+#: airtime_mvc/application/services/CalendarService.php:302
+msgid "Can't move show into past"
+msgstr "节目不能设置到已过去的时间点"
+
+#: airtime_mvc/application/services/CalendarService.php:322
+msgid "Can't move a recorded show less than 1 hour before its rebroadcasts."
+msgstr "录音和重播节目之间的间隔必须大于等于1小时。"
+
+#: airtime_mvc/application/services/CalendarService.php:332
+msgid "Show was deleted because recorded show does not exist!"
+msgstr "录音节目不存在，节目已删除！"
+
+#: airtime_mvc/application/services/CalendarService.php:339
+msgid "Must wait 1 hour to rebroadcast."
+msgstr "重播节目必须设置于1小时之后。"
+
+#: airtime_mvc/application/services/HistoryService.php:1126
+msgid "Track"
+msgstr "曲目"
+
+#: airtime_mvc/application/services/HistoryService.php:1174
+msgid "Played"
+msgstr "已播放"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:23
+msgid "previous"
+msgstr "往前"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:28
+msgid "play"
+msgstr "播放"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:32
+msgid "pause"
+msgstr "暂停"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:37
+msgid "next"
+msgstr "往后"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:42
+msgid "stop"
+msgstr "停止"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:60
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:90
+msgid "mute"
+msgstr "静音"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:63
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:91
+msgid "unmute"
+msgstr "取消静音"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:69
+msgid "max volume"
+msgstr "最大音量"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:79
+msgid "Update Required"
+msgstr "需要更新升级"
+
+#: airtime_mvc/application/views/scripts/audiopreview/audio-preview.phtml:80
+#, php-format
+msgid "To play the media you will need to either update your browser to a recent version or update your %sFlash plugin%s."
+msgstr "想要播放媒体，需要更新你的浏览器到最新的版本，或者更新你的%sFalsh插件%s。"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:2
+msgid "About"
+msgstr "关于"
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:9
+#, php-format
+msgid "%1$s %2$s, the open radio software for scheduling and remote station management."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/about.phtml:22
+#, php-format
+msgid "%1$s %2$s is distributed under the %3$s"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:2
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:1
+#, php-format
+msgid "Welcome to %s!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:3
+#, php-format
+msgid "Here's how you can get started using %s to automate your broadcasts: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:6
+msgid "Upload audio tracks"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:7
+msgid "Click the 'Upload' button in the left corner to upload tracks to your library."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:8
+msgid "Schedule a show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:9
+msgid "Click on 'Calendar' in the navigation bar on the left. From there click the '+ New Show' button and fill out the required fields."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:10
+msgid "Add tracks to your show"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:11
+msgid "Click on your show in the calendar and select 'Schedule Show'. In the popup window drag tracks into your show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:16
+msgid "Now you're good to go!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/dashboard/help.phtml:19
+#, php-format
+msgid "For more detailed help, read the %suser manual%s."
+msgstr "详细的指导，可以参考%s用户手册%s。"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:3
+msgid "Share"
+msgstr "共享"
+
+#: airtime_mvc/application/views/scripts/dashboard/stream-player.phtml:64
+msgid "Select stream:"
+msgstr "选择流："
+
+#: airtime_mvc/application/views/scripts/dashboard/table-test.phtml:2
+msgid "Table Test"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embed/player.phtml:393
+msgid "Next"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/embeddablewidgets/facebook.phtml:5
+msgid "Facebook Radio Player"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:5
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:5
+#: airtime_mvc/application/views/scripts/error/error.phtml:6
+msgid "An error has occurred."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:10
+msgid "Bad Request!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-400.phtml:11
+msgid "The requested action is not supported!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:10
+msgid "Access Denied!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-403.phtml:11
+msgid "You do not have permission to access this page!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:10
+msgid "Page not found!"
+msgstr "页面不存在！"
+
+#: airtime_mvc/application/views/scripts/error/error-404.phtml:11
+msgid "We couldn't find the page you were looking for."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error-500.phtml:10
+msgid "Oops!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/error/error.phtml:12
+msgid "Looks like the page you were looking for doesn't exist!"
+msgstr "你所寻找的页面不存在！"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:10
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:30
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:39
+msgid "Show Source"
+msgstr "节目定制的输入流"
+
+#: airtime_mvc/application/views/scripts/form/add-show-live-stream.phtml:12
+msgid "DJs can use these settings to connect with compatible software and broadcast live during this show. Assign a DJ below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:4
+msgid "Choose Days:"
+msgstr "选择天数："
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast-absolute.phtml:40
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:41
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:28
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:75
+msgid "Add"
+msgstr "添加"
+
+#: airtime_mvc/application/views/scripts/form/add-show-rebroadcast.phtml:4
+msgid "Repeat Days:"
+msgstr "重复天数："
+
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:6
+#: airtime_mvc/application/views/scripts/form/daterange.phtml:7
+msgid "Filter History"
+msgstr "历史记录过滤"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:45
+msgid "Choose Show Instance"
+msgstr "选择节目项"
+
+#: airtime_mvc/application/views/scripts/form/edit-history-item.phtml:56
+msgid "Find"
+msgstr "查找"
+
+#: airtime_mvc/application/views/scripts/form/edit-user.phtml:7
+#, php-format
+msgid "<b>Note:</b> Since you're the station owner, your account information can be edited in <a href=\"%s\">Billing Settings</a> instead."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/login.phtml:41
+msgid "Forgot your password?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/player.phtml:12
+msgid ""
+"Customize the player by configuring the options below. When you are done,\n"
+"            copy the embeddable code below and paste it into your website's HTML."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:6
+msgid "TuneIn Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:13
+msgid "SoundCloud Settings"
+msgstr "SoundCloud设置"
+
+#: airtime_mvc/application/views/scripts/form/preferences.phtml:21
+msgid "Dangerous Options"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:1
+msgid "Live Broadcasting"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:11
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:30
+msgid "Master Source"
+msgstr "主输入流"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:13
+msgid "Use these settings in your broadcasting software to stream live at any time."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:19
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:36
+msgid "Override"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "OK"
+msgstr "确定"
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:22
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:40
+msgid "RESET"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_livestream.phtml:32
+msgid "DJs can use these settings in their broadcasting software to broadcast live only during shows assigned to them."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:9
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:27
+msgid "Choose folder"
+msgstr "选择文件夹"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:10
+msgid "Set"
+msgstr "设置"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:19
+msgid "Current Import Folder:"
+msgstr "当前的导入文件夹："
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:43
+#, php-format
+msgid "Rescan watched directory (This is useful if it is network mount and may be out of sync with %s)"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:44
+msgid "Remove watched directory"
+msgstr "移除监控文件夹"
+
+#: airtime_mvc/application/views/scripts/form/preferences_watched_dirs.phtml:49
+msgid "You are not watching any media folders."
+msgstr "你没有正在监控的文件夹。"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:1
+msgid "Register Airtime"
+msgstr "注册Airtime"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:6
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:5
+#, php-format
+msgid "Help improve %s by letting us know how you're using it. This information will be collected regularly in order to enhance your user experience.<br />Click the box below and we'll make sure the features you use are constantly improving."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:29
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:29
+#, php-format
+msgid "Click the box below to promote your station on %s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:49
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:41
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:55
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:51
+msgid "(Required)"
+msgstr "（必填）"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:67
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:81
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:66
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:81
+msgid "(for verification purposes only, will not be published)"
+msgstr "（仅作为验证目的使用，不会用于发布）"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:166
+msgid "Show me what I am sending "
+msgstr "显示我所发送的信息"
+
+#: airtime_mvc/application/views/scripts/form/register-dialog.phtml:180
+msgid "Terms and Conditions"
+msgstr "使用条款"
+
+#: airtime_mvc/application/views/scripts/form/setup-lang-timezone.phtml:12
+msgid "You can change these later in your preferences and user settings."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/showbuilder.phtml:7
+msgid "Find Shows"
+msgstr "查找节目"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:66
+msgid "Search Criteria:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:68
+msgid "New Criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:77
+msgid "or"
+msgstr "或"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:78
+msgid "and"
+msgstr "和"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:99
+msgid "New Modifier"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:102
+msgid " to "
+msgstr "到"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:130
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:143
+msgid "files meet the criteria"
+msgstr "个文件符合条件"
+
+#: airtime_mvc/application/views/scripts/form/smart-block-criteria.phtml:137
+msgid "file meets the criteria"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:4
+msgid "Stream "
+msgstr "流"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:84
+msgid "Additional Options"
+msgstr "附属选项"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:144
+msgid "The following info will be displayed to listeners in their media player:"
+msgstr "以下内容将会在听众的媒体播放器上显示："
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:177
+msgid "(Your radio station website)"
+msgstr "（你电台的网站）"
+
+#: airtime_mvc/application/views/scripts/form/stream-setting-form.phtml:215
+msgid "Stream URL: "
+msgstr "流的链接地址："
+
+#: airtime_mvc/application/views/scripts/form/support-setting.phtml:46
+msgid "(In order to promote your station, 'Send support feedback' must be enabled)."
+msgstr "（为了推广您的电台，请启用‘发送支持反馈’）"
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:3
+msgid "You do not have permission to edit this track."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:6
+msgid "Viewing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/edit-file-md.phtml:8
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:10
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:10
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:4
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:8
+msgid "Editing "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:12
+msgid "Track:"
+msgstr "曲目编号："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:13
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:36
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:38
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:147
+msgid "Length:"
+msgstr "长度："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:14
+msgid "Sample Rate:"
+msgstr "样本率："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:24
+msgid "Isrc Number:"
+msgstr "ISRC编号："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:27
+msgid "File Path:"
+msgstr "文件路径："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:45
+msgid "Web Stream"
+msgstr "网络流媒体"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:46
+msgid "Dynamic Smart Block"
+msgstr "动态智能模块"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:47
+msgid "Static Smart Block"
+msgstr "静态智能模块"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:48
+msgid "Audio Track"
+msgstr "音频文件"
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:63
+msgid "Playlist Contents: "
+msgstr "播放列表内容："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:65
+msgid "Static Smart Block Contents: "
+msgstr "静态智能模块条件："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:104
+msgid "Dynamic Smart Block Criteria: "
+msgstr "动态智能模块条件："
+
+#: airtime_mvc/application/views/scripts/library/get-file-metadata.ajax.phtml:137
+msgid "Limit to "
+msgstr "限制到"
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:3
+msgid "File import in progress..."
+msgstr "导入文件进行中..."
+
+#: airtime_mvc/application/views/scripts/library/library.phtml:10
+#: airtime_mvc/application/views/scripts/widgets/lib-table.phtml:4
+msgid "Advanced Search Options"
+msgstr "高级查询选项"
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:4
+msgid "Publishing"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:6
+msgid "Edit Metadata..."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:20
+msgid "Publish to:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:27
+msgid "You have already published this track to all available sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:28
+msgid "Published tracks can be removed or updated below."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:32
+msgid "Published on:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:36
+msgid "Unpublish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:39
+msgid "You haven't published this track to any sources!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:40
+msgid "Check the boxes above and hit 'Publish' to publish this track to the marked sources."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:53
+#: airtime_mvc/application/views/scripts/library/publish-dialog.phtml:54
+msgid "Publish"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:2
+msgid "Listeners"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:10
+msgid "Stream Data Collection Status"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/listenerstat/index.phtml:23
+msgid "Monthly Listener Bandwidth Usage"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/index.phtml:7
+#, php-format
+msgid "Welcome to the %s demo! You can log in using the username 'admin' and the password 'admin'."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:3
+msgid "New password"
+msgstr "新密码"
+
+#: airtime_mvc/application/views/scripts/login/password-change.phtml:6
+msgid "Please enter and confirm your new password in the fields below."
+msgstr "请再次输入你的新密码。"
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:3
+msgid "Email Sent!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore-after.phtml:6
+msgid "A password reset link has been sent to your email address. Please check your email and follow the instructions inside to reset your password. If you don't see the email, please check your spam folder!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/login/password-restore.phtml:3
+msgid "Password Reset"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/dashboard-sub-nav.php:18
+msgid "Webstreams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:4
+msgid "Previous:"
+msgstr "之前的："
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:11
+msgid "Next:"
+msgstr "之后的："
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:25
+msgid "Source Streams"
+msgstr "输入流"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:49
+msgid "ON AIR"
+msgstr "直播中"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:50
+msgid "Listen"
+msgstr "收听"
+
+#: airtime_mvc/application/views/scripts/partialviews/header.phtml:61
+msgid "Logout"
+msgstr "登出"
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:3
+msgid "Your trial expires in"
+msgstr "你的试用天数还剩"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:40
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:46
+msgid "Toggle Details"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:44
+msgid "Shuffle playlist"
+msgstr "随机打乱播放列表"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:48
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:56
+msgid "Playlist crossfade"
+msgstr "播放列表交错淡入淡出效果"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+msgid "Empty playlist content"
+msgstr "播放列表无内容"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:52
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Clear"
+msgstr "清除"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:60
+msgid "Fade in:  "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:63
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:72
+msgid "Fade out: "
+msgstr "淡出："
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:78
+msgid "Save playlist"
+msgstr "保存播放列表"
+
+#: airtime_mvc/application/views/scripts/playlist/playlist.phtml:86
+msgid "No open playlist"
+msgstr "没有打开的播放列表"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:3
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:3
+msgid "Show Waveform"
+msgstr "显示波形图"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+msgid "Cue In: "
+msgstr "切入："
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:5
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "(hh:mm:ss.t)"
+msgstr "（时:分:秒.分秒）"
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:12
+msgid "Cue Out: "
+msgstr "切出："
+
+#: airtime_mvc/application/views/scripts/playlist/set-cue.phtml:19
+msgid "Original Length:"
+msgstr "原始长度："
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:6
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+msgid "(ss.t)"
+msgstr "（秒.分秒）"
+
+#: airtime_mvc/application/views/scripts/playlist/set-fade.phtml:19
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:68
+msgid "Fade in: "
+msgstr "淡入："
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:60
+msgid "Remove all content from this smart block"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/smart-block.phtml:93
+msgid "No smart block currently open"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:56
+msgid "Expand Static Block"
+msgstr "展开静态智能模块"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:61
+msgid "Expand Dynamic Block"
+msgstr "展开动态智能模块"
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:138
+msgid "Choose some search criteria above and click Generate to create this playlist."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:140
+msgid "A track list will be generated when you schedule this smart block into a show."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playlist/update.phtml:143
+msgid "Drag tracks here from your library to add them to the playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:8
+msgid "Log Sheet"
+msgstr "历史记录表单"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:9
+msgid "File Summary"
+msgstr "文件播放记录"
+
+#: airtime_mvc/application/views/scripts/playouthistory/index.phtml:11
+msgid "Show Summary"
+msgstr "节目播放记录"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:3
+msgid "Playout History Templates"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:5
+msgid "Log Sheet Templates"
+msgstr "历史记录表单模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:6
+msgid "New Log Sheet Template"
+msgstr "新建历史记录模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:9
+msgid "No Log Sheet Templates"
+msgstr "无历史记录表单模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:36
+msgid "File Summary Templates"
+msgstr "文件播放记录模板列表"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:37
+msgid "New File Summary Template"
+msgstr "新建文件播放记录模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/index.phtml:40
+msgid "No File Summary Templates"
+msgstr "无文件播放记录模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:2
+msgid "Creating File Summary Template"
+msgstr "创建文件播放记录模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:4
+msgid "Creating Log Sheet Template"
+msgstr "创建历史记录表单模板"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:46
+msgid "Add more elements"
+msgstr "增加更多元素"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:67
+msgid "Add New Field"
+msgstr "添加新项目"
+
+#: airtime_mvc/application/views/scripts/playouthistorytemplate/template-contents.phtml:83
+msgid "Set Default Template"
+msgstr "设为默认模板"
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:34
+msgid "Drop files here or click to browse your computer."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:66
+msgid "Failed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:67
+msgid "Pending"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/plupload/index.phtml:70
+msgid "Recent Uploads"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:11
+msgid "Podcast Name: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:15
+msgid "Podcast URL: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:22
+msgid "Automatically download latest episodes?"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:26
+msgid "Override album name with podcast name during ingest."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast.phtml:40
+msgid "Save podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:8
+msgid "RSS Feed URL:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/podcast_url_dialog.phtml:17
+msgid "Subscribe"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:8
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:101
+msgid "Save station podcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:12
+msgid "View Feed"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:20
+msgid "General Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:44
+msgid "Link"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:49
+msgid "iTunes Fields"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:52
+msgid "Author"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:55
+msgid "Keywords"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:58
+msgid "Summary"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:61
+msgid "Subtitle"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:64
+msgid "Category"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:67
+msgid "Explicit"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:72
+msgid "Privacy Settings"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/podcast/station.phtml:92
+#, php-format
+msgid ""
+"For detailed information on what these metadata fields mean, please see the %sRSS specification%s\n"
+"                    or %sApple's podcasting documentation%s."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:2
+msgid "Stream Settings"
+msgstr "流设定"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:11
+msgid "Global"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:88
+msgid "dB"
+msgstr "分贝"
+
+#: airtime_mvc/application/views/scripts/preference/stream-setting.phtml:106
+msgid "Output Streams"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Add this show"
+msgstr "添加此节目"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:6
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:53
+msgid "Update show"
+msgstr "更新节目"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:10
+msgid "What"
+msgstr "名称"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:14
+msgid "Automatic Playlist"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:18
+msgid "When"
+msgstr "时间"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:32
+msgid "Live Stream Input"
+msgstr "输入流设置"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:36
+msgid "Record & Rebroadcast"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:42
+msgid "Who"
+msgstr "管理和编辑"
+
+#: airtime_mvc/application/views/scripts/schedule/add-show-form.phtml:46
+msgid "Style"
+msgstr "风格"
+
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:29
+#: airtime_mvc/application/views/scripts/showbuilder/builderDialog.phtml:30
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:27
+#: airtime_mvc/application/views/scripts/showbuilder/index.phtml:28
+msgid "Scheduled Shows"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:25
+#, php-format
+msgid "%s Version"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:29
+msgid "Service"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/systemstatus/index.phtml:154
+msgid "Disk Space"
+msgstr "磁盘空间"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:3
+msgid "Manage Users"
+msgstr "用户管理"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:10
+msgid "New User"
+msgstr "新建用户"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:17
+msgid "id"
+msgstr "编号"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:19
+msgid "First Name"
+msgstr "名"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:20
+msgid "Last Name"
+msgstr "姓"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:21
+msgid "User Type"
+msgstr "用户类型"
+
+#: airtime_mvc/application/views/scripts/user/add-user.phtml:31
+#, php-format
+msgid "Super Admin details can be changed in your <a href=\"%s\">Billing Settings</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:30
+msgid "Stream URL:"
+msgstr "流的链接地址："
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:35
+msgid "Default Length:"
+msgstr "默认长度："
+
+#: airtime_mvc/application/views/scripts/webstream/webstream.phtml:53
+msgid "No webstream"
+msgstr "没有网络流媒体"
+
+#: airtime_mvc/public/setup/rabbitmq-setup.php:76
+msgid "Couldn't connect to RabbitMQ server! Please check if the server is running and your credentials are correct."
+msgstr ""
+
+#~ msgid "please put in a time in seconds '00 (.0)'"
+#~ msgstr "请输入秒数‘00（.0）’"
+
+#~ msgid "Content in linked shows must be scheduled before or after any one is broadcasted"
+#~ msgstr "绑定的节目要么提前设置好，要么等待其中的任何一个节目结束后才能编辑内容"

--- a/airtime_mvc/locale/zh_CN/LC_MESSAGES/pro.po
+++ b/airtime_mvc/locale/zh_CN/LC_MESSAGES/pro.po
@@ -1,16 +1,133 @@
-#: airtime_mvc/application/controllers/LoginController.php:170
+#: airtime_mvc/application/controllers/LoginController.php:188
 #, php-format
 msgid "That username or email address could not be found. If you are the station owner, you should <a href=\"%s\">reset your here</a>."
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:16
+msgid "First Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:25
+msgid "Last Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:34
+msgid "Company Name:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:43
+msgid "Email Address:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:53
+msgid "Address 1:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:62
+msgid "Address 2:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:69
+msgid "City:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:79
+msgid "State/Region:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:88
+msgid "Zip Code / Postal Code:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:101
+msgid "Country:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:111
+msgid "Phone Number:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:120
+msgid "Please choose a security question:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:134
+msgid "Please enter an answer:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:151
+msgid "VAT/Tax ID (EU only)"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:161
+msgid "Subscribe to Sourcefabric newsletter"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:171
+msgid "Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:180
+msgid "Verify Password:"
+msgstr ""
+
+#: airtime_mvc/application/forms/BillingClient.php:196
+msgid "Save"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
+msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
+msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:177
+msgid "Account Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:178
+msgid "Upgrade today to get more listeners and storage space!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:182
+msgid "Monthly Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:316
+msgid "View Plans"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:318
+msgid "Your Current Plan:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:332
+msgid "Choose a plan: "
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:358
+msgid "Please enter your payment details:"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/form/password-restore.phtml:5
+#, php-format
+msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+#, php-format
+msgid "Purchase an %s plan!"
+msgstr ""
+
+#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
+msgid "My Account"
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/plupload/index.phtml:9
 #, php-format
 msgid "Disk quota exceeded. You cannot upload files until you %s upgrade your storage"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/form/password-restore.phtml:4
-#, php-format
-msgid "If you are the primary owner of this station, <a href=\"%s\">please reset your password here</a>."
 msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:16
@@ -23,130 +140,4 @@ msgstr ""
 
 #: airtime_mvc/application/views/scripts/thank-you/index.phtml:18
 msgid "Return to Airtime"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-#, php-format
-msgid "Purchase an %s plan!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/partialviews/trialBox.phtml:9
-msgid "My Account"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:171
-msgid "Account Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:172
-msgid "Upgrade today to get more listeners and storage space!"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:255
-msgid "View Plans"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:257
-msgid "Your Current Plan:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/upgrade.phtml:291
-msgid "Please enter your payment details:"
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:7
-msgid "<b>Thank you!</b> Your plan has been updated and you will be invoiced during your next billing cycle."
-msgstr ""
-
-#: airtime_mvc/application/views/scripts/billing/invoices.phtml:11
-msgid "Tip: To pay an invoice, click \"View Invoice\" and look for the \"Checkout\" button."
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:17
-msgid "First Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:26
-msgid "Last Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:35
-msgid "Company Name:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:44
-msgid "Email Address:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:54
-msgid "Address 1:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:63
-msgid "Address 2:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:70
-msgid "City:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:80
-msgid "State/Region:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:89
-msgid "Zip Code / Postal Code:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:102
-msgid "Country:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:112
-msgid "Phone Number:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:121
-msgid "Please choose a security question:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:135
-msgid "Please enter an answer:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:152
-msgid "VAT/Tax ID (EU only)"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:162
-msgid "Subscribe to Sourcefabric newsletter"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:172
-msgid "Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:181
-msgid "Verify Password:"
-msgstr ""
-
-#: airtime_mvc/application/forms/BillingClient.php:193
-msgid "Save"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:35
-#, php-format
-msgid ""
-"\n"
-"\n"
-"If you have any problems, please contact our support team: %s"
-msgstr ""
-
-#: airtime_mvc/application/models/Auth.php:36
-#, php-format
-msgid ""
-"\n"
-"\n"
-"Thank you,\n"
-"The %s Team"
 msgstr ""


### PR DESCRIPTION
This updates the translation strings so they reflect what is in the code.

It was based on running the following and committing the results.

```
pushd dev_tools
bash update_po_files.sh
popd
```

It allows for translation using a desktop app since the new strings are contained. I would like to get these strings updated automatically from travis and then also get the translation automated through zanata, but that will need some refactoring and testing.

If anyone start translating these, the `pro.po` files can probably be ignored, if not we need to refactor the code since pro should only have legacy upstream saas strings that we are not interested in.