### PR TITLE
Fix/celery worker crash

### DIFF
--- a/python_apps/airtime-celery/setup.py
+++ b/python_apps/airtime-celery/setup.py
@@ -44,7 +44,7 @@ setup(name='airtime-celery',
       install_requires=[
           'soundcloud',
           'celery < 4',
-          'kombu',
+          'kombu < 3.1',
           'configobj'
       ],
       zip_safe=False,

--- a/python_apps/airtime-celery/setup.py
+++ b/python_apps/airtime-celery/setup.py
@@ -43,7 +43,7 @@ setup(name='airtime-celery',
       packages=['airtime-celery'],
       install_requires=[
           'soundcloud',
-          'celery',
+          'celery < 4',
           'kombu',
           'configobj'
       ],


### PR DESCRIPTION
This fixes #147 by using the compatible celery < 4 and the compatible kombu version.