### PR TITLE
Problem: Deleting the initial admin won't work since it doesn't re-assign files

### DIFF
--- a/airtime_mvc/application/controllers/UserController.php
+++ b/airtime_mvc/application/controllers/UserController.php
@@ -204,7 +204,7 @@ class UserController extends Zend_Controller_Action
         # TODO : remove this. we only use default for now not to break the UI.
         if (!$files_action) { # set default action
             $files_action = "reassign_to";
-            $new_owner    = Application_Model_User::getFirstAdmin();
+            $new_owner    = Application_Model_User::getFirstAdmin($delId);
         }
 
         # only delete when valid action is selected for the owned files

--- a/airtime_mvc/application/models/User.php
+++ b/airtime_mvc/application/models/User.php
@@ -267,16 +267,6 @@ class Application_Model_User
         }
     }
 
-    public static function getFirstAdminId()
-    {
-        $admin = self::getFirstAdmin();
-        if ($admin) { 
-            return $admin->getDbId();
-        } else {
-            return null;
-        }
-    }
-
     public static function getUsers(array $type, $search=null)
     {
         $con     = Propel::getConnection();

--- a/airtime_mvc/application/models/User.php
+++ b/airtime_mvc/application/models/User.php
@@ -253,12 +253,29 @@ class Application_Model_User
         return CcSubjsQuery::create()->filterByDbType($type)->find();
     }
 
-    public static function getFirstAdmin() {
+    /**
+     * Get the first admin user from the database
+     *
+     * This function gets used in UserController in the delete action. The controller
+     * uses it to figure out who to reassign the deleted users files to.
+     *
+     * @param $ignoreUser String optional userid of a user that shall be ignored when
+     *                           when looking for the "first" admin.
+     *
+     * @return CcSubj|null
+     */
+    public static function getFirstAdmin($ignoreUser = null) {
         $superAdmins = Application_Model_User::getUsersOfType('S');
         if (count($superAdmins) > 0) { // found superadmin => pick first one
             return $superAdmins[0];
         } else {
-            $admins = Application_Model_User::getUsersOfType('A');
+            // get all admin users
+            $query = CcSubjsQuery::create()->filterByDbType('A');
+            // ignore current user if one was specified
+            if ($ignoreUser !== null) {
+                $query->filterByDbId($ignoreUser, Criteria::NOT_EQUAL);
+            }
+            $admins = $query->find();
             if (count($admins) > 0) { // found admin => pick first one
                 return $admins[0];
             }


### PR DESCRIPTION
As described in #205 the default admin user can't be deleted. This stems from [the UserController trying to re-assign all the users files to the first admin it can find](https://github.com/LibreTime/libretime/blob/2b30a14744f857657f2e3b7e9c96713929343dd2/airtime_mvc/application/controllers/UserController.php#L207). In this case the initial admin is the user we are trying to delete. Since the controller can't re-assign the files to a new user deleting the user fails with a `foreign key violation: 7 ERROR:  update or delete on table "cc_subjs" violates foreign key constraint "cc_files_owner_fkey" on table "cc_files"` error.

Solution: Update the `getFirstAdmin` function in the user model to ignore the user being deleted. This way it finds a different admin to re-assign the files to and deleting works as intended.