### PR TITLE
issue 350 - change z-index to allow advanced search in calendar mode

### DIFF
--- a/airtime_mvc/public/css/dashboard.css
+++ b/airtime_mvc/public/css/dashboard.css
@@ -294,7 +294,7 @@ thead th.ui-state-default:focus {
     top: 4px;
     right: 4px;
     left: 4px;
-    z-index: 1; /* Display above the content wrapper */
+    z-index: auto; /* Allows advanced mode expander to be visible in calendar schedule mode */
 
     -webkit-flex: 1 100%;
     -moz-flex: 1 100%;


### PR DESCRIPTION
While using Calendar mode to edit a show, advanced search was not available for the library objects. After reviewing the CSS through Chrome's Developer Tools, it was clear that the control was physically there, just could not be seen to click on.  Changing the z-index for the containing element allowed the control to be visible and enabled the functionality that had previously been blocked.