### PR TITLE
Correction lines 399 and 400.  ls_script.liq

### DIFF
--- a/python_apps/pypo/liquidsoap/ls_script.liq
+++ b/python_apps/pypo/liquidsoap/ls_script.liq
@@ -396,8 +396,8 @@ if s3_enable == true then
     end
     server.register(namespace=!s3_namespace, "connected", fun (s) -> begin log("#{!s3_namespace}.connected") !s3_connected end)
     output_to(s3_output, s3_type, s3_bitrate, s3_host, s3_port, s3_pass,
-                s3_mount, s3_url, s3_name, s3_genre, s3_user, s, "3",
-                s3_connected, s3_description, s3_channels)
+                s3_mount, s3_url, s3_description, s3_genre, s3_user, s, "3",
+                s3_connected, s3_name, s3_channels)
 end
 
 s4_namespace = ref ''


### PR DESCRIPTION
Lines 399 and 400. Changed the values of s3_name and s3_description places. 
(Because of this error, the Icecast confused the name and description of the flow)
_______________________
Строки 399 и 400. Поменял значения s3_name и s3_description местами. (Из-за этой ошибки Icecast путал название и описание потока)
_______________________
Sorry for my clumsy translation, I'm from Russia