### PR TITLE
Problem: legacy upstream name is still in defaultdata

### DIFF
--- a/airtime_mvc/build/sql/defaultdata.sql
+++ b/airtime_mvc/build/sql/defaultdata.sql
@@ -3,7 +3,7 @@ INSERT INTO cc_pref("keystr", "valstr") VALUES('schema_version', '3.0.0-alpha');
 
 INSERT INTO cc_subjs ("login", "type", "pass") VALUES ('admin', 'A', md5('admin'));
 -- added in 2.3
-INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('off_air_meta', 'Airtime - offline', 'string');
+INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('off_air_meta', 'LibreTime - offline', 'string');
 INSERT INTO cc_pref("keystr", "valstr") VALUES('enable_replay_gain', 1);
 -- end of added in 2.3
 
@@ -36,7 +36,7 @@ INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_admin_use
 INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_admin_pass', '', 'string');
 INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_mount', 'airtime_128', 'string');
 INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_url', 'http://airtime.sourcefabric.org', 'string');
-INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_description', 'Airtime Radio! Stream #1', 'string');
+INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_description', 'LibreTime Radio! Stream #1', 'string');
 INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s1_genre', 'genre', 'string');
 
 INSERT INTO cc_stream_setting ("keyname", "value", "type") VALUES ('s2_enable', 'false', 'boolean');
@@ -312,7 +312,7 @@ INSERT INTO cc_country (isocode, name) VALUES ('ZWE', 'Zimbabwe ');
 
 
 -- added in 2.2
-INSERT INTO cc_stream_setting (keyname, value, type) VALUES ('s1_name', 'Airtime!', 'string');
+INSERT INTO cc_stream_setting (keyname, value, type) VALUES ('s1_name', 'LibreTime!', 'string');
 INSERT INTO cc_stream_setting (keyname, value, type) VALUES ('s2_name', '', 'string');
 INSERT INTO cc_stream_setting (keyname, value, type) VALUES ('s3_name', '', 'string');
 

--- a/python_apps/pypo/liquidsoap/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/ls_script.liq
@@ -179,7 +179,7 @@ server.register(namespace="dynamic_source",
 default = amplify(id="silence_src", 0.00001, noise())
 ref_off_air_meta = ref off_air_meta
 if !ref_off_air_meta == "" then
-    ref_off_air_meta := "Airtime - offline"
+    ref_off_air_meta := "LibreTime - offline"
 end
 default = rewrite_metadata([("title", !ref_off_air_meta)], default)
 ignore(output.dummy(default, fallible=true))


### PR DESCRIPTION
This shows up in places like *Off Air Metadata* as mentioned in #162 and others like the default stream setup.

Solution: Replace legacy upstream name with "LibreTime" in defaultdata.sql

I believe the file is not autogenerated so just changing it directly is the way to go.
