### PR TITLE
Install python-rgain and mp3 deps

### DIFF
--- a/installer/lib/requirements-debian-jessie.apt
+++ b/installer/lib/requirements-debian-jessie.apt
@@ -25,6 +25,10 @@ libportaudio2
 libsamplerate0
 libvo-aacenc0
 
+python-rgain
+python-gst-1.0
+gstreamer1.0-plugins-ugly
+
 patch
 
 icecast2

--- a/installer/lib/requirements-debian-wheezy.apt
+++ b/installer/lib/requirements-debian-wheezy.apt
@@ -25,6 +25,11 @@ libportaudio2
 libsamplerate0
 libvo-aacenc0
 
+python-rgain
+python-gst0.10
+gstreamer0.10-plugins-ugly
+gir1.2-gstreamer-0.10
+
 patch
 
 icecast2

--- a/installer/lib/requirements-ubuntu-precise.apt
+++ b/installer/lib/requirements-ubuntu-precise.apt
@@ -24,6 +24,10 @@ ecasound
 libportaudio2
 libsamplerate0
 
+python-rgain
+python-gst0.10
+gstreamer0.10-plugins-ugly
+gir1.2-gstreamer-0.10
 patch
 
 php5-curl

--- a/installer/lib/requirements-ubuntu-trusty.apt
+++ b/installer/lib/requirements-ubuntu-trusty.apt
@@ -24,6 +24,10 @@ ecasound
 libportaudio2
 libsamplerate0
 
+python-rgain
+python-gst-1.0
+gstreamer1.0-plugins-ugly
+
 patch
 
 php5-curl


### PR DESCRIPTION
I tested installing these in a docker container on each of the distros. The gir1.2-gstreamer-1.0 package is getting pulled in by the python-rgain package which I added to the list. I'm pretty sure this installs everything mentioned in #128.

Fixes #128 