### PR TITLE
Use file-magic instead of python-magic

### DIFF
--- a/python_apps/airtime_analyzer/airtime_analyzer/metadata_analyzer.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/metadata_analyzer.py
@@ -41,7 +41,10 @@ class MetadataAnalyzer(Analyzer):
             metadata["md5"] = m.hexdigest()
 
         # Mutagen doesn't handle WAVE files so we use a different package 
-        mime_check = magic.from_file(filename, mime=True)
+        ms = magic.open(magic.MIME_TYPE)
+        ms.load()
+        with open(filename, 'rb') as fh:
+            mime_check = ms.buffer(fh.read(2014))
         metadata["mime"] = mime_check
         if mime_check == 'audio/x-wav':
             return MetadataAnalyzer._analyze_wave(filename, metadata)
@@ -164,7 +167,6 @@ class MetadataAnalyzer(Analyzer):
     def _analyze_wave(filename, metadata):
         try:
             reader = wave.open(filename, 'rb')
-            metadata["mime"] = magic.from_file(filename, mime=True)
             metadata["channels"] = reader.getnchannels()
             metadata["sample_rate"] = reader.getframerate()
             length_seconds = float(reader.getnframes()) / float(metadata["sample_rate"])

--- a/python_apps/airtime_analyzer/setup.py
+++ b/python_apps/airtime_analyzer/setup.py
@@ -31,7 +31,7 @@ setup(name='airtime_analyzer',
           'mutagen==1.31', # The Mutagen guys change stuff all the time that break our unit tests. Watch out for this.
           'pika',
           'daemon',
-          'python-magic',
+          'file-magic',
           'nose',
           'coverage',
           'mock',


### PR DESCRIPTION
This gets the mime type using file-magic in a most minimal way. Since the python bindings have been available as a distro package for quite a while it is written in a way so it should also run on pre pypi installs of file-magic. This means not being able to use nice things like magic.detect_from_filename due to the fact that they where added rather recently (with recently being 2 years ago).

As the mime type is only used to check for wav files that mutagen can't handle it only reads the mime type and ignores the charset and other attributes that magic can find.

Due to the fact that file-magic is not properly unicode safe I'm checking the file based on it's first 2048 bytes as per <http://stackoverflow.com/questions/34836792/python-magic-cant-identify-unicode-filename#comment57418632_34838355>. This is not an issue since wav files need to start with a wav header by definition anyway.

I tested this successfully on both CentOS and Debian with files containing Unicode in their names.

Fixes #166 