### PR TITLE
Install curl on all platforms

### DIFF
--- a/installer/lib/requirements-debian-wheezy.apt
+++ b/installer/lib/requirements-debian-wheezy.apt
@@ -34,6 +34,7 @@ patch
 
 icecast2
 
+curl
 php5-curl
 mpg123
 

--- a/installer/lib/requirements-ubuntu-precise.apt
+++ b/installer/lib/requirements-ubuntu-precise.apt
@@ -30,6 +30,7 @@ gstreamer0.10-plugins-ugly
 gir1.2-gstreamer-0.10
 patch
 
+curl
 php5-curl
 mpg123
 

--- a/installer/lib/requirements-ubuntu-trusty.apt
+++ b/installer/lib/requirements-ubuntu-trusty.apt
@@ -30,6 +30,7 @@ gstreamer1.0-plugins-ugly
 
 patch
 
+curl
 php5-curl
 mpg123
 


### PR DESCRIPTION
As per the https://github.com/LibreTime/libretime/issues/145#issuecomment-292744215 it looks like we always need to install this.