### PR TITLE
Enable Automatic Creation of Smartblocks and Playlists for new Podcasts

### DIFF
--- a/airtime_mvc/application/controllers/PreferenceController.php
+++ b/airtime_mvc/application/controllers/PreferenceController.php
@@ -46,6 +46,7 @@ class PreferenceController extends Zend_Controller_Action
                 Application_Model_Preference::SetDefaultFadeIn($values["stationDefaultFadeIn"]);
                 Application_Model_Preference::SetDefaultFadeOut($values["stationDefaultFadeOut"]);
                 Application_Model_Preference::SetPodcastAlbumOverride($values["podcastAlbumOverride"]);
+                Application_Model_Preference::SetPodcastAutoSmartblock($values["podcastAutoSmartblock"]);
                 Application_Model_Preference::SetAllow3rdPartyApi($values["thirdPartyApi"]);
                 Application_Model_Preference::SetAllowedCorsUrls($values["allowedCorsUrls"]);
                 Application_Model_Preference::SetDefaultLocale($values["locale"]);

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -110,12 +110,27 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
         $podcast_album_override->setValue(Application_Model_Preference::GetPodcastAlbumOverride());
         $podcast_album_override->setDescription(_('Enabling this means that podcast tracks will always contain the podcast name in their album field.'));
         $podcast_album_override->setSeparator(' '); //No <br> between radio buttons
-        //$third_party_api->addDecorator(new Zend_Form_Decorator_Label(array('tag' => 'dd', 'class' => 'radio-inline-list')));
         $podcast_album_override->addDecorator('HtmlTag', array('tag' => 'dd',
             'id'=>"podcastAlbumOverride-element",
             'class' => 'radio-inline-list',
         ));
         $this->addElement($podcast_album_override);
+
+        $podcast_auto_smartblock = new Zend_Form_Element_Radio('podcastAutoSmartblock');
+        $podcast_auto_smartblock->setLabel(_('Podcast Automatic Smartblock and Playlist'));
+        $podcast_auto_smartblock->setMultiOptions(array(
+            _("Disabled"),
+            _("Enabled"),
+        ));
+        $podcast_auto_smartblock->setValue(Application_Model_Preference::GetPodcastAutoSmartblock());
+        $podcast_auto_smartblock->setDescription(_('Enabling this means that a smartblock and playlist matching the newest track of a 
+        podcast will be created when a new podcast is added. This depends upon the Podcast Album Override to work.'));
+        $podcast_auto_smartblock->setSeparator(' '); //No <br> between radio buttons
+        $podcast_auto_smartblock->addDecorator('HtmlTag', array('tag' => 'dd',
+            'id'=>"podcastAutoSmartblock-element",
+            'class' => 'radio-inline-list',
+        ));
+        $this->addElement($podcast_auto_smartblock);
 
         //TODO add and insert Podcast Smartblock and Playlist autogenerate options
 

--- a/airtime_mvc/application/forms/GeneralPreferences.php
+++ b/airtime_mvc/application/forms/GeneralPreferences.php
@@ -117,6 +117,7 @@ class Application_Form_GeneralPreferences extends Zend_Form_SubForm
         ));
         $this->addElement($podcast_album_override);
 
+        //TODO add and insert Podcast Smartblock and Playlist autogenerate options
 
         $third_party_api = new Zend_Form_Element_Radio('thirdPartyApi');
         $third_party_api->setLabel(_('Public Airtime API'));

--- a/airtime_mvc/application/models/Preference.php
+++ b/airtime_mvc/application/models/Preference.php
@@ -376,6 +376,18 @@ class Application_Model_Preference
         return $val === '1' ? true : false;
     }
 
+    public static function SetPodcastAutoSmartblock($bool)
+    {
+        self::setValue("podcast_auto_smartblock", $bool);
+    }
+
+    public static function GetPodcastAutoSmartblock()
+    {
+        $val = self::getValue("podcast_auto_smartblock");
+        return $val === '1' ? true : false;
+    }
+
+
     public static function SetPhone($phone)
     {
         self::setValue("phone", $phone);

--- a/airtime_mvc/application/services/PodcastService.php
+++ b/airtime_mvc/application/services/PodcastService.php
@@ -147,9 +147,10 @@ class Application_Service_PodcastService
             $importedPodcast->setDbAutoIngest(true);
             $importedPodcast->save();
 
-            // need to add an if statement to check if this option is enabled
-            self::createPodcastSmartblockAndPlaylist($podcast);
-
+            // if the autosmartblock and album override are enabled then create a smartblock and playlist matching this podcast via the album name
+            if (Application_Model_Preference::GetPodcastAutoSmartblock() && Application_Model_Preference::GetPodcastAlbumOverride()) {
+                self::createPodcastSmartblockAndPlaylist($podcast);
+            }
 
 
             return $podcast->toArray(BasePeer::TYPE_FIELDNAME);
@@ -159,52 +160,52 @@ class Application_Service_PodcastService
         }
     }
 
