### PR TITLE
[WIP] adding and fixing log rotation

### DIFF
--- a/python_apps/airtime_analyzer/airtime-analyzer.logrotate
+++ b/python_apps/airtime_analyzer/airtime-analyzer.logrotate
@@ -1,0 +1,11 @@
+/var/log/airtime/airtime_analyzer.log {
+  compress
+  rotate 10
+  size 1000k
+  missingok
+  notifempty
+  sharedscripts
+  postrotate
+    start-stop-daemon --stop --signal USR1 --quiet --pidfile /var/run/airtime/airtime-liquidsoap.pid
+  endscript
+}

--- a/python_apps/pypo/pypo/airtime-playout.logrotate
+++ b/python_apps/pypo/pypo/airtime-playout.logrotate
@@ -1,0 +1,11 @@
+/var/log/airtime/pypo/pypo.log {
+  compress
+  rotate 10
+  size 1000k
+  missingok
+  notifempty
+  sharedscripts
+  postrotate
+    start-stop-daemon --stop --signal USR1 --quiet --pidfile /var/run/airtime/airtime-liquidsoap.pid
+  endscript
+}


### PR DESCRIPTION
This is a fix in progress for #233 
The syntax for restarting the processes after postrotate needs to be fixed. 
the postrotate for the airtime-liquidsoap logrotate uses a pidfile that doesn't exist and I'm not sure the best way to restart the processes considering we want this to work in upstart and/or init.d and systemd.