### PR TITLE
Use json_encode if we need to return js and not json

### DIFF
--- a/airtime_mvc/application/controllers/LocaleController.php
+++ b/airtime_mvc/application/controllers/LocaleController.php
@@ -438,7 +438,7 @@ final class LocaleController extends Zend_Controller_Action
         );
         $this->view->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
-        header("Content-type: text/javascript");
-        echo "var general_dict=".$this->_helper->json->encodeJson($translations);
+        header("Content-Type: text/javascript");
+        echo "var general_dict=" . json_encode($translations);
     }
 }


### PR DESCRIPTION
Turns out the zf1 jsonHelper whas doing some weird stuff to the content-type header under the hood.

Fixes #145 