### PR TITLE
Don't pull dev packages on install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-composer install
+composer install --no-dev
 
 git_build=""
 if [ -d .git ]; then


### PR DESCRIPTION
We don't need them for the end user runtime and this speeds up the
install quite a bit when installing from the full tarball.

Devs will need to run `composer install` to run unit tests locally
but that's about it.