+    /**
+     * @param $podcast
+     * This will automatically create a smartblock and playlist for this podcast.
+     */
+
     public static function createPodcastSmartblockAndPlaylist($podcast)
     {
+            $newBl = new Application_Model_Block();
+            $newBl->setCreator(Application_Model_User::getCurrentUser()->getId());
+            $newBl->setName($podcast->getDbTitle());
+            $newBl->setDescription('Auto-generated smartblock for podcast');
+            $newBl->saveType('dynamic');
+            // limit the smartblock to 1 item
+            $row = new CcBlockcriteria();
+            $row->setDbCriteria('limit');
+            $row->setDbModifier('items');
+            $row->setDbValue(1);
+            $row->setDbBlockId($newBl->getId());
+            $row->save();
 
-        // need to check that album override is either globally enabled or enabled for this podcast
-        // also need to check an option
-        // right here need to create new smartblock and playlist with same name as podcast title
-        $newBl = new Application_Model_Block();
-        $newBl->setCreator(Application_Model_User::getCurrentUser()->getId());
-        $newBl->setName($podcast->getDbTitle());
-        $newBl->setDescription('Auto-generated smartblock for podcast');
-        $newBl->saveType('dynamic');
-        // limit the smartblock to 1 item
-        $row = new CcBlockcriteria();
-        $row->setDbCriteria('limit');
-        $row->setDbModifier('items');
-        $row->setDbValue(1);
-        $row->setDbBlockId($newBl->getId());
-        $row->save();
+            // sort so that it is the newest item
+            $row = new CcBlockcriteria();
+            $row->setDbCriteria('sort');
+            $row->setDbModifier('N/A');
+            $row->setDbValue('newest');
+            $row->setDbBlockId($newBl->getId());
+            $row->save();
 
-        // sort so that it is the newest item
-        $row = new CcBlockcriteria();
-        $row->setDbCriteria('sort');
-        $row->setDbModifier('N/A');
-        $row->setDbValue('newest');
-        $row->setDbBlockId($newBl->getId());
-        $row->save();
+            // match the track by ensuring the album title matches the podcast
+            $row = new CcBlockcriteria();
+            $row->setDbCriteria('album_title');
+            $row->setDbModifier('is');
+            $row->setDbValue($newBl->getName());
+            $row->setDbBlockId($newBl->getId());
+            $row->save();
 
-        // match the track by ensuring the album title matches the podcast
-        $row = new CcBlockcriteria();
-        $row->setDbCriteria('album_title');
-        $row->setDbModifier('is');
-        $row->setDbValue($newBl->getName());
-        $row->setDbBlockId($newBl->getId());
-        $row->save();
+            $newPl = new Application_Model_Playlist();
+            $newPl->setName($podcast->getDbTitle());
+            $newPl->setCreator(Application_Model_User::getCurrentUser()->getId());
+            $row = new CcPlaylistcontents();
+            $row->setDbBlockId($newBl->getId());
+            $row->setDbPlaylistId($newPl->getId());
+            $row->setDbType(2);
+            $row->save();
+        }
 
-        //TODO create a playlist that contains only this SmartBlock
-
-        $newPl = new Application_Model_Playlist();
-        $newPl->setName($podcast->getDbTitle());
-        $newPl->setCreator(Application_Model_User::getCurrentUser()->getId());
-        $row = new CcPlaylistcontents();
-        $row->setDbBlockId($newBl->getId());
-        $row->setDbPlaylistId($newPl->getId());
-        $row->setDbType(2);
-        $row->save();
-    }
 
     public static function createStationPodcast()
     {

--- a/airtime_mvc/application/views/scripts/form/preferences_general.phtml
+++ b/airtime_mvc/application/views/scripts/form/preferences_general.phtml
@@ -33,6 +33,8 @@
 
         <?php echo $this->element->getElement('podcastAlbumOverride')->render() ?>
 
+        <?php echo $this->element->getElement('podcastAutoSmartblock')->render() ?>
+
         <?php echo $this->element->getElement('thirdPartyApi')->render() ?>
         <?php echo $this->element->getElement('allowedCorsUrls')->render() ?>
 

--- a/airtime_mvc/public/js/airtime/preferences/preferences.js
+++ b/airtime_mvc/public/js/airtime/preferences/preferences.js
@@ -29,6 +29,19 @@ function setEnableSystemEmailsListener() {
     });
 }
 
+function setPodcastAutoSmartblockReadonly() {
+    var disablePodcastAutomSmartblock = $("#podcastAutoSmartblock-0");
+    var enablePodcastAutomSmartblock = $("#podcastAutoSmartblock-1");
+    var podcastOverride = $("#podcastAlbumOverride-1");
+    if ($(podcastOverride).is(':checked')) {
+        enablePodcastAutomSmartblock.removeAttr("readonly");
+    } else {
+        disablePodcastAutomSmartblock.prop("checked", true);
+        disablePodcastAutomSmartblock.attr("readonly","readonly");
+        enablePodcastAutomSmartblock.attr("readonly","readonly");
+    }
+}
+
 function setSystemFromEmailReadonly() {
     var enableSystemEmails = $("#enableSystemEmail");
     var systemFromEmail = $("#systemEmail");
@@ -189,6 +202,7 @@ $(document).ready(function() {
     showErrorSections();
     
     setMailServerInputReadonly();
+    setPodcastAutoSmartblockReadonly();
     setSystemFromEmailReadonly();
     setConfigureMailServerListener();
     setEnableSystemEmailsListener();


### PR DESCRIPTION
This adds an option to preferences that can be enabled when the Podcast Album Override is enabled that will automatically create a smartblock matching the newest item from a Podcast and a Playlist containing this Smartblock. This dramatically speeds up the creation of new automatic playlist shows from RSS feeds.