### PR TITLE
Add python-pika to install script

### DIFF
--- a/installer/lib/requirements-debian-jessie.apt
+++ b/installer/lib/requirements-debian-jessie.apt
@@ -28,6 +28,7 @@ libvo-aacenc0
 python-rgain
 python-gst-1.0
 gstreamer1.0-plugins-ugly
+python-pika
 
 patch
 

--- a/installer/lib/requirements-ubuntu-trusty.apt
+++ b/installer/lib/requirements-ubuntu-trusty.apt
@@ -27,6 +27,7 @@ libsamplerate0
 python-rgain
 python-gst-1.0
 gstreamer1.0-plugins-ugly
+python-pika
 
 patch
 

--- a/installer/lib/requirements-ubuntu-xenial.apt
+++ b/installer/lib/requirements-ubuntu-xenial.apt
@@ -29,6 +29,7 @@ libsamplerate0
 python-rgain
 python-gst-1.0
 gstreamer1.0-plugins-ugly
+python-pika
 
 patch
 

--- a/installer/vagrant/centos.sh
+++ b/installer/vagrant/centos.sh
@@ -75,6 +75,7 @@ rabbitmqctl add_vhost /airtime
 rabbitmqctl set_permissions -p /airtime airtime ".*" ".*" ".*"
 
 # LibreTime deps
+# TODO: move me to requirements-file ala debian e.a.
 yum install -y \
   git \
   php \
@@ -94,6 +95,7 @@ yum install -y \
   selinux-policy \
   policycoreutils-python \
   python-celery \
+  python2-pika \
   lsof
 
 # for pip ssl install


### PR DESCRIPTION
Currently pip is pulling a new pre-release version of pika. This
version does not seem to be backwards compatible and is the reason
why uploads fail on new installs.

Since there are packages available for pika on all major distros
we can get away with just installing those as pip will not try to
replace/upgrade them the way it is currently configured.

See #256 for more info on this issue.