### PR TITLE
Better error message when parsing WAVE file

### DIFF
--- a/python_apps/airtime_analyzer/airtime_analyzer/metadata_analyzer.py
+++ b/python_apps/airtime_analyzer/airtime_analyzer/metadata_analyzer.py
@@ -175,7 +175,7 @@ class MetadataAnalyzer(Analyzer):
             metadata["length"] = str(track_length) #time.strftime("%H:%M:%S.%f", track_length)
             metadata["length_seconds"] = length_seconds
             metadata["cueout"] = metadata["length"] 
-        except wave.Error:
-            logging.error("Invalid WAVE file.")
+        except wave.Error as ex:
+            logging.error("Invalid WAVE file: {}".format(str(ex)))
             raise
         return metadata


### PR DESCRIPTION
As shown by #279 the error message logged by analyzer when ingesting .wav files doesn't help debug cases where the `wave` module can't read the file. This adds the error message from the wave module to help in that case.