### PR TITLE
Switch Vagrantfile to use bento boxes for Debian #170

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,17 @@ Vagrant.configure("2") do |config|
     os.vm.box = "ubuntu/trusty64"
     provision_libretime(os, "ubuntu.sh", installer_args + "--distribution=ubuntu --release=trusty")
   end
+  config.vm.define "debian-jessie" do |os|
+    os.vm.box = "bento/debian-8.7"
+    provision_libretime(os, "debian.sh", installer_args + "--distribution=debian --release=jessie")
+  end
+  config.vm.define "debian-wheezy" do |os|
+    os.vm.box = "bento/debian-7.11"
+    provision_libretime(os, "debian.sh", installer_args + "--distribution=debian --release=wheezy")
+  end
   config.vm.define "debian" do |os|
+    STDERR.puts 'WARNING: The "debian" option is deprecated. Please migrate to "debian-jessie".'
+    STDERR.puts
     os.vm.box = "debian/jessie64"
     provision_libretime(os, "debian.sh", installer_args + "--distribution=debian --release=jessie")
   end

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -34,10 +34,12 @@ With the above instructions LibreTime is installed on Ubuntu Trusty Tahir. The V
 | OS     | Command             | Comment |
 | ------ | ------------------- | ------- |
 | Ubuntu 14.04 | `vagrant up ubuntu-trusty` | Current default install since it was used by legacy upstream, based on Trusty Tahir. |
-| Debian | `vagrant up debian` | Recommended install on Jessie as per the docs. |
+| Debian 8.7   | `vagrant up debian-jessie` | Recommended install on Jessie as per the docs. |
 | Ubuntu 16.04 | `vagrant up ubuntu-xenial` | Experimental install on current Ubuntu Xenial Xerus. |
+| Debian 7.11  | `vagrant up debian-wheezy` | Recommended install on Wheezy as per the docs. |
 | CentOS | `vagrant up centos` | Experimental install on 7.3 with native systemd support and activated SELinux. |
 | Ubuntu | `vagrant up ubuntu` | Deprecated Ubuntu Trusty install, replaced by `ubuntu-trusty`. Do not use for new installs! |
+| Debian | `vagrant up debian` | Deprecated Debian Jessie install, replaced by `debian-jessie`. Do not use for new installs! |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Update Vagrantfile and docs for Debian as outlined in issue #170.