### PR TITLE
Made rabbitmq settings write to tempfile upon check to fix install bug

### DIFF
--- a/airtime_mvc/build/airtime-setup/forms/rabbitmq-settings.php
+++ b/airtime_mvc/build/airtime-setup/forms/rabbitmq-settings.php
@@ -10,7 +10,7 @@
     <h3 class="form-title">RabbitMQ Settings</h3>
     <span id="helpBlock" class="help-block help-message"></span>
     <p>
-        RabbitMQ is an AMQP-based messaging system used by Airtime. You should only edit these settings
+        RabbitMQ is an AMQP-based messaging system used by Libretime. You should only edit these settings
         if you have changed the defaults since running the installer, or if you've opted to install RabbitMQ manually.
     </p>
     <p>

--- a/airtime_mvc/public/setup/database-setup.php
+++ b/airtime_mvc/public/setup/database-setup.php
@@ -7,9 +7,9 @@
  * Wrapper class for validating and installing the Airtime database during the installation process
  */
 class DatabaseSetup extends Setup {
-
+    
     // airtime.conf section header
-    protected static $_settings = "[database]";
+    protected static $_section = "[database]";
 
     // Constant form field names for passing errors back to the front-end
     const DB_USER = "dbUser",
@@ -51,6 +51,7 @@ class DatabaseSetup extends Setup {
      * @throws AirtimeDatabaseException
      */
     public function runSetup() {
+        $this->writeToTemp();
         try {
             $this->setNewDatabaseConnection("postgres");
             if ($this->checkDatabaseExists()) {
@@ -61,14 +62,11 @@ class DatabaseSetup extends Setup {
                 $this->installDatabaseTables();
             }
         } catch (PDOException $e) {
-            throw new AirtimeDatabaseException("Couldn't establish a connection to the database! "
-                                               . "Please check your credentials and try again. "
+            throw new AirtimeDatabaseException("Couldn't establish a connection to the database! ".
+                                                "Please check your credentials and try again. "
                                                . "PDO Exception: " .  $e->getMessage(),
                                                array(self::DB_NAME, self::DB_USER, self::DB_PASS));
         }
-
-        $this->writeToTemp();
-
         self::$dbh = null;
         return array(
             "message" => "Airtime database was created successfully!",

--- a/airtime_mvc/public/setup/media-setup.php
+++ b/airtime_mvc/public/setup/media-setup.php
@@ -104,7 +104,7 @@ class MediaSetup extends Setup {
     function setupMusicDirectory() {
         try {
             $_SERVER['AIRTIME_CONF'] = AIRTIME_CONF_TEMP_PATH;
-            Propel::init(CONFIG_PATH . "airtime-conf-production.php");
+            Propel::init(AIRTIME_CONF_TEMP_PATH);
             $con = Propel::getConnection();
         } catch(Exception $e) {
             self::$message = "Failed to insert media folder; database isn't configured properly!";

--- a/airtime_mvc/public/setup/rabbitmq-setup.php
+++ b/airtime_mvc/public/setup/rabbitmq-setup.php
@@ -50,7 +50,6 @@ class RabbitMQSetup extends Setup {
         } catch(Exception $e) {
             $this->identifyRMQConnectionError();
         }
-
         return array(
             "message" => self::$message,
             "errors" => self::$errors
@@ -63,6 +62,7 @@ class RabbitMQSetup extends Setup {
                                    self::$_properties["user"],
                                    self::$_properties["password"],
                                    self::$_properties["vhost"]);
+        $this->writeToTemp();
         return isset($conn);
     }
 

--- a/airtime_mvc/public/setup/setup-functions.php
+++ b/airtime_mvc/public/setup/setup-functions.php
@@ -1,6 +1,6 @@
 <?php
 define("BUILD_PATH", dirname(dirname(__DIR__)) . "/build/");
-define("AIRTIME_CONF_TEMP_PATH", "/tmp/airtime.conf.temp");
+define("AIRTIME_CONF_TEMP_PATH", "/etc/airtime/airtime.conf.temp");
 define("RMQ_INI_TEMP_PATH", "/tmp/rabbitmq.ini.tmp");
 
 // load autoloader since this files is an entry path see 
@@ -37,7 +37,7 @@ abstract class Setup {
         if (!file_exists(AIRTIME_CONF_TEMP_PATH)) {
             copy(BUILD_PATH . "airtime.example.conf", AIRTIME_CONF_TEMP_PATH);
         }
-
+        //Logging::info(AIRTIME_CONF_TEMP_PATH);
         $this->_write(AIRTIME_CONF_TEMP_PATH);
     }
 


### PR DESCRIPTION
This fixes #330 and #288 by having the rabbit-mq setup function write to the temp file when it checks the rabbitMQ settings.