### PR TITLE
Remove assert() from rest module bootstrap

### DIFF
--- a/airtime_mvc/application/modules/rest/Bootstrap.php
+++ b/airtime_mvc/application/modules/rest/Bootstrap.php
@@ -9,7 +9,7 @@ class Rest_Bootstrap extends Zend_Application_Module_Bootstrap
 
         $restRoute = new Zend_Rest_Route($front, array(), array(
             'rest'=> array('media', 'show-image', 'podcast', 'podcast-episodes')));
-        assert($router->addRoute('rest', $restRoute));
+        $router->addRoute('rest', $restRoute);
 
         $podcastBulkRoute = new Zend_Controller_Router_Route(
             'rest/podcast/bulk',


### PR DESCRIPTION
## Problem

`assert()` is a language construct in php 7 and not a function anymore. It also seems to behave slightly differently with regards to what kind of side effects assertions are allowed to have. This leads to all of the rest endpoints being broken in php 7 since the assertion silently fails and the routes never really get added to the front controllers router.

## Solution

Don't wrap the `addRouter()` call in `assert()`. The way assert was being used was rather unusual for php code this age. It was also mostly checking zf1 rather than guarding against errors in LibreTime itself.

The php manual clearly states "As a rule of thumb your code should always be able to work correctly if assertion checking is not activated." giving even more reason to not wrap critical paths in assertions.

There are some other instances of `assert()` being used in non test code, those don't seem to have any negative effects on php7.