### PR TITLE
Update legacy constructors

### DIFF
--- a/airtime_mvc/application/cloud_storage/Amazon_S3StorageBackend.php
+++ b/airtime_mvc/application/cloud_storage/Amazon_S3StorageBackend.php
@@ -8,7 +8,7 @@ class Amazon_S3StorageBackend extends StorageBackend
     private $s3Client;
     private $proxyHost;
 
-    public function Amazon_S3StorageBackend($securityCredentials)
+    public function __construct($securityCredentials)
     {
         $this->setBucket($securityCredentials['bucket']);
         $this->setAccessKey($securityCredentials['api_key']);

--- a/airtime_mvc/application/cloud_storage/FileStorageBackend.php
+++ b/airtime_mvc/application/cloud_storage/FileStorageBackend.php
@@ -2,11 +2,6 @@
 
 class FileStorageBackend extends StorageBackend
 {
-    //Stub class
-    public function FileStorageBackend()
-    {
-    }
-
     public function getAbsoluteFilePath($resourceId)
     {
         //TODO

--- a/airtime_mvc/application/cloud_storage/ProxyStorageBackend.php
+++ b/airtime_mvc/application/cloud_storage/ProxyStorageBackend.php
@@ -14,7 +14,7 @@ class ProxyStorageBackend extends StorageBackend
      * Receives the file's storage backend and instantiates the appropriate
      * object.
      */
-    public function ProxyStorageBackend($storageBackend)
+    public function __construct($storageBackend)
     {
         $CC_CONFIG = Config::getConfig();
 


### PR DESCRIPTION
These go way back to php 4 and don't need to be like this for any
reason. Currently error handling is acting up when these throw an
error.

This should take care of #289.