### PR TITLE
issue 349 - add missing code to allow preview seek

### DIFF
--- a/airtime_mvc/application/common/FileIO.php
+++ b/airtime_mvc/application/common/FileIO.php
@@ -70,9 +70,15 @@ class Application_Common_FileIO
             ob_end_flush();
         }
 
-        // NOTE: We can't use fseek here because it does not work with streams
-        // (a.k.a. Files stored in the cloud)
-        while(!feof($fm) && (connection_status() == 0)) {
+
+        //These two lines were removed from Airtime 2.5.x at some point after Libretime forked from Airtime.
+        //These lines allow seek to work for files.
+        //Issue #349
+        $cur = $begin;
+        fseek($fm,$begin,0);
+
+
+        while(!feof($fm) && (connection_status() == 0) && ($cur <= $end)) {       
             echo fread($fm, 1024 * 8);
         }
         fclose($fm);


### PR DESCRIPTION
Comparing latest Libretime code to Airtime 2.5.1 song preview functionality, Airtime had no issues seeking to various points in time while previewing. Libretime however rarely worked when seeking to random spots in time.   After trying various things, and then reviewing the code for smartReadFile() function between Airtime and Libretime code, it became clear that at some point after 2.5.2 Airtime, a key call to fseek was removed which prevented seeking from working.

Adding this code back as is in Airtime 2.5.x line fixed the problem in my local setup of Libretime.