### PR TITLE
Fix recording through ecasound

### DIFF
--- a/airtime_mvc/application/configs/conf.php
+++ b/airtime_mvc/application/configs/conf.php
@@ -73,10 +73,6 @@ class Config {
 
         $CC_CONFIG['apiKey'] = array($values['general']['api_key']);
         
-        if (defined('APPLICATION_ENV') && APPLICATION_ENV == "development"){
-            $CC_CONFIG['apiKey'][] = "";
-        }
-
         $CC_CONFIG['soundcloud-connection-retries'] = $values['soundcloud']['connection_retries'];
         $CC_CONFIG['soundcloud-connection-wait'] = $values['soundcloud']['time_between_retries'];
 

--- a/airtime_mvc/application/controllers/ApiController.php
+++ b/airtime_mvc/application/controllers/ApiController.php
@@ -642,25 +642,6 @@ class ApiController extends Zend_Controller_Action
         }
     }
 
-    public function uploadFileAction()
-    {
-        Logging::error("FIXME: Change the show recorder to use the File Upload API and remove this function."); // Albert - April 3, 2014
-        /**
-        $upload_dir = ini_get("upload_tmp_dir");
-        $tempFilePath = Application_Model_StoredFile::uploadFile($upload_dir);
-        $tempFileName = basename($tempFilePath);
-
-        $fileName = isset($_REQUEST["name"]) ? $_REQUEST["name"] : '';
-        $result = Application_Model_StoredFile::copyFileToStor($upload_dir, $fileName, $tempFileName);
-
-        if (!is_null($result)) {
-            $this->_helper->json->sendJson(
-                array("jsonrpc" => "2.0", "error" => array("code" => $result['code'], "message" => $result['message']))
-            );
-        }
-        **/
-    }
-
     public function uploadRecordedAction()
     {
         $show_instance_id           = $this->_getParam('showinstanceid');

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -87,6 +87,8 @@ yum install -y \
   fdk-aac \
   liquidsoap \
   silan \
+  ecasound \
+  alsa-utils \
   icecast \
   python-pip \
   selinux-policy \
@@ -155,3 +157,6 @@ systemctl restart httpd
 # icecast needs to be available to everyone
 sed -i -e 's@<bind-address>127.0.0.1</bind-address>@<bind-address>0.0.0.0</bind-address>@' /etc/icecast.xml 
 systemctl enable --now icecast
+
+# let em use alsa
+usermod -a -G audio apache

--- a/python_apps/pypo/pypo/recorder.py
+++ b/python_apps/pypo/pypo/recorder.py
@@ -95,7 +95,7 @@ class ShowRecorder(Thread):
         self.logger.info("starting record")
         self.logger.info("command " + command)
  
-        self.p = Popen(args,stdout=PIPE)
+        self.p = Popen(args,stdout=PIPE,stderr=PIPE)
 
         #blocks at the following line until the child process
         #quits
@@ -129,11 +129,10 @@ class ShowRecorder(Thread):
         # Register the streaming http handlers with urllib2
         register_openers()
 
-        # headers contains the necessary Content-Type and Content-Length
-        # datagen is a generator object that yields the encoded parameters
-        datagen, headers = multipart_encode({"file": open(filepath, "rb"), 'name': filename, 'show_instance': self.show_instance})
+        # files is what requests actually expects
+        files = {'file': open(filepath, "rb"), 'name': filename, 'show_instance': str(self.show_instance)}
 
-        self.api_client.upload_recorded_show(datagen, headers)
+        self.api_client.upload_recorded_show(files, self.show_instance)
 
     def set_metadata_and_save(self, filepath):
         """


### PR DESCRIPTION
This is part 2 of fixing ecasound recordings from line-in. Part 1 restored the User-Interface, part 2 takes care of getting to the point where ecasound gets started, records something and uploads it through rest when done. Part 3 will take care of making sure that the recorded file is mapped to the show and not just stored as a new track.

I refactored api_clients to not use urllib2 for posting multipart data since I was loosing my sanity over it and requests seems to have a modern approach to doing this compared to what api_clients was previously doing.

This is a large part of #42 but there is still some more re-implementing to do. I'm PRing this now since I already spent way too much time to get it to this stage.