### PR TITLE
Problem: airtime-liquidsoap --debug only works for liquidsoap

### DIFF
--- a/python_apps/pypo/liquidsoap/__main__.py
+++ b/python_apps/pypo/liquidsoap/__main__.py
@@ -4,6 +4,7 @@
 import argparse
 import os
 import generate_liquidsoap_cfg
+import logging
 
 PYPO_HOME = '/var/tmp/airtime/pypo/'
 
@@ -15,6 +16,9 @@ def run():
     args = parser.parse_args()
     
     os.environ["HOME"] = PYPO_HOME
+
+    if args.debug:
+        logging.basicConfig(level=getattr(logging, 'DEBUG', None))
     
     generate_liquidsoap_cfg.run()
     script_path = os.path.join(os.path.dirname(__file__), 'ls_script.liq')


### PR DESCRIPTION
It doesn't reconfigure python logging to get python debug output working as expected. This does not help for debugging #140 as there is already a debug log call that would output the actual URL being used.

Solution: Reconfigure python logging to output DEBUG log messages if `--debug` is passed.

Called as `airtime-liquidsoap --debug` the script will output the following should the connection to the api fail.

```
DEBUG:root:http://localhost:808/api/get-stream-setting/format/json/api_key/4ITVDK98D9USO9OLM7OA/
ERROR:root:HTTP request to http://localhost:808/api/get-stream-setting/format/json/api_key/4ITVDK98D9USO9OLM7OA/ failed
```