### PR TITLE
Remove hardcoded include of pervasives.liq

### DIFF
--- a/python_apps/pypo/liquidsoap/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/ls_script.liq
@@ -5,7 +5,6 @@ set("server.telnet", true)
 set("server.telnet.port", 1234)
 # set("init.daemon.pidfile.path", "/var/run/airtime/airtime-liquidsoap.pid")
 
-%include "library/pervasives.liq"
 
 #Dynamic source list
 #dyn_sources = ref []


### PR DESCRIPTION
There was an attempt to include library/pervasives.liq which was causing errors after #131 was merged. I think that this library is automatically included so I removed the include and it appears to be working. Hopefully this fixes #140