### PR TITLE
Fix update warning

### DIFF
--- a/install
+++ b/install
@@ -734,6 +734,7 @@ elif [ -n "$web_root" ]; then
     verbose "\n * Creating Apache web root directory..."
     cp -R ${AIRTIMEROOT}/airtime_mvc ${web_root}
     cp -R ${AIRTIMEROOT}/vendor ${web_root}
+    cp ${AIRTIMEROOT}/VERSION ${web_root}
     web_root=${web_root}/airtime_mvc/public/
 else
     verbose "\n * Creating default Apache web root directory /usr/share/airtime/php..."
@@ -741,6 +742,7 @@ else
     mkdir -p ${web_root}
     cp -R ${AIRTIMEROOT}/airtime_mvc ${web_root}
     cp -R ${AIRTIMEROOT}/vendor ${web_root}
+    cp ${AIRTIMEROOT}/VERSION ${web_root}
     web_root=${web_root}/airtime_mvc/public/
 fi
 verbose "...Done"


### PR DESCRIPTION
I fixed the manual installer to ensure that the VERSION file ends up
in the right directory on install.

I also took care of the pre-release parts of the naggingness. It shows
no updates as long there is no stable release for the current version.
As soon as one is available it uses the orange update icon to alert the
user that an update would be in order since a stable version has been
released.

Fixes #198, Thanks for the reminder in #246 