### PR TITLE
Refactor upgrading docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,8 @@ from around the globe that use, document and improve LibreTime.
 **Can I upgrade to LibreTime?**
 
 In theory you can update any pre 3.0 version of AirTime to
-LibreTime 3.0.0 and above. 
+LibreTime 3.0.0 and above. More information on [Upgrading](../manual/upgrading)
+is in the docs.
 
 LibreTime is complex software, as such it is close to impossible
 to guarantee that every upgrade path works as intended. This

--- a/docs/manual/upgrading/index.md
+++ b/docs/manual/upgrading/index.md
@@ -1,33 +1,61 @@
-Airtime 2.5.x versions support upgrading from version 2.3.0 and above. If you are running a production server with a version of Airtime prior to 2.3.0, you should upgrade it to version 2.3.0 before continuing. 
+LibreTime 3.x versions support upgrading from Airtime 2.5.x versions. LibreTime 
+follows the [Semantic Versioning (semver)](http://semver.org/spec/v2.0.0.html) standards.
 
-Before upgrading a production Airtime server, you should back up both the PostgreSQL database and the storage server used by Airtime. This is especially important if you have not already set up a regular back up routine. This extra back up is a safety measure in case of accidental data loss during the upgrade, for example due to the wrong command being entered when moving files. See the chapter *Backing up the server* in this book for details of how to perform these back ups.
+In a nutshell, given a version number MAJOR.MINOR.PATCH we increment the:
 
-If you have deployed Airtime using the method shown in the *Automated installation* chapter, you can upgrade in the same way. A new Airtime package available in the Sourcefabric repository can be installed with:
+1. MAJOR version when we make incompatible API changes,
+2. MINOR version when we add functionality in a backwards-compatible manner, and
+3. PATCH version when we make backwards-compatible bug fixes.
+
+Any pre-release versions of LibreTime are denoted by appending a hyphen and a series 
+of dot separated identifiers immediately following the patch version. This pre-release
+indicates that the version is unstable in a sense that it might contain incomplete
+features or not satisfy the intended compatibility requirements as per semver.
+
+Before upgrading a production LibreTime server, you should back up both the PostgreSQL
+database and the storage server used by LibreTime. This is especially important if you 
+have not already set up a regular back up routine. This extra back up is a safety measure 
+in case of accidental data loss during the upgrade, for example due to the wrong command
+being entered when moving files. See [Backing up the server](../backing-up-the-server/)
+in this manual for details of how to perform these back ups.
+
+If you have deployed LibreTime using the method shown in [Automated installation](../automated-installation/),
+you can upgrade in the same way. A new LibreTime package available in 
+the repository can be installed with:
 
     sudo apt-get update
     sudo apt-get upgrade
 
-If you have used the method shown in the *Manual installation* chapter, you should repeat the installation steps of downloading and unpacking the tarball to an installation directory, or pulling from the git repository, and running the **airtime-install** or **airtime-full-install** script. The installation script will detect an existing Airtime deployment and back up any configuration files that it finds.
+If you have used the method shown in [Manual installation](../manual-installation/), you should 
+repeat the installation steps of downloading and unpacking the tarball to an 
+installation directory, or pulling from the git repository with `git pull`, and 
+running the `./install` script. The installation script will detect an existing 
+LibreTime deployment and back up any configuration files that it finds. We recommend 
+taking your own manual backups of the configuration yourself nevertheless.
 
-After the upgrade has completed, you may need to clear your web browser's cache before logging into the new version of the Airtime administration interface. If the playout engine starts up and detects that a show should be playing at the current time, it will skip to the correct point in the current item and start playing.
+After the upgrade has completed, you may need to clear your web browser's cache 
+before logging into the new version of the LibreTime administration interface. If
+the playout engine starts up and detects that a show should be playing at the 
+current time, it will skip to the correct point in the current item and start playing.
 
-In Airtime 1.9.0 onwards, the concept of *linked files* was replaced with the concept of *watched folders*. If you are upgrading from a version of Airtime earlier than 1.9.0 and you have previously linked files, the folders they are in will not be watched until you add them to your watched folder list. See the chapter *Media Folders* for more details.
+There will be tested ways to switch from a LibreTime pre-release to a packaged version
+of LibreTime.
+
+Airtime 2.5.x versions support upgrading from version 2.3.0 and above. If you are
+running a production server with a version of Airtime prior to 2.3.0, you should
+upgrade it to version 2.3.0 before continuing. 
+
+In Airtime 1.9.0 onwards, the concept of *linked files* was replaced with the
+concept of *watched folders*. If you are upgrading from a version of Airtime 
+earlier than 1.9.0 and you have previously linked files, the folders they are
+in will not be watched until you add them to your watched folder list. See
+[Media Folders](../media-folders) for more details.
 
 Upgrading the server distribution
 ---------------------------------
 
-After your Airtime server has been deployed for a few years, you may need to upgrade the GNU/Linux distribution that it runs in order to maintain security update support. If the upgrade does not go smoothly, it may cause significant downtime, so you should always have a fallback system available during the upgrade to ensure broadcast continuity.
-
-After upgrading a server from Ubuntu Lucid 10.04 LTS to Ubuntu Precise 12.04 LTS, you may experience problems with Monit failing to start, due to a change in the format of its configuration files. If so, a double equals sign can be changed to single equals in line 39 of /etc/init.d/monit so that it reads:
-
-      if [ "$1" = "start" ]
-
-Also, the file /etc/default/monit should contain the line:
-
-    START=yes
-
-instead of how it was configured in Ubuntu Lucid:
-
-    startup=1
-
-This modification is sometimes necessary because during distribution upgrade it is normal to keep any locally modified configuration files.
+After your LibreTime server has been deployed for a few years, you may need to
+upgrade the GNU/Linux distribution that it runs in order to maintain security
+update support. If the upgrade does not go smoothly, it may cause significant
+downtime, so you should always have a fallback system available during the 
+upgrade to ensure broadcast continuity.

--- a/docs/manual/upgrading/index.md
+++ b/docs/manual/upgrading/index.md
@@ -33,6 +33,12 @@ running the `./install` script. The installation script will detect an existing
 LibreTime deployment and back up any configuration files that it finds. We recommend 
 taking your own manual backups of the configuration yourself nevertheless.
 
+The install script tries to restart the needed services during an upgrade. In any case
+you should monitor if this happened and also take a quick look at the logs files to
+be sure everything is still fine. Now might be the time to reboot the system or
+virtual machine LibreTime is running on since regular reboots are part of a healthy
+system anyway.
+
 After the upgrade has completed, you may need to clear your web browser's cache 
 before logging into the new version of the LibreTime administration interface. If
 the playout engine starts up and detects that a show should be playing at the 


### PR DESCRIPTION
This is to make it so it's clear that the update path is still more or less the same and adds all the new info I'm aware of that needs to be considered during the upgrade.

* [x] explain semver since this upgrade cases are when this applies
* [x] links to different parts of manual
* [x] move backup section to the top
* [x] add "real" git pull example
* [x] rename install script to plain ./install
* [x] remove very old monit upgrade help

You can see the updated docs by [looking at the changed branch directly](https://github.com/radiorabe/libretime/blob/feature/update-docs/docs/manual/upgrading/index.md). I'm keeping the apt-get install stuff as is since we plan on re-adding it.

Please let me know if you have any more info or would want me to clarify something in the text and I'll be glad to add it here. I think this should cover both #184 and #178.

Fix #184 
Fix #178