### PR TITLE
Create .gitattributes to ensure proper cloning with Windows Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Auto-detect text vs. binary files and ensure newlines are always LF for
+# text files on check-out and check-in.
+* text=auto eol=lf


### PR DESCRIPTION
Address issue #141 so Git cloning under Windows preserves line endings of relevant scripts and files regardless of a user's local Git configuration so it's possible to provision a VM with Vagrant, install and run LibreTime in place without issue.