### PR TITLE
Get base_recorder_file config from proper subsection in conf

### DIFF
--- a/python_apps/pypo/pypo/recorder.py
+++ b/python_apps/pypo/pypo/recorder.py
@@ -78,7 +78,7 @@ class ShowRecorder(Thread):
         else:
             filetype = "ogg";
 
-        joined_path = os.path.join(config["base_recorded_files"], filename)
+        joined_path = os.path.join(config["pypo"]["base_recorded_files"], filename)
         filepath = "%s.%s" % (joined_path, filetype)
 
         br = config["pypo"]["record_bitrate"]


### PR DESCRIPTION
Some work for #42. There is probably more but this one leads ecasound being called again (and crashing).