### PR TITLE
Add CORS handling to podcast feed

### DIFF
--- a/airtime_mvc/application/controllers/FeedsController.php
+++ b/airtime_mvc/application/controllers/FeedsController.php
@@ -7,14 +7,17 @@ class FeedsController extends Zend_Controller_Action
         $this->view->layout()->disableLayout();
         $this->_helper->viewRenderer->setNoRender(true);
 
+        $request = $this->getRequest();
+        $response = $this->getResponse();
+
         if ((Application_Model_Preference::getStationPodcastPrivacy()
-                && $this->getRequest()->getParam("sharing_token") != Application_Model_Preference::getStationPodcastDownloadKey())
+                && $request->getParam("sharing_token") != Application_Model_Preference::getStationPodcastDownloadKey())
                 && !RestAuth::verifyAuth(true, false, $this)) {
-            $this->getResponse()
-                ->setHttpResponseCode(401);
+            $response->setHttpResponseCode(401);
             return;
         }
 
+        CORSHelper::enableCrossOriginRequests($request, $response);
 
         $rssData = Application_Service_PodcastService::createStationRssFeed();
 


### PR DESCRIPTION
I'm building an archive page for our station that will pull libretime's podcast feed. I needed to add CORS support to the file, and noticed libretime already handles CORS responses for other resources.