### PR TITLE
Use the minimized angular from public dir instead of cdn

### DIFF
--- a/airtime_mvc/application/controllers/EmbedController.php
+++ b/airtime_mvc/application/controllers/EmbedController.php
@@ -90,6 +90,7 @@ class EmbedController extends Zend_Controller_Action
 
         $request = $this->getRequest();
 
+        $this->view->angular = Application_Common_HTTPHelper::getStationUrl() . 'js/libs/angular.min.js?'.$CC_CONFIG['airtime_version'];
         $widgetStyle = $request->getParam('style');
         if ($widgetStyle == "premium") {
             $this->view->widgetStyle = "premium";

--- a/airtime_mvc/application/views/scripts/embed/weekly-program.phtml
+++ b/airtime_mvc/application/views/scripts/embed/weekly-program.phtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.16/angular.js" type="text/javascript"></script>
+    <script src="<?php echo $this->angular ?>" type="text/javascript"></script>
     <link rel="stylesheet" href="<?php echo $this->css?>" type="text/css">
     <script src="<?php echo $this->jquery ?>" type="text/javascript"></script>
     <link href='https://fonts.googleapis.com/css?family=Roboto:400,100,300,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
This uses the available minimized version of angular instead of using the non minimized version from the google cdn. 

Fixes #167 