### PR TITLE
Use proper protocol in URL if port is set to 443

### DIFF
--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -64,8 +64,12 @@ class PypoFile(Thread):
                 username = self._config.get(CONFIG_SECTION, 'api_key')
                 host = self._config.get(CONFIG_SECTION, 'base_url')
                 port = self._config.get(CONFIG_SECTION, 'base_port', 80)
-                url = "http://%s:%s/rest/media/%s/download" % (host, port, media_item["id"])
-                self.logger.error(url)
+
+                url = "%s://%s:%s/rest/media/%s/download" % (str(("http", "https")[int(port) == 443]),
+                                                             host,
+                                                             port,
+                                                             media_item["id"])
+                self.logger.info(url)
                 with open(dst, "wb") as handle:
                     response = requests.get(url, auth=requests.auth.HTTPBasicAuth(username, ''), stream=True, verify=False)
                     


### PR DESCRIPTION
This adds TLS support to pypo when downloading files from the REST
API. I previously fixed some similar issues in the api_client and
wasn't aware that pypo isn't using it for every URL..

Fixes the problem from https://github.com/LibreTime/libretime/issues/175#issuecomment-316826523.