### PR TITLE
Do not explicity load pervasives.liq

### DIFF
--- a/utils/airtime-test-stream.py
+++ b/utils/airtime-test-stream.py
@@ -98,7 +98,7 @@ try:
     if stream_type == "icecast":
         command = "%s 'output.icecast(%%vorbis, host = \"%s\", port = %s, user= \"%s\", password = \"%s\", mount=\"%s\", sine())'" % (liquidsoap_exe, host, port, user, password, mount)
     else:
-        command = "%s /usr/lib/airtime/pypo/bin/liquidsoap_scripts/library/pervasives.liq 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
+        command = "%s 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
         % (liquidsoap_exe, host, port, user, password)
 
     if not verbose:

--- a/utils/airtime-test-stream.py
+++ b/utils/airtime-test-stream.py
@@ -30,6 +30,8 @@ def printUsage():
 
 def find_liquidsoap_binary():
     """
+    With libretime 3.0 we are no longer depending upon airtime-liquidsoap but using the built in liquidsoap
+    rather than a bundled version of it. So this function no longer needs to be used.
     Starting with Airtime 2.0, we don't know the exact location of the Liquidsoap
     binary because it may have been installed through a debian package. Let's find
     the location of this binary.
@@ -91,15 +93,14 @@ try:
     print "Outputting to %s streaming server. You should be able to hear a monotonous tone on '%s'. Press ctrl-c to quit." % (stream_type, url)
 
     liquidsoap_exe = find_liquidsoap_binary()
-
     if liquidsoap_exe is None:
         raise Exception("Liquidsoap not found!")
 
     if stream_type == "icecast":
-        command = "%s 'output.icecast(%%vorbis, host = \"%s\", port = %s, user= \"%s\", password = \"%s\", mount=\"%s\", sine())'" % (liquidsoap_exe, host, port, user, password, mount)
+        command = "liquidsoap 'output.icecast(%%vorbis, host = \"%s\", port = %s, user= \"%s\", password = \"%s\", mount=\"%s\", sine())'" % (host, port, user, password, mount)
     else:
-        command = "%s 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
-        % (liquidsoap_exe, host, port, user, password)
+        command = "liquidsoap 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
+        % (host, port, user, password)
 
     if not verbose:
         command += " 2>/dev/null | grep \"failed\""

--- a/utils/airtime-test-stream.py
+++ b/utils/airtime-test-stream.py
@@ -30,16 +30,14 @@ def printUsage():
 
 def find_liquidsoap_binary():
     """
-    With libretime 3.0 we are no longer depending upon airtime-liquidsoap but using the built in liquidsoap
-    rather than a bundled version of it. So this function no longer needs to be used.
-    Starting with Airtime 2.0, we don't know the exact location of the Liquidsoap
-    binary because it may have been installed through a debian package. Let's find
-    the location of this binary.
+    With libretime 3.0 we are no longer depending upon the airtime-liquidsoap binary
+    but use a generic install of liquidsoap. This takes care of checking if it is on the
+    path and will lead to an error otherwise.
     """
 
-    rv = subprocess.call("which airtime-liquidsoap > /dev/null", shell=True)
+    rv = subprocess.call("which liquidsoap > /dev/null", shell=True)
     if rv == 0:
-        return "airtime-liquidsoap"
+        return "liquidsoap"
 
     return None
 
@@ -97,10 +95,10 @@ try:
         raise Exception("Liquidsoap not found!")
 
     if stream_type == "icecast":
-        command = "liquidsoap 'output.icecast(%%vorbis, host = \"%s\", port = %s, user= \"%s\", password = \"%s\", mount=\"%s\", sine())'" % (host, port, user, password, mount)
+        command = "%s 'output.icecast(%%vorbis, host = \"%s\", port = %s, user= \"%s\", password = \"%s\", mount=\"%s\", sine())'" % (liquidsoap_exe, host, port, user, password, mount)
     else:
-        command = "liquidsoap 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
-        % (host, port, user, password)
+        command = "%s 'output.shoutcast(%%mp3, host=\"%s\", port = %s, user= \"%s\", password = \"%s\", sine())'" \
+        % (liquidsoap_exe, host, port, user, password)
 
     if not verbose:
         command += " 2>/dev/null | grep \"failed\""


### PR DESCRIPTION
As per the liquidsoap docs the file is loaded per default anyhow http://savonet.sourceforge.net/doc-svn/script_loading.html.

I think the output.shoutcast might be the only place where we really use it though. Testing this against shoutcast would be nice, but I don't have one and am not sure how relevant it still is.

Sorry again for breaking liquidsoap with #131 😞 