### PR TITLE
Fix - repoint to airtime-production-conf.php to resolve hardcoded values and broken install

### DIFF
--- a/airtime_mvc/public/setup/media-setup.php
+++ b/airtime_mvc/public/setup/media-setup.php
@@ -104,7 +104,7 @@ class MediaSetup extends Setup {
     function setupMusicDirectory() {
         try {
             $_SERVER['AIRTIME_CONF'] = AIRTIME_CONF_TEMP_PATH;
-            Propel::init(AIRTIME_CONF_TEMP_PATH);
+            Propel::init(CONFIG_PATH . "airtime-conf-production.php");
             $con = Propel::getConnection();
         } catch(Exception $e) {
             self::$message = "Failed to insert media folder; database isn't configured properly!";


### PR DESCRIPTION
This is part of the requirement of hardcoded database values tracked on issue #356.
My change to fix #330 actually caused #360 because it wasn't properly writing the media directory and thus causing 

Error: Call to a member function getDirectory() on null in /vagrant/airtime_mvc/application/models/MusicDir.php:34 

Which results in a UI with no values whatsoever.

Changing this back fixes it, but it still probably is still dependent upon a hardcoded database password to work.

So we need to either rewrite the hardcoded calls to the php based propel inits or something else.