### PR TITLE
Only update timescale pref in db on change

### DIFF
--- a/airtime_mvc/public/js/airtime/schedule/full-calendar-functions.js
+++ b/airtime_mvc/public/js/airtime/schedule/full-calendar-functions.js
@@ -177,9 +177,12 @@ function viewDisplay( view ) {
         }
     }
 
-    //save view name to db
-    var url = baseUrl+'Schedule/set-time-scale/format/json';
-    $.post(url, {timeScale: view.name});
+    //save view name to db if it was changed
+    if (calendarPref.timeScale !== view.name) {
+        var url = baseUrl+'Schedule/set-time-scale/format/json';
+        $.post(url, {timeScale: view.name});
+        calendarPref.timeScale = view.name;
+    }
 }
 
 function eventRender(event, element, view) {


### PR DESCRIPTION
## Problem
The /Schedule/set-time-scale/format/json was being hit every time a new calendar page was displayed. The isn't good for performance reasons and also makes race conditions like #210 much more likely.

## Solution

With this change the preference is only updated on the server when the GUI state changes because the user clicked on one of the "Day", "Week", or "Month" buttons.

This does not fix the locking issue completely, but it should help because the cc_prefs time-scale row in the database will get locked much less often. After applying this I wasn't able to reproduce #210 any more on an install with an extensive schedule.