### PR TITLE
Add silan info to faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,6 +19,10 @@ infrastructure to minimize possible downtime.
 Please let the community know if you encounter issues with the
 update process. 
 
+**Why are Cue-In/Out points wrong in some tracks? / What's with silan?**
+
+The silan silence detection is currently outdated on almost all distributions. The older versions report clearly wrong information and may segfault at the worst. Versions starting with 0.3.3 (and some patched 0.3.2 builds) are much better but still need thorough testing. Please see the [release notes](https://github.com/LibreTime/libretime/releases) for up to date mitigation scenarios and details on the issues. 
+
 **Why did you fork AirTime?**
 
 See this [open letter to the Airtime community](https://gist.github.com/hairmare/8c03b69c9accc90cfe31fd7e77c3b07d).


### PR DESCRIPTION
"What's with cue-In/Out points and silan?" is a frequently asked question that currently has multiple possible fixes and a couple of open tasks (not only "Why is it broken?" but also "Where is the cue-point editor?").

I added current infos to the release notes and was thinking this should be pointed out in the FAQ until we have a stable solution ready.