### PR TITLE
Revert pypofile try block move

### DIFF
--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -61,11 +61,11 @@ class PypoFile(Thread):
             self.logger.info("copying from %s to local cache %s" % (src, dst))
 
             CONFIG_SECTION = "general"
+            username = self._config.get(CONFIG_SECTION, 'api_key')
+            baseurl = self._config.get(CONFIG_SECTION, 'base_url')
+            port = self._config.get(CONFIG_SECTION, 'base_port', 80)
+            protocol = self._config.get(CONFIG_SECTION, 'protocol', str(("http", "https")[int(port) == 443]))
             try:
-                username = self._config.get(CONFIG_SECTION, 'api_key')
-                baseurl = self._config.get(CONFIG_SECTION, 'base_url')
-                port = self._config.get(CONFIG_SECTION, 'base_port', 80)
-                protocol = self._config.get(CONFIG_SECTION, 'protocol', str(("http", "https")[int(port) == 443]))
 
                 host = [protocol, baseurl, port]
                 url = "%s://%s:%s/rest/media/%s/download" % (host[0],

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -2,6 +2,7 @@
 
 from threading import Thread
 from Queue import Empty
+from ConfigParser import NoOptionError
 
 import logging
 import shutil
@@ -63,14 +64,16 @@ class PypoFile(Thread):
             CONFIG_SECTION = "general"
             username = self._config.get(CONFIG_SECTION, 'api_key')
             baseurl = self._config.get(CONFIG_SECTION, 'base_url')
-            port = self._config.get(CONFIG_SECTION, 'base_port')
-            if not port:
-                port = 80
-            protocol = self._config.get(CONFIG_SECTION, 'protocol')
-            if not protocol:
-                protocol = str(("http", "https")[int(port) == 443])
             try:
+                port = self._config.get(CONFIG_SECTION, 'base_port')
+            except NoOptionError, e:
+                port = 80
+            try:
+                protocol = self._config.get(CONFIG_SECTION, 'protocol')
+            except NoOptionError, e:
+                protocol = str(("http", "https")[int(port) == 443])
 
+            try:
                 host = [protocol, baseurl, port]
                 url = "%s://%s:%s/rest/media/%s/download" % (host[0],
                                                              host[1],

--- a/python_apps/pypo/pypo/pypofile.py
+++ b/python_apps/pypo/pypo/pypofile.py
@@ -63,8 +63,12 @@ class PypoFile(Thread):
             CONFIG_SECTION = "general"
             username = self._config.get(CONFIG_SECTION, 'api_key')
             baseurl = self._config.get(CONFIG_SECTION, 'base_url')
-            port = self._config.get(CONFIG_SECTION, 'base_port', 80)
-            protocol = self._config.get(CONFIG_SECTION, 'protocol', str(("http", "https")[int(port) == 443]))
+            port = self._config.get(CONFIG_SECTION, 'base_port')
+            if not port:
+                port = 80
+            protocol = self._config.get(CONFIG_SECTION, 'protocol')
+            if not protocol:
+                protocol = str(("http", "https")[int(port) == 443])
             try:
 
                 host = [protocol, baseurl, port]
@@ -162,7 +166,7 @@ class PypoFile(Thread):
 
     def read_config_file(self, config_path):
         """Parse the application's config file located at config_path."""
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.SafeConfigParser(allow_no_value=True)
         try:
             config.readfp(open(config_path))
         except IOError as e:


### PR DESCRIPTION
Config file getting is allowed to fail. I didn't realize that it would not just use the default instead of excepting and getting caught. Sorry for that. 

I broke this with my changes in #329 this reverts them and blocks 2.0.0-alpha.3. Sorry again about that.

---
### Workaround

Add `protocol = http` or `protocol = https` to the general section of your airtime.conf.