### PR TITLE
Fix python tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ addons:
     - python-nose
     - python-rgain
     - python-gst-1.0
+    - python-magic
     - mp3gain
 install:
 - >

--- a/travis/python.sh
+++ b/travis/python.sh
@@ -4,7 +4,8 @@ set -xe
 
 [[ "$PYTHON" == false ]] && exit 0
 
-pushd python_apps/airtime_analyzer 
+pushd python_apps/airtime_analyzer
+pip install -e .
 nosetests -a '!rgain'
 echo "replaygain tests where skipped due to not having a reliable replaygain install on travis."
 popd

--- a/travis/python.sh
+++ b/travis/python.sh
@@ -5,6 +5,7 @@ set -xe
 [[ "$PYTHON" == false ]] && exit 0
 
 pushd python_apps/airtime_analyzer
+pyenv local 2.7
 pip install -e .
 nosetests -a '!rgain'
 echo "replaygain tests where skipped due to not having a reliable replaygain install on travis."


### PR DESCRIPTION
It looks like travis has activated python3 by default. This switches back to 2.7 for testing analyzer. This will also make #293 not fail anymore.