### PR TITLE
Fixing dependence upon hard-coded password in AutoPlaylist

### DIFF
--- a/airtime_mvc/application/common/AutoPlaylistManager.php
+++ b/airtime_mvc/application/common/AutoPlaylistManager.php
@@ -23,21 +23,18 @@ class AutoPlaylistManager {
      *
      */
     public static function buildAutoPlaylist() {
-            // Starting a session
-            Zend_Session::start();
-	        Logging::info("Checking to run Auto Playlist");
-            $autoPlaylists = static::_upcomingAutoPlaylistShows();
-            foreach ($autoPlaylists as $autoplaylist) {
-       	    // creates a ShowInstance object to build the playlist in from the ShowInstancesQuery Object     
-	        $si = new Application_Model_ShowInstance($autoplaylist->getDbId());
-	        $playlistid = $si->GetAutoPlaylistId();
+        Logging::info("Checking to run Auto Playlist");
+        $autoPlaylists = static::_upcomingAutoPlaylistShows();
+        foreach ($autoPlaylists as $autoplaylist) {
+            // creates a ShowInstance object to build the playlist in from the ShowInstancesQuery Object     
+            $si = new Application_Model_ShowInstance($autoplaylist->getDbId());
+            $playlistid = $si->GetAutoPlaylistId();
             Logging::info("Scheduling $playlistid");
             // call the addPlaylist to show function and don't check for user permission to avoid call to non-existant user object
             $si->addPlaylistToShow($playlistid, false);
             $si->setAutoPlaylistBuilt(true);
-            }
-            Application_Model_Preference::setAutoPlaylistPollLock(microtime(true));
-	        Zend_Session::stop();
+        }
+        Application_Model_Preference::setAutoPlaylistPollLock(microtime(true));
     }
 
     /**

--- a/airtime_mvc/application/models/Scheduler.php
+++ b/airtime_mvc/application/models/Scheduler.php
@@ -1,6 +1,6 @@
 <?php
 
-class Application_Model_Scheduler
+final class Application_Model_Scheduler
 {
     private $con;
     private $fileInfo = array(
@@ -23,7 +23,7 @@ class Application_Model_Scheduler
 
     private $checkUserPermissions = true;
 
-    public function __construct()
+    public function __construct($checkUserPermissions=true)
     {
         $this->con = Propel::getConnection(CcSchedulePeer::DATABASE_NAME);
 
@@ -40,7 +40,11 @@ class Application_Model_Scheduler
             $this->nowDT = DateTime::createFromFormat("U", time(), new DateTimeZone("UTC"));
         }
 
-        $this->user = Application_Model_User::getCurrentUser();
+        $this->setCheckUserPermissions($checkUserPermissions);
+
+        if ($this->checkUserPermissions) {
+            $this->user = Application_Model_User::getCurrentUser();
+        }
 
         $this->crossfadeDuration = Application_Model_Preference::GetDefaultCrossfadeDuration();
     }

--- a/airtime_mvc/application/models/Scheduler.php
+++ b/airtime_mvc/application/models/Scheduler.php
@@ -76,7 +76,7 @@ class Application_Model_Scheduler
     }
 
     /*
-     * make sure any incoming requests for scheduling are ligit.
+     * make sure any incoming requests for scheduling are legit.
     *
     * @param array $items, an array containing pks of cc_schedule items.
     */

--- a/airtime_mvc/application/models/ShowInstance.php
+++ b/airtime_mvc/application/models/ShowInstance.php
@@ -229,8 +229,7 @@ SQL;
         $ts = intval($this->_showInstance->getDbLastScheduled("U")) ? : 0;
         $id = $this->_showInstance->getDbId();
 
-        $scheduler = new Application_Model_Scheduler();
-        $scheduler->setCheckUserPermissions($checkUserPerm);
+        $scheduler = new Application_Model_Scheduler($checkUserPerm);
         $scheduler->scheduleAfter(
             array(array("id" => 0, "instance"  => $id, "timestamp" => $ts)),
             array(array("id" => $pl_id, "type" => "playlist"))

--- a/airtime_mvc/application/models/ShowInstance.php
+++ b/airtime_mvc/application/models/ShowInstance.php
@@ -230,6 +230,7 @@ SQL;
         $id = $this->_showInstance->getDbId();
 
         $scheduler = new Application_Model_Scheduler();
+        $scheduler->setCheckUserPermissions($checkUserPerm);
         $scheduler->scheduleAfter(
             array(array("id" => 0, "instance"  => $id, "timestamp" => $ts)),
             array(array("id" => $pl_id, "type" => "playlist"))


### PR DESCRIPTION
The add playlistoshow function had a parameter that wasn't being utilized to allow it to tell the validation to not check the user permissions. The passing of this parameter was added back to the addPlaylistToShow function and this removed the dependence upon initializing a user object with the hardcoded admin password. This fixes #103